### PR TITLE
feat(gsm8k): add dataset and 8-shot base-model task

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -47,7 +47,6 @@ tasks:
         model: math_model
         args:
             k: 8
-            n: 1
         # infer_args:                  # per-task inference parameter overrides
         #     max_tokens: 512
 ```

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -41,7 +41,7 @@ datasets:
         path: "openai/gsm8k"
 
 tasks:
-    gsm8k_8shot:
+    gsm8k_kshot_base_gen:
         class: GSM8KFewShotBaseGenTask
         dataset: gsm8k
         model: math_model

--- a/sieval/cli/dataset/render.py
+++ b/sieval/cli/dataset/render.py
@@ -10,6 +10,7 @@ from sieval.cli._readiness import evaluate_dataset_readiness, readiness_to_wire
 from sieval.cli.output import CommandResult
 from sieval.core.datasets.meta import DatasetMeta
 from sieval.core.tasks.meta import TaskMeta
+from sieval.datasets.downloaders.hf import parse_hf_source
 
 
 def _suggested_yaml_path(meta: DatasetMeta) -> str | None:
@@ -25,7 +26,7 @@ def _suggested_yaml_path(meta: DatasetMeta) -> str | None:
     if url_sources and not hf_sources:
         return "${SIEVAL_DATA_DIR}/" + meta.name
     if len(hf_sources) == 1 and not url_sources:
-        return hf_sources[0][len("hf:") :]
+        return parse_hf_source(hf_sources[0]).repo_id
     return None
 
 

--- a/sieval/datasets/__init__.pyi
+++ b/sieval/datasets/__init__.pyi
@@ -17,6 +17,10 @@ from .gpqa_diamond import (
     GPQADiamondDataset,
     GPQADiamondDatasetSample,
 )
+from .gsm8k import (
+    GSM8KDataset,
+    GSM8KDatasetSample,
+)
 from .human_eval import (
     HumanEvalDataset,
     HumanEvalDatasetSample,
@@ -55,6 +59,8 @@ __all__ = [
     "DROPDatasetSample",
     "GPQADiamondDataset",
     "GPQADiamondDatasetSample",
+    "GSM8KDataset",
+    "GSM8KDatasetSample",
     "HumanEvalDataset",
     "HumanEvalDatasetSample",
     "IFEvalDataset",

--- a/sieval/datasets/downloaders/hf.py
+++ b/sieval/datasets/downloaders/hf.py
@@ -14,9 +14,29 @@ AI-Generated Code - Claude Opus 4.7 (1M context) (Anthropic)
 """
 
 from pathlib import Path
+from typing import NamedTuple
 
 # Payload suffixes found across pilot datasets; extend as other formats surface.
 _DATA_SUFFIXES = (".arrow", ".parquet", ".jsonl", ".json", ".csv")
+
+
+class HFSource(NamedTuple):
+    repo_id: str
+    revision: str | None
+
+
+def parse_hf_source(source: str) -> HFSource:
+    if not source.startswith("hf:"):
+        raise ValueError(f"Expected hf: scheme, got {source!r}")
+    repo_ref = source[len("hf:") :]
+    if not repo_ref:
+        raise ValueError(f"Invalid hf source: {source!r}")
+    repo_id, separator, revision = repo_ref.rpartition("@")
+    if not separator:
+        return HFSource(repo_id=repo_ref, revision=None)
+    if not repo_id or not revision:
+        raise ValueError(f"Invalid hf source revision pin: {source!r}")
+    return HFSource(repo_id=repo_id, revision=revision)
 
 
 class HFHandler:
@@ -31,12 +51,13 @@ class HFHandler:
     ) -> None:
         from huggingface_hub import snapshot_download
 
-        repo_id = self._strip_scheme(source)
-        local_dir = dest_root / repo_id
+        parsed = parse_hf_source(source)
+        local_dir = dest_root / parsed.repo_id
         local_dir.mkdir(parents=True, exist_ok=True)
         snapshot_download(
-            repo_id=repo_id,
+            repo_id=parsed.repo_id,
             repo_type="dataset",
+            revision=parsed.revision,
             local_dir=str(local_dir),
             force_download=force,
         )
@@ -47,8 +68,8 @@ class HFHandler:
         dest_root: Path,
         dataset_name: str,
     ) -> bool:
-        repo_id = self._strip_scheme(source)
-        local_dir = dest_root / repo_id
+        parsed = parse_hf_source(source)
+        local_dir = dest_root / parsed.repo_id
         if not local_dir.exists():
             return False
         # `huggingface_hub` writes `.incomplete` sidecars under
@@ -68,9 +89,3 @@ class HFHandler:
             if p.suffix in _DATA_SUFFIXES:
                 return True
         return False
-
-    @staticmethod
-    def _strip_scheme(source: str) -> str:
-        if not source.startswith("hf:"):
-            raise ValueError(f"Expected hf: scheme, got {source!r}")
-        return source[len("hf:") :]

--- a/sieval/datasets/downloaders/hf.py
+++ b/sieval/datasets/downloaders/hf.py
@@ -13,14 +13,15 @@ indirection, no offline/online split inside ``datasets.load_dataset``.
 AI-Generated Code - Claude Opus 4.7 (1M context) (Anthropic)
 """
 
+from dataclasses import dataclass
 from pathlib import Path
-from typing import NamedTuple
 
 # Payload suffixes found across pilot datasets; extend as other formats surface.
 _DATA_SUFFIXES = (".arrow", ".parquet", ".jsonl", ".json", ".csv")
 
 
-class HFSource(NamedTuple):
+@dataclass(frozen=True)
+class HFSource:
     repo_id: str
     revision: str | None
 

--- a/sieval/datasets/gsm8k.py
+++ b/sieval/datasets/gsm8k.py
@@ -31,14 +31,14 @@ class GSM8KDatasetSample(TypedDict):
     license="MIT",
 )
 class GSM8KDataset(Dataset[GSM8KDatasetSample]):
+    GSM8K_REVISION = "740312add88f781978c0658806c59bc2815b9866"
     @override
     def load(
         self,
         name_or_path: str,
         config: str | None = "main",
+        revision: str = GSM8K_REVISION,
         **kwargs,
     ) -> HFDatasetDict:
-        if name_or_path.startswith("hf://"):
-            name_or_path = name_or_path.removeprefix("hf://")
-        dataset = load_dataset(name_or_path, config, **kwargs)
+        dataset = load_dataset(name_or_path, config, revision=revision, **kwargs)
         return ensure_dataset_dict(dataset)

--- a/sieval/datasets/gsm8k.py
+++ b/sieval/datasets/gsm8k.py
@@ -1,0 +1,44 @@
+"""
+AI-Generated Code - GPT-5.5 (OpenAI)
+"""
+
+from typing import TypedDict, override
+
+from datasets import DatasetDict as HFDatasetDict
+from datasets import load_dataset
+
+from sieval.core.datasets import (
+    Category,
+    Dataset,
+    Level1Category,
+    sieval_dataset,
+)
+from sieval.core.utils.hf import ensure_dataset_dict
+
+
+class GSM8KDatasetSample(TypedDict):
+    question: str
+    answer: str
+
+
+@sieval_dataset(
+    name="gsm8k",
+    display_name="GSM8K",
+    description="Grade School Math 8K - grade-school arithmetic word problems.",
+    source="hf:openai/gsm8k",
+    categories=(Category(Level1Category.MATHEMATICS, "ElementaryMath"),),
+    tags=("english", "math-word-problems", "open-ended"),
+    license="MIT",
+)
+class GSM8KDataset(Dataset[GSM8KDatasetSample]):
+    @override
+    def load(
+        self,
+        name_or_path: str,
+        config: str | None = "main",
+        **kwargs,
+    ) -> HFDatasetDict:
+        if name_or_path.startswith("hf://"):
+            name_or_path = name_or_path.removeprefix("hf://")
+        dataset = load_dataset(name_or_path, config, **kwargs)
+        return ensure_dataset_dict(dataset)

--- a/sieval/datasets/gsm8k.py
+++ b/sieval/datasets/gsm8k.py
@@ -15,6 +15,8 @@ from sieval.core.datasets import (
 )
 from sieval.core.utils.hf import ensure_dataset_dict
 
+GSM8K_REVISION = "740312add88f781978c0658806c59bc2815b9866"
+
 
 class GSM8KDatasetSample(TypedDict):
     question: str
@@ -25,13 +27,12 @@ class GSM8KDatasetSample(TypedDict):
     name="gsm8k",
     display_name="GSM8K",
     description="Grade School Math 8K - grade-school arithmetic word problems.",
-    source="hf:openai/gsm8k",
+    source=f"hf:openai/gsm8k@{GSM8K_REVISION}",
     categories=(Category(Level1Category.MATHEMATICS, "ElementaryMath"),),
     tags=("english", "math-word-problems", "open-ended"),
     license="MIT",
 )
 class GSM8KDataset(Dataset[GSM8KDatasetSample]):
-    GSM8K_REVISION = "740312add88f781978c0658806c59bc2815b9866"
     @override
     def load(
         self,

--- a/sieval/datasets/gsm8k.py
+++ b/sieval/datasets/gsm8k.py
@@ -38,8 +38,7 @@ class GSM8KDataset(Dataset[GSM8KDatasetSample]):
         self,
         name_or_path: str,
         config: str | None = "main",
-        revision: str = GSM8K_REVISION,
         **kwargs,
     ) -> HFDatasetDict:
-        dataset = load_dataset(name_or_path, config, revision=revision, **kwargs)
+        dataset = load_dataset(name_or_path, config, **kwargs)
         return ensure_dataset_dict(dataset)

--- a/sieval/meta/index.json
+++ b/sieval/meta/index.json
@@ -88,6 +88,27 @@
       "license": "CC-BY-4.0"
     },
     {
+      "name": "gsm8k",
+      "display_name": "GSM8K",
+      "description": "Grade School Math 8K - grade-school arithmetic word problems.",
+      "source": [
+        "hf:openai/gsm8k"
+      ],
+      "categories": [
+        {
+          "level1": "Mathematics",
+          "level2": "ElementaryMath"
+        }
+      ],
+      "tags": [
+        "english",
+        "math-word-problems",
+        "open-ended"
+      ],
+      "deps_group": null,
+      "license": "MIT"
+    },
+    {
       "name": "human_eval",
       "display_name": "HumanEval",
       "description": "OpenAI HumanEval — 164 Python function-synthesis problems.",
@@ -310,6 +331,28 @@
         "source": "simple-evals",
         "url": "https://github.com/openai/simple-evals/blob/ee3b0318d8d1d9d72755a4120879be65f7c07e9e/gpqa_eval.py",
         "notes": "Permutation + seed logic aligned with simple-evals."
+      },
+      "status": "stable"
+    },
+    {
+      "name": "gsm8k_8shot_base_gen",
+      "display_name": "GSM8K (8-shot, base generative)",
+      "description": "GSM8K 8-shot base-model generative evaluation with lm-eval filters.",
+      "dataset": "gsm8k",
+      "eval_mode": "gen",
+      "n_shot": 8,
+      "tags": [
+        "english",
+        "math-word-problems",
+        "open-ended",
+        "base-model"
+      ],
+      "deps_group": null,
+      "model_type": "gen",
+      "reference_impl": {
+        "source": "lm-evaluation-harness",
+        "url": "https://github.com/EleutherAI/lm-evaluation-harness/blob/1dd931087362abba74e0375c8c631295559f48b2/lm_eval/tasks/gsm8k/gsm8k.yaml",
+        "notes": "Prompt/filter rules mirror GSM8K yaml; num_fewshot changed to 8."
       },
       "status": "stable"
     },

--- a/sieval/meta/index.json
+++ b/sieval/meta/index.json
@@ -92,7 +92,7 @@
       "display_name": "GSM8K",
       "description": "Grade School Math 8K - grade-school arithmetic word problems.",
       "source": [
-        "hf:openai/gsm8k"
+        "hf:openai/gsm8k@740312add88f781978c0658806c59bc2815b9866"
       ],
       "categories": [
         {

--- a/sieval/meta/index.json
+++ b/sieval/meta/index.json
@@ -335,9 +335,9 @@
       "status": "stable"
     },
     {
-      "name": "gsm8k_8shot_base_gen",
-      "display_name": "GSM8K (8-shot, base generative)",
-      "description": "GSM8K 8-shot base-model generative evaluation with lm-eval filters.",
+      "name": "gsm8k_kshot_base_gen",
+      "display_name": "GSM8K (few-shot, base generative)",
+      "description": "GSM8K few-shot base-model strict-match EM evaluation.",
       "dataset": "gsm8k",
       "eval_mode": "gen",
       "n_shot": 8,
@@ -352,7 +352,7 @@
       "reference_impl": {
         "source": "lm-evaluation-harness",
         "url": "https://github.com/EleutherAI/lm-evaluation-harness/blob/1dd931087362abba74e0375c8c631295559f48b2/lm_eval/tasks/gsm8k/gsm8k.yaml",
-        "notes": "Prompt/filter rules mirror GSM8K yaml; num_fewshot changed to 8."
+        "notes": "Uses lm-eval-harness strict-match extraction, aligned with the original GSM8K dataset.py #### answer delimiter. Default k=8 follows the DeepSeek-V3 Table 3 comparison target (Qwen2.5-72B-Base GSM8K 8-shot EM = 88.3); DeepSeek-V3 does not specify strict vs flexible extraction."
       },
       "status": "stable"
     },

--- a/sieval/meta/index.json
+++ b/sieval/meta/index.json
@@ -231,6 +231,47 @@
       "license": "MIT"
     },
     {
+      "name": "mmmlu",
+      "display_name": "MMMLU",
+      "description": "OpenAI MMMLU - human-translated MMLU test split covering 57 subjects across 14 locales.",
+      "source": [
+        "hf:openai/MMMLU"
+      ],
+      "categories": [
+        {
+          "level1": "Knowledge",
+          "level2": "Multi-domain"
+        }
+      ],
+      "tags": [
+        "multilingual",
+        "multiple-choice"
+      ],
+      "deps_group": null,
+      "license": "MIT"
+    },
+    {
+      "name": "mmmlu_zh_cn",
+      "display_name": "MMMLU ZH-CN",
+      "description": "OpenAI MMMLU Simplified Chinese - human-translated MMLU test split covering 57 subjects.",
+      "source": [
+        "hf:openai/MMMLU"
+      ],
+      "categories": [
+        {
+          "level1": "Knowledge",
+          "level2": "Multi-domain"
+        }
+      ],
+      "tags": [
+        "chinese",
+        "simplified-chinese",
+        "multiple-choice"
+      ],
+      "deps_group": null,
+      "license": "MIT"
+    },
+    {
       "name": "t_eval_before_calling",
       "display_name": "T-Eval Before-Calling",
       "description": "T-Eval tool-use benchmark — before-calling stage (plan/reason).",
@@ -250,6 +291,31 @@
       ],
       "deps_group": null,
       "license": "Apache-2.0"
+    },
+    {
+      "name": "theoremqa",
+      "display_name": "TheoremQA",
+      "description": "Theorem-driven STEM QA benchmark with 800 expert-written questions.",
+      "source": [
+        "hf:TIGER-Lab/TheoremQA@a340b1782960a712843aae3ed25f1e013cc008a5"
+      ],
+      "categories": [
+        {
+          "level1": "Knowledge",
+          "level2": "STEM"
+        },
+        {
+          "level1": "Mathematics",
+          "level2": "AppliedMath"
+        }
+      ],
+      "tags": [
+        "english",
+        "open-ended",
+        "theorem-driven"
+      ],
+      "deps_group": null,
+      "license": "MIT"
     }
   ],
   "tasks": [
@@ -352,7 +418,7 @@
       "reference_impl": {
         "source": "lm-evaluation-harness",
         "url": "https://github.com/EleutherAI/lm-evaluation-harness/blob/1dd931087362abba74e0375c8c631295559f48b2/lm_eval/tasks/gsm8k/gsm8k.yaml",
-        "notes": "Uses lm-eval-harness strict-match extraction, aligned with the original GSM8K dataset.py #### answer delimiter. Default k=8 follows the DeepSeek-V3 Table 3 comparison target (Qwen2.5-72B-Base GSM8K 8-shot EM = 88.3); DeepSeek-V3 does not specify strict vs flexible extraction."
+        "notes": "Uses lm-eval-harness strict-match extraction, aligned with the original GSM8K dataset.py #### answer delimiter. Also reports lm-eval-harness flexible-extract as a secondary metric, not as the original GSM8K official metric. Default k=8 follows the DeepSeek-V3 Table 3 comparison target (Qwen2.5-72B-Base GSM8K 8-shot EM = 88.3); DeepSeek-V3 does not specify strict vs flexible extraction."
       },
       "status": "stable"
     },
@@ -479,6 +545,47 @@
       "status": "stable"
     },
     {
+      "name": "mmmlu_kshot_base_gen",
+      "display_name": "MMMLU (k-shot, base generative)",
+      "description": "OpenAI MMMLU multilingual k-shot MCQ with weighted groups.",
+      "dataset": "mmmlu",
+      "eval_mode": "ppl",
+      "n_shot": 5,
+      "tags": [
+        "multilingual",
+        "multiple-choice"
+      ],
+      "deps_group": null,
+      "model_type": "gen",
+      "reference_impl": {
+        "source": "lm-evaluation-harness + hendrycks/test",
+        "url": "https://github.com/EleutherAI/lm-evaluation-harness/tree/1dd931087362abba74e0375c8c631295559f48b2/lm_eval/tasks/openai-mmmlu",
+        "notes": "Uses MMMLU locale/category/subject organization and size-weighted aggregation from lm-evaluation-harness; uses Hendrycks evaluate.py completion top-logprob scoring for base models."
+      },
+      "status": "stable"
+    },
+    {
+      "name": "mmmlu_zh_cn_kshot_base_gen",
+      "display_name": "MMMLU ZH-CN (k-shot, base generative)",
+      "description": "MMMLU ZH-CN k-shot MCQ with Hendrycks official logprob scoring.",
+      "dataset": "mmmlu_zh_cn",
+      "eval_mode": "ppl",
+      "n_shot": 5,
+      "tags": [
+        "chinese",
+        "simplified-chinese",
+        "multiple-choice"
+      ],
+      "deps_group": null,
+      "model_type": "gen",
+      "reference_impl": {
+        "source": "hendrycks/test",
+        "url": "https://github.com/hendrycks/test/blob/4450500f923c49f1fb1dd3d99108a0bd9717b660/evaluate.py",
+        "notes": "Mirrors official prompt format and one-call next-token logprob scoring over space-prefixed A/B/C/D choices."
+      },
+      "status": "stable"
+    },
+    {
       "name": "t_eval_before_calling_0shot_gen",
       "display_name": "T-Eval Before-Calling (0-shot)",
       "description": "T-Eval tool-use benchmark — before-calling stage (plan/reason).",
@@ -496,6 +603,27 @@
         "source": "open-compass/T-Eval",
         "url": "https://github.com/open-compass/T-Eval/tree/58f22406404d7e2a4f36856a19c7f4dc28a0a5f0/teval",
         "notes": "ResponseDataSample (schema.py) + format_load (utils/format_load.py) vendored."
+      },
+      "status": "stable"
+    },
+    {
+      "name": "theoremqa_kshot_base_gen",
+      "display_name": "TheoremQA (k-shot, base generative)",
+      "description": "TheoremQA k-shot ICL with official short prompt and matcher.",
+      "dataset": "theoremqa",
+      "eval_mode": "gen",
+      "n_shot": 5,
+      "tags": [
+        "english",
+        "open-ended",
+        "theorem-driven"
+      ],
+      "deps_group": "math",
+      "model_type": "gen",
+      "reference_impl": {
+        "source": "TIGER-AI-Lab/TheoremQA",
+        "url": "https://github.com/TIGER-AI-Lab/TheoremQA/blob/acfc9686aa9b49f3c8f189364a9a9ee9c53da039/utils.py",
+        "notes": "Prompt follows official short-form examples by default; k can select any prefix of the built-in examples. answer_clean and numeric matching mirror official utils.py/number_utils.py."
       },
       "status": "stable"
     }

--- a/sieval/meta/index.json
+++ b/sieval/meta/index.json
@@ -231,47 +231,6 @@
       "license": "MIT"
     },
     {
-      "name": "mmmlu",
-      "display_name": "MMMLU",
-      "description": "OpenAI MMMLU - human-translated MMLU test split covering 57 subjects across 14 locales.",
-      "source": [
-        "hf:openai/MMMLU"
-      ],
-      "categories": [
-        {
-          "level1": "Knowledge",
-          "level2": "Multi-domain"
-        }
-      ],
-      "tags": [
-        "multilingual",
-        "multiple-choice"
-      ],
-      "deps_group": null,
-      "license": "MIT"
-    },
-    {
-      "name": "mmmlu_zh_cn",
-      "display_name": "MMMLU ZH-CN",
-      "description": "OpenAI MMMLU Simplified Chinese - human-translated MMLU test split covering 57 subjects.",
-      "source": [
-        "hf:openai/MMMLU"
-      ],
-      "categories": [
-        {
-          "level1": "Knowledge",
-          "level2": "Multi-domain"
-        }
-      ],
-      "tags": [
-        "chinese",
-        "simplified-chinese",
-        "multiple-choice"
-      ],
-      "deps_group": null,
-      "license": "MIT"
-    },
-    {
       "name": "t_eval_before_calling",
       "display_name": "T-Eval Before-Calling",
       "description": "T-Eval tool-use benchmark — before-calling stage (plan/reason).",
@@ -291,31 +250,6 @@
       ],
       "deps_group": null,
       "license": "Apache-2.0"
-    },
-    {
-      "name": "theoremqa",
-      "display_name": "TheoremQA",
-      "description": "Theorem-driven STEM QA benchmark with 800 expert-written questions.",
-      "source": [
-        "hf:TIGER-Lab/TheoremQA@a340b1782960a712843aae3ed25f1e013cc008a5"
-      ],
-      "categories": [
-        {
-          "level1": "Knowledge",
-          "level2": "STEM"
-        },
-        {
-          "level1": "Mathematics",
-          "level2": "AppliedMath"
-        }
-      ],
-      "tags": [
-        "english",
-        "open-ended",
-        "theorem-driven"
-      ],
-      "deps_group": null,
-      "license": "MIT"
     }
   ],
   "tasks": [
@@ -545,47 +479,6 @@
       "status": "stable"
     },
     {
-      "name": "mmmlu_kshot_base_gen",
-      "display_name": "MMMLU (k-shot, base generative)",
-      "description": "OpenAI MMMLU multilingual k-shot MCQ with weighted groups.",
-      "dataset": "mmmlu",
-      "eval_mode": "ppl",
-      "n_shot": 5,
-      "tags": [
-        "multilingual",
-        "multiple-choice"
-      ],
-      "deps_group": null,
-      "model_type": "gen",
-      "reference_impl": {
-        "source": "lm-evaluation-harness + hendrycks/test",
-        "url": "https://github.com/EleutherAI/lm-evaluation-harness/tree/1dd931087362abba74e0375c8c631295559f48b2/lm_eval/tasks/openai-mmmlu",
-        "notes": "Uses MMMLU locale/category/subject organization and size-weighted aggregation from lm-evaluation-harness; uses Hendrycks evaluate.py completion top-logprob scoring for base models."
-      },
-      "status": "stable"
-    },
-    {
-      "name": "mmmlu_zh_cn_kshot_base_gen",
-      "display_name": "MMMLU ZH-CN (k-shot, base generative)",
-      "description": "MMMLU ZH-CN k-shot MCQ with Hendrycks official logprob scoring.",
-      "dataset": "mmmlu_zh_cn",
-      "eval_mode": "ppl",
-      "n_shot": 5,
-      "tags": [
-        "chinese",
-        "simplified-chinese",
-        "multiple-choice"
-      ],
-      "deps_group": null,
-      "model_type": "gen",
-      "reference_impl": {
-        "source": "hendrycks/test",
-        "url": "https://github.com/hendrycks/test/blob/4450500f923c49f1fb1dd3d99108a0bd9717b660/evaluate.py",
-        "notes": "Mirrors official prompt format and one-call next-token logprob scoring over space-prefixed A/B/C/D choices."
-      },
-      "status": "stable"
-    },
-    {
       "name": "t_eval_before_calling_0shot_gen",
       "display_name": "T-Eval Before-Calling (0-shot)",
       "description": "T-Eval tool-use benchmark — before-calling stage (plan/reason).",
@@ -603,27 +496,6 @@
         "source": "open-compass/T-Eval",
         "url": "https://github.com/open-compass/T-Eval/tree/58f22406404d7e2a4f36856a19c7f4dc28a0a5f0/teval",
         "notes": "ResponseDataSample (schema.py) + format_load (utils/format_load.py) vendored."
-      },
-      "status": "stable"
-    },
-    {
-      "name": "theoremqa_kshot_base_gen",
-      "display_name": "TheoremQA (k-shot, base generative)",
-      "description": "TheoremQA k-shot ICL with official short prompt and matcher.",
-      "dataset": "theoremqa",
-      "eval_mode": "gen",
-      "n_shot": 5,
-      "tags": [
-        "english",
-        "open-ended",
-        "theorem-driven"
-      ],
-      "deps_group": "math",
-      "model_type": "gen",
-      "reference_impl": {
-        "source": "TIGER-AI-Lab/TheoremQA",
-        "url": "https://github.com/TIGER-AI-Lab/TheoremQA/blob/acfc9686aa9b49f3c8f189364a9a9ee9c53da039/utils.py",
-        "notes": "Prompt follows official short-form examples by default; k can select any prefix of the built-in examples. answer_clean and numeric matching mirror official utils.py/number_utils.py."
       },
       "status": "stable"
     }

--- a/sieval/tasks/__init__.pyi
+++ b/sieval/tasks/__init__.pyi
@@ -13,6 +13,9 @@ from .drop_kshot_gen import (
 from .gpqa_diamond_0shot_gen import (
     GPQADiamondZeroShotGenTask,
 )
+from .gsm8k_8shot_base_gen import (
+    GSM8KFewShotBaseGenTask,
+)
 from .human_eval_0shot_gen import (
     HumanEvalZeroShotGenTask,
 )
@@ -40,6 +43,7 @@ __all__ = [
     "AIME2025ZeroShotGenTask",
     "DROPFewShotGenTask",
     "GPQADiamondZeroShotGenTask",
+    "GSM8KFewShotBaseGenTask",
     "HumanEvalZeroShotGenTask",
     "IFEvalZeroShotGenTask",
     "LiveCodeBenchCodeGenerationZeroShotGenTask",

--- a/sieval/tasks/__init__.pyi
+++ b/sieval/tasks/__init__.pyi
@@ -13,7 +13,7 @@ from .drop_kshot_gen import (
 from .gpqa_diamond_0shot_gen import (
     GPQADiamondZeroShotGenTask,
 )
-from .gsm8k_8shot_base_gen import (
+from .gsm8k_kshot_base_gen import (
     GSM8KFewShotBaseGenTask,
 )
 from .human_eval_0shot_gen import (

--- a/sieval/tasks/gsm8k_8shot_base_gen.py
+++ b/sieval/tasks/gsm8k_8shot_base_gen.py
@@ -1,0 +1,201 @@
+"""
+AI-Generated Code - GPT-5.5 (OpenAI)
+"""
+
+import random
+import re
+from typing import TypedDict, cast, override
+
+from sieval.core.models import ModelOutput
+from sieval.core.tasks import (
+    EvalMode,
+    ReferenceImpl,
+    Task,
+    sieval_task,
+)
+from sieval.datasets import GSM8KDatasetSample
+
+N_SHOT = 8
+DEFAULT_MAX_TOKENS = 256
+DEFAULT_FEWSHOT_SEED = 1234
+STOP_SEQUENCES = ("Question:", "\n\n", "<|im_end|>")
+
+_STRICT_ANSWER_RE = re.compile(r"#### (\-?[0-9\.\,]+)")
+_FLEXIBLE_ANSWER_RE = re.compile(r"(-?[$0-9.,]{2,})|(-?[0-9]+)")
+
+
+class Feedback(TypedDict):
+    correct: bool
+    answer: str
+    prediction: str
+    extraction_method: str
+
+
+class Prediction(TypedDict):
+    answer: str
+    extraction_method: str
+
+
+def _format_example(sample: GSM8KDatasetSample, include_answer: bool) -> str:
+    prompt = f"Question: {sample['question']}\nAnswer:"
+    if include_answer:
+        prompt += f" {sample['answer']}\n\n"
+    return prompt
+
+
+def _normalize_exact_match(text: str) -> str:
+    text = re.sub(r",", "", text)
+    text = re.sub(r"\$", "", text)
+    text = re.sub(r"(?s).*#### ", "", text)
+    text = re.sub(r"\.$", "", text.strip())
+    return text.strip().lower()
+
+
+def _extract_strict_answer(text: str) -> str:
+    match = _STRICT_ANSWER_RE.search(text)
+    return match.group(1).strip() if match else ""
+
+
+def _extract_flexible_answer(text: str) -> str:
+    matches = _FLEXIBLE_ANSWER_RE.findall(text)
+    if not matches:
+        return ""
+    match = matches[-1]
+    return next((group.strip() for group in match if group), "")
+
+
+def _extract_answer(text: str) -> tuple[str, str]:
+    strict = _extract_strict_answer(text)
+    if strict:
+        return _normalize_exact_match(strict), "strict-match"
+    flexible = _extract_flexible_answer(text)
+    if flexible:
+        return _normalize_exact_match(flexible), "flexible-extract"
+    return "", "none"
+
+
+@sieval_task(
+    name="gsm8k_8shot_base_gen",
+    display_name="GSM8K (8-shot, base generative)",
+    description="GSM8K 8-shot base-model generative evaluation with lm-eval filters.",
+    eval_mode=EvalMode.GEN,
+    n_shot=N_SHOT,
+    tags=("english", "math-word-problems", "open-ended", "base-model"),
+    model_type="gen",
+    reference_impl=ReferenceImpl(
+        source="lm-evaluation-harness",
+        url=(
+            "https://github.com/EleutherAI/lm-evaluation-harness/blob/1dd931087362abba74e0375c8c631295559f48b2/lm_eval/tasks/gsm8k/gsm8k.yaml"
+        ),
+        notes="Prompt/filter rules mirror GSM8K yaml; num_fewshot changed to 8.",
+    ),
+)
+class GSM8KFewShotBaseGenTask(
+    Task[
+        GSM8KDatasetSample,
+        str,
+        ModelOutput,
+        Prediction,
+        Feedback,
+        dict[str, float],
+    ]
+):
+    def __init__(
+        self,
+        dataset,
+        model,
+        name: str | None = None,
+        *,
+        k: int = N_SHOT,
+        n: int = 1,
+        max_tokens: int = DEFAULT_MAX_TOKENS,
+        temperature: float = 0.0,
+        fewshot_split: str = "train",
+        fewshot_seed: int | None = DEFAULT_FEWSHOT_SEED,
+        stop: tuple[str, ...] = STOP_SEQUENCES,
+    ):
+        if k < 0:
+            raise ValueError(f"k must be >= 0, got {k}")
+        if n < 1:
+            raise ValueError(f"n must be >= 1, got {n}")
+        if max_tokens < 1:
+            raise ValueError(f"max_tokens must be >= 1, got {max_tokens}")
+        super().__init__(dataset=dataset, model=model, name=name)
+        self._k = k
+        self._n = n
+        self._max_tokens = max_tokens
+        self._temperature = temperature
+        self._fewshot_split = fewshot_split
+        self._fewshot_seed = fewshot_seed
+        self._stop = stop
+        self._fewshot_examples: list[GSM8KDatasetSample] | None = None
+
+    @override
+    async def setup(self) -> None:
+        self._fewshot_examples = self._sample_fewshot_examples()
+
+    @override
+    async def preprocess(self, raw, ctx):
+        examples = self._get_fewshot_examples()
+        return "".join(_format_example(ex, include_answer=True) for ex in examples) + (
+            _format_example(raw, include_answer=False)
+        )
+
+    @override
+    async def infer(self, pre, ctx):
+        kwargs: dict[str, object] = {
+            "max_tokens": self._max_tokens,
+            "temperature": self._temperature,
+            "n": self._n,
+        }
+        if self._stop:
+            kwargs["stop"] = list(self._stop)
+        return await self.model.agenerate(pre, **kwargs)
+
+    @override
+    async def postprocess(self, inf, ctx):
+        text = inf.texts[0] if inf.texts else ""
+        answer, extraction_method = _extract_answer(text)
+        return {"answer": answer, "extraction_method": extraction_method}
+
+    @override
+    async def feedback(self, post, ctx):
+        answer, _ = _extract_answer(ctx.raw_sample["answer"])
+        return True, {
+            "correct": post["answer"] == answer,
+            "answer": answer,
+            "prediction": post["answer"],
+            "extraction_method": post["extraction_method"],
+        }
+
+    @override
+    async def report(self, finals, fails):
+        total = len(finals) + len(fails)
+        if total == 0:
+            return {"score": 0.0, "fails": len(fails), "exact_match": 0.0}
+        correct_num = sum(1 for ctx in finals if ctx.feedback_result["correct"])
+        exact_match = 100 * correct_num / total
+        return {"score": exact_match, "fails": len(fails), "exact_match": exact_match}
+
+    def _get_fewshot_examples(self) -> list[GSM8KDatasetSample]:
+        if self._fewshot_examples is None:
+            self._fewshot_examples = self._sample_fewshot_examples()
+        return self._fewshot_examples
+
+    def _sample_fewshot_examples(self) -> list[GSM8KDatasetSample]:
+        split = self.dataset.dataset_dict.get(self._fewshot_split)
+        if split is None:
+            raise ValueError(
+                "GSM8K 8-shot base_gen requires a "
+                f"{self._fewshot_split!r} split for few-shot examples."
+            )
+        if len(split) < self._k:
+            raise ValueError(
+                "GSM8K 8-shot base_gen requires at least "
+                f"{self._k} examples in split {self._fewshot_split!r}; "
+                f"found {len(split)}."
+            )
+        examples = [cast(GSM8KDatasetSample, row) for row in split]
+        if self._k == 0:
+            return []
+        return random.Random(self._fewshot_seed).sample(examples, self._k)

--- a/sieval/tasks/gsm8k_kshot_base_gen.py
+++ b/sieval/tasks/gsm8k_kshot_base_gen.py
@@ -3,8 +3,13 @@ GSM8K few-shot base-model generative task.
 
 The reported `score` and `exact_match` are strict GSM8K EM: predictions are
 scored only when the model emits a `#### N` final answer. This matches the
-lm-eval-harness `strict-match` filter and the original GSM8K dataset.py answer
-delimiter.
+original GSM8K dataset.py answer delimiter and the lm-eval-harness
+`strict-match` filter. The prompt examples and strict extractor must stay in
+lockstep around that `####` final-answer format.
+
+The secondary `flexible_exact_match` metric mirrors the lm-eval-harness
+`flexible-extract` last-number filter; it is not part of the original GSM8K
+official metric.
 
 The comparison target is DeepSeek-V3 Table 3: Qwen2.5-72B-Base GSM8K 8-shot
 EM = 88.3. DeepSeek-V3 does not specify whether it used strict-match or
@@ -32,17 +37,24 @@ DEFAULT_FEWSHOT_SEED = 1234
 STOP_SEQUENCES = ("Question:", "</s>", "<|im_end|>")
 
 _STRICT_ANSWER_RE = re.compile(r"#### (\-?[0-9\.\,]+)")
+_FLEXIBLE_ANSWER_RE = re.compile(r"(-?[$0-9.,]{2,})|(-?[0-9]+)")
+
 
 class Feedback(TypedDict):
     correct: bool
+    flexible_correct: bool
     answer: str
     prediction: str
+    flexible_prediction: str
     extraction_method: str
+    flexible_extraction_method: str
 
 
 class Prediction(TypedDict):
     answer: str
+    flexible_answer: str
     extraction_method: str
+    flexible_extraction_method: str
 
 
 def _format_example(sample: GSM8KDatasetSample, include_answer: bool) -> str:
@@ -55,7 +67,6 @@ def _format_example(sample: GSM8KDatasetSample, include_answer: bool) -> str:
 def _normalize_exact_match(text: str) -> str:
     text = re.sub(r",", "", text)
     text = re.sub(r"\$", "", text)
-    text = re.sub(r"(?s).*#### ", "", text)
     text = re.sub(r"\.$", "", text.strip())
     return text.strip().lower()
 
@@ -65,11 +76,24 @@ def _extract_strict_answer(text: str) -> str:
     return match.group(1).strip() if match else ""
 
 
+def _extract_flexible_answer(text: str) -> str:
+    matches = _FLEXIBLE_ANSWER_RE.findall(text)
+    if not matches:
+        return ""
+    return next((part.strip() for part in matches[-1] if part), "")
+
 
 def _extract_answer(text: str) -> tuple[str, str]:
     strict = _extract_strict_answer(text)
     if strict:
         return _normalize_exact_match(strict), "strict-match"
+    return "", "none"
+
+
+def _extract_flexible_match(text: str) -> tuple[str, str]:
+    flexible = _extract_flexible_answer(text)
+    if flexible:
+        return _normalize_exact_match(flexible), "flexible-extract"
     return "", "none"
 
 
@@ -88,10 +112,12 @@ def _extract_answer(text: str) -> tuple[str, str]:
         ),
         notes=(
             "Uses lm-eval-harness strict-match extraction, aligned with the "
-            "original GSM8K dataset.py #### answer delimiter. Default k=8 "
-            "follows the DeepSeek-V3 Table 3 comparison target "
-            "(Qwen2.5-72B-Base GSM8K 8-shot EM = 88.3); DeepSeek-V3 does "
-            "not specify strict vs flexible extraction."
+            "original GSM8K dataset.py #### answer delimiter. Also reports "
+            "lm-eval-harness flexible-extract as a secondary metric, not as "
+            "the original GSM8K official metric. Default k=8 follows the "
+            "DeepSeek-V3 Table 3 comparison target (Qwen2.5-72B-Base GSM8K "
+            "8-shot EM = 88.3); DeepSeek-V3 does not specify strict vs "
+            "flexible extraction."
         ),
     ),
 )
@@ -112,7 +138,6 @@ class GSM8KFewShotBaseGenTask(
         name: str | None = None,
         *,
         k: int = N_SHOT,
-        n: int = 1,
         max_tokens: int = DEFAULT_MAX_TOKENS,
         temperature: float = 0.0,
         fewshot_split: str = "train",
@@ -121,13 +146,10 @@ class GSM8KFewShotBaseGenTask(
     ):
         if k < 0:
             raise ValueError(f"k must be >= 0, got {k}")
-        if n < 1:
-            raise ValueError(f"n must be >= 1, got {n}")
         if max_tokens < 1:
             raise ValueError(f"max_tokens must be >= 1, got {max_tokens}")
         super().__init__(dataset=dataset, model=model, name=name)
         self._k = k
-        self._n = n
         self._max_tokens = max_tokens
         self._temperature = temperature
         self._fewshot_split = fewshot_split
@@ -151,7 +173,6 @@ class GSM8KFewShotBaseGenTask(
         kwargs: dict[str, object] = {
             "max_tokens": self._max_tokens,
             "temperature": self._temperature,
-            "n": self._n,
         }
         if self._stop:
             kwargs["stop"] = list(self._stop)
@@ -161,26 +182,49 @@ class GSM8KFewShotBaseGenTask(
     async def postprocess(self, inf, ctx):
         text = inf.texts[0] if inf.texts else ""
         answer, extraction_method = _extract_answer(text)
-        return {"answer": answer, "extraction_method": extraction_method}
+        flexible_answer, flexible_extraction_method = _extract_flexible_match(text)
+        return {
+            "answer": answer,
+            "flexible_answer": flexible_answer,
+            "extraction_method": extraction_method,
+            "flexible_extraction_method": flexible_extraction_method,
+        }
 
     @override
     async def feedback(self, post, ctx):
         answer, _ = _extract_answer(ctx.raw_sample["answer"])
         return True, {
             "correct": post["answer"] == answer,
+            "flexible_correct": post["flexible_answer"] == answer,
             "answer": answer,
             "prediction": post["answer"],
+            "flexible_prediction": post["flexible_answer"],
             "extraction_method": post["extraction_method"],
+            "flexible_extraction_method": post["flexible_extraction_method"],
         }
 
     @override
     async def report(self, finals, fails):
         count = len(finals)
         if count == 0:
-            return {"score": 0.0, "fails": len(fails), "exact_match": 0.0}
+            return {
+                "score": 0.0,
+                "fails": len(fails),
+                "exact_match": 0.0,
+                "flexible_exact_match": 0.0,
+            }
         correct_num = sum(1 for ctx in finals if ctx.feedback_result["correct"])
+        flexible_correct_num = sum(
+            1 for ctx in finals if ctx.feedback_result["flexible_correct"]
+        )
         exact_match = 100 * correct_num / count
-        return {"score": exact_match, "fails": len(fails), "exact_match": exact_match}
+        flexible_exact_match = 100 * flexible_correct_num / count
+        return {
+            "score": exact_match,
+            "fails": len(fails),
+            "exact_match": exact_match,
+            "flexible_exact_match": flexible_exact_match,
+        }
 
     def _get_fewshot_examples(self) -> list[GSM8KDatasetSample]:
         if self._fewshot_examples is None:

--- a/sieval/tasks/gsm8k_kshot_base_gen.py
+++ b/sieval/tasks/gsm8k_kshot_base_gen.py
@@ -1,10 +1,21 @@
 """
+GSM8K few-shot base-model generative task.
+
+The reported `score` and `exact_match` are strict GSM8K EM: predictions are
+scored only when the model emits a `#### N` final answer. This matches the
+lm-eval-harness `strict-match` filter and the original GSM8K dataset.py answer
+delimiter.
+
+The comparison target is DeepSeek-V3 Table 3: Qwen2.5-72B-Base GSM8K 8-shot
+EM = 88.3. DeepSeek-V3 does not specify whether it used strict-match or
+flexible-match extraction, so this task states and reports strict-match EM.
+Default k=8 is chosen for that DeepSeek-V3 comparison.
+
 AI-Generated Code - GPT-5.5 (OpenAI)
 """
 
-import random
 import re
-from typing import TypedDict, cast, override
+from typing import TypedDict, override
 
 from sieval.core.models import ModelOutput
 from sieval.core.tasks import (
@@ -16,13 +27,11 @@ from sieval.core.tasks import (
 from sieval.datasets import GSM8KDatasetSample
 
 N_SHOT = 8
-DEFAULT_MAX_TOKENS = 256
+DEFAULT_MAX_TOKENS = 2048
 DEFAULT_FEWSHOT_SEED = 1234
-STOP_SEQUENCES = ("Question:", "\n\n", "<|im_end|>")
+STOP_SEQUENCES = ("Question:", "</s>", "<|im_end|>")
 
 _STRICT_ANSWER_RE = re.compile(r"#### (\-?[0-9\.\,]+)")
-_FLEXIBLE_ANSWER_RE = re.compile(r"(-?[$0-9.,]{2,})|(-?[0-9]+)")
-
 
 class Feedback(TypedDict):
     correct: bool
@@ -56,28 +65,18 @@ def _extract_strict_answer(text: str) -> str:
     return match.group(1).strip() if match else ""
 
 
-def _extract_flexible_answer(text: str) -> str:
-    matches = _FLEXIBLE_ANSWER_RE.findall(text)
-    if not matches:
-        return ""
-    match = matches[-1]
-    return next((group.strip() for group in match if group), "")
-
 
 def _extract_answer(text: str) -> tuple[str, str]:
     strict = _extract_strict_answer(text)
     if strict:
         return _normalize_exact_match(strict), "strict-match"
-    flexible = _extract_flexible_answer(text)
-    if flexible:
-        return _normalize_exact_match(flexible), "flexible-extract"
     return "", "none"
 
 
 @sieval_task(
-    name="gsm8k_8shot_base_gen",
-    display_name="GSM8K (8-shot, base generative)",
-    description="GSM8K 8-shot base-model generative evaluation with lm-eval filters.",
+    name="gsm8k_kshot_base_gen",
+    display_name="GSM8K (few-shot, base generative)",
+    description="GSM8K few-shot base-model strict-match EM evaluation.",
     eval_mode=EvalMode.GEN,
     n_shot=N_SHOT,
     tags=("english", "math-word-problems", "open-ended", "base-model"),
@@ -87,7 +86,13 @@ def _extract_answer(text: str) -> tuple[str, str]:
         url=(
             "https://github.com/EleutherAI/lm-evaluation-harness/blob/1dd931087362abba74e0375c8c631295559f48b2/lm_eval/tasks/gsm8k/gsm8k.yaml"
         ),
-        notes="Prompt/filter rules mirror GSM8K yaml; num_fewshot changed to 8.",
+        notes=(
+            "Uses lm-eval-harness strict-match extraction, aligned with the "
+            "original GSM8K dataset.py #### answer delimiter. Default k=8 "
+            "follows the DeepSeek-V3 Table 3 comparison target "
+            "(Qwen2.5-72B-Base GSM8K 8-shot EM = 88.3); DeepSeek-V3 does "
+            "not specify strict vs flexible extraction."
+        ),
     ),
 )
 class GSM8KFewShotBaseGenTask(
@@ -111,7 +116,7 @@ class GSM8KFewShotBaseGenTask(
         max_tokens: int = DEFAULT_MAX_TOKENS,
         temperature: float = 0.0,
         fewshot_split: str = "train",
-        fewshot_seed: int | None = DEFAULT_FEWSHOT_SEED,
+        fewshot_seed: int = DEFAULT_FEWSHOT_SEED,
         stop: tuple[str, ...] = STOP_SEQUENCES,
     ):
         if k < 0:
@@ -170,11 +175,11 @@ class GSM8KFewShotBaseGenTask(
 
     @override
     async def report(self, finals, fails):
-        total = len(finals) + len(fails)
-        if total == 0:
+        count = len(finals)
+        if count == 0:
             return {"score": 0.0, "fails": len(fails), "exact_match": 0.0}
         correct_num = sum(1 for ctx in finals if ctx.feedback_result["correct"])
-        exact_match = 100 * correct_num / total
+        exact_match = 100 * correct_num / count
         return {"score": exact_match, "fails": len(fails), "exact_match": exact_match}
 
     def _get_fewshot_examples(self) -> list[GSM8KDatasetSample]:
@@ -186,16 +191,20 @@ class GSM8KFewShotBaseGenTask(
         split = self.dataset.dataset_dict.get(self._fewshot_split)
         if split is None:
             raise ValueError(
-                "GSM8K 8-shot base_gen requires a "
+                "GSM8K few-shot base generative task requires a "
                 f"{self._fewshot_split!r} split for few-shot examples."
             )
         if len(split) < self._k:
             raise ValueError(
-                "GSM8K 8-shot base_gen requires at least "
+                "GSM8K few-shot base generative task requires at least "
                 f"{self._k} examples in split {self._fewshot_split!r}; "
                 f"found {len(split)}."
             )
-        examples = [cast(GSM8KDatasetSample, row) for row in split]
         if self._k == 0:
             return []
-        return random.Random(self._fewshot_seed).sample(examples, self._k)
+        return self.dataset.retrieve_samples(
+            self._k,
+            split=self._fewshot_split,
+            mode="random",
+            seed=self._fewshot_seed,
+        )

--- a/tests/unit/datasets/downloaders/test_hf.py
+++ b/tests/unit/datasets/downloaders/test_hf.py
@@ -2,11 +2,35 @@ from unittest.mock import patch
 
 import pytest
 
-from sieval.datasets.downloaders.hf import HFHandler
+from sieval.datasets.downloaders.hf import HFHandler, HFSource, parse_hf_source
 
 
 def test_scheme():
     assert HFHandler().scheme == "hf"
+
+
+def test_parse_hf_source_without_revision():
+    assert parse_hf_source("hf:org/foo") == HFSource(repo_id="org/foo", revision=None)
+
+
+def test_parse_hf_source_with_revision():
+    assert parse_hf_source("hf:org/foo@abc123") == HFSource(
+        repo_id="org/foo", revision="abc123"
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "url:https://example.com/x",
+        "hf:",
+        "hf:@abc123",
+        "hf:org/foo@",
+    ],
+)
+def test_parse_hf_source_rejects_invalid_source(source):
+    with pytest.raises(ValueError):
+        parse_hf_source(source)
 
 
 def test_download_invokes_snapshot_download_with_local_dir(tmp_path):
@@ -24,10 +48,24 @@ def test_download_invokes_snapshot_download_with_local_dir(tmp_path):
     call = mock_snap.call_args
     assert call.kwargs["repo_id"] == "org/foo"
     assert call.kwargs["repo_type"] == "dataset"
+    assert call.kwargs["revision"] is None
     assert call.kwargs["local_dir"] == str(tmp_path / "org" / "foo")
     assert call.kwargs["force_download"] is False
     # `cache_dir=` must not be passed — local_dir mode is the contract.
     assert "cache_dir" not in call.kwargs
+
+
+def test_download_invokes_snapshot_download_with_revision(tmp_path):
+    h = HFHandler()
+    with patch("huggingface_hub.snapshot_download") as mock_snap:
+        mock_snap.return_value = str(tmp_path / "org" / "foo")
+        h.download(
+            "hf:org/foo@abc123", dest_root=tmp_path, dataset_name="foo", force=False
+        )
+    call = mock_snap.call_args
+    assert call.kwargs["repo_id"] == "org/foo"
+    assert call.kwargs["revision"] == "abc123"
+    assert call.kwargs["local_dir"] == str(tmp_path / "org" / "foo")
 
 
 def test_force_maps_to_force_download(tmp_path):
@@ -72,6 +110,14 @@ def test_is_downloaded_true_with_parquet_payload(tmp_path):
     local_dir.mkdir(parents=True)
     (local_dir / "data.parquet").write_bytes(b"x")
     assert h.is_downloaded("hf:org/foo", tmp_path, "foo")
+
+
+def test_is_downloaded_strips_revision_from_local_dir(tmp_path):
+    h = HFHandler()
+    local_dir = tmp_path / "org" / "foo"
+    local_dir.mkdir(parents=True)
+    (local_dir / "data.parquet").write_bytes(b"x")
+    assert h.is_downloaded("hf:org/foo@abc123", tmp_path, "foo")
 
 
 def test_is_downloaded_true_with_arrow_payload(tmp_path):

--- a/tests/unit/tasks/test_gsm8k_kshot_base_gen.py
+++ b/tests/unit/tasks/test_gsm8k_kshot_base_gen.py
@@ -1,0 +1,107 @@
+"""Unit tests for the GSM8K k-shot base generative task.
+
+AI-Generated Code - GPT-5-Codex (OpenAI)
+"""
+
+import pytest
+from datasets import Dataset as HFDataset
+from datasets import DatasetDict as HFDatasetDict
+
+from sieval.core.models import ModelOutput
+from sieval.core.models.gen_model import GenModel
+from sieval.core.tasks import TaskContext
+from sieval.datasets.gsm8k import GSM8KDataset, GSM8KDatasetSample
+from sieval.tasks.gsm8k_kshot_base_gen import (
+    GSM8KFewShotBaseGenTask,
+    _extract_answer,
+    _extract_flexible_match,
+)
+
+
+class _CapturingGenModel(GenModel):
+    def __init__(self):
+        super().__init__(model="mock-gen", api_key="fake")
+        self.last_kwargs: dict[str, object] = {}
+
+    async def _agenerate_impl(self, prompt: str, **kwargs) -> ModelOutput:
+        _ = prompt
+        self.last_kwargs = dict(kwargs)
+        return ModelOutput(model=self.meta(), texts=[" Work shown.\n#### 42"])
+
+    async def _alogprobs_impl(
+        self,
+        prompt: str,
+        *,
+        max_tokens: int = 1,
+        logprobs: int = 5,
+        echo: bool = True,
+        temperature: float = 0.0,
+        **kwargs,
+    ) -> ModelOutput:
+        _ = (prompt, max_tokens, logprobs, echo, temperature, kwargs)
+        return ModelOutput(model=self.meta(), texts=[""])
+
+
+def _sample(answer: str = "Solution.\n#### 42") -> GSM8KDatasetSample:
+    return {"question": "What is 40 + 2?", "answer": answer}
+
+
+def _task() -> tuple[GSM8KFewShotBaseGenTask, _CapturingGenModel]:
+    dataset = GSM8KDataset(
+        _hf_dict=HFDatasetDict(
+            {
+                "train": HFDataset.from_list([dict(_sample())]),
+                "test": HFDataset.from_list([dict(_sample())]),
+            }
+        )
+    )
+    model = _CapturingGenModel()
+    return GSM8KFewShotBaseGenTask(dataset, model, k=0), model
+
+
+def test_strict_and_flexible_extractors_are_distinct():
+    assert _extract_answer("Therefore the answer is 42.") == ("", "none")
+    assert _extract_flexible_match("Therefore the answer is 42.") == (
+        "42",
+        "flexible-extract",
+    )
+    assert _extract_answer("Final.\n#### 1,234.") == ("1234", "strict-match")
+
+
+@pytest.mark.anyio
+async def test_infer_does_not_forward_n():
+    task, model = _task()
+
+    await task.infer("prompt", TaskContext(sample_id=0, raw_sample=_sample()))
+
+    assert "n" not in model.last_kwargs
+
+
+@pytest.mark.anyio
+async def test_feedback_and_report_include_flexible_secondary_metric():
+    task, model = _task()
+    raw = _sample()
+    inferred = ModelOutput(
+        model=model.meta(),
+        texts=["No strict delimiter, but the final sentence says 42."],
+    )
+
+    post = await task.postprocess(
+        inferred,
+        TaskContext(sample_id=0, raw_sample=raw, infer_result=inferred),
+    )
+    finalize, feedback = await task.feedback(
+        post,
+        TaskContext(sample_id=0, raw_sample=raw, infer_result=inferred),
+    )
+    report = await task.report(
+        [TaskContext(sample_id=0, raw_sample=raw, feedback_result=feedback)],
+        [],
+    )
+
+    assert finalize is True
+    assert feedback["correct"] is False
+    assert feedback["flexible_correct"] is True
+    assert report["score"] == 0.0
+    assert report["exact_match"] == 0.0
+    assert report["flexible_exact_match"] == 100.0


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Type

- feature — new benchmark, task, or capability

## Summary

- Add the GSM8K dataset wrapper backed by `hf:openai/gsm8k`.
- Add `gsm8k_8shot_base_gen`, an 8-shot generative task for base models.
- Mirror lm-evaluation-harness GSM8K prompt, stop sequences, and answer extraction behavior, with `num_fewshot` set to 8.
- Register the GSM8K dataset/task exports and meta index entries for discovery.
- Reference paper: https://arxiv.org/abs/2110.14168
- Reference repo: https://github.com/EleutherAI/lm-evaluation-harness/blob/1dd931087362abba74e0375c8c631295559f48b2/lm_eval/tasks/gsm8k/gsm8k.yaml

## Test Plan

### Automated

- [x] Lint/format clean (`ruff check && ruff format --check`)
- [x] Type check clean (`ty check` or `mypy --strict`)

### Manual

- [x] Dataset loading tested (`pdm run sieval dataset download gsm8k --data-dir /tmp/sieval-gsm8k-download-test`) succeeds
- [x] Ran `gsm8k_8shot_base_gen` on the full GSM8K test split with Qwen2.5-72B Base
- [x] Run completed 1319/1319 samples with 0 failures
- [x] Actual score: 86.35 exact match; reference score: 88.30; diff: -1.95

| Model | Expected| Actual | Diff |
| --- | ---: | ---: | ---: |
| Qwen2.5-72B Base | 88.30 | 86.35 | -1.95(-2.21%) |

## Checklist

### Required (all PRs)

- [x] PR title follows conventional format (`type(scope): description`)
- [x] No internal paths, credentials, or personal info in committed files
- [x] AI-generated code has `AI-Generated Code - <model> (<provider>)` in module docstring
- [x] No new upper-layer dependencies added to `core/`
- [x] Deleted code verified — no remaining call sites depend on it

### If: New or Modified Benchmark

- [x] Reference paper/repo linked in Summary
- [x] Score comparison table included (model, expected, actual, diff)
- [x] Dataset loading tested (`sieval dataset download <name>` succeeds)
- [x] Task registered in package-level `__init__.py`