### PR TITLE
feat(session): tolerate throughput-only config diffs on --resume

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ SiEval is a **model delivery quality verification system**: eval-side knowledge 
 Precise reproducibility is a product contract, not a nicety.
 
 * Safety guards (e.g. `--resume` strict match) ship strict-only. No `--force-*` flags, no bypass env vars, no "(future)" escape-hatch hints in errors.
+* The `--resume` match scope is deliberately narrowed to fields whose change could make resumed data incompatible with what is already on disk. Pure throughput/orchestration knobs (concurrency, retries, buffering, profiling, progress) are excluded and may be retuned across a resume — this narrows the contract's scope, it does not add a bypass. Result- and disk-layout-affecting fields (sampling params, seeds, `max_iterations`, `shard_samples`, `record_*`) and `infer_plans.yaml` remain strict.
 * Recovery: "start fresh" or "match the invocation". Escape-hatch proposals must re-justify the contract, not just add a flag.
 
 ## Toolchain

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ SiEval is a **model delivery quality verification system**: eval-side knowledge 
 Precise reproducibility is a product contract, not a nicety.
 
 * Safety guards (e.g. `--resume` strict match) ship strict-only. No `--force-*` flags, no bypass env vars, no "(future)" escape-hatch hints in errors.
-* The `--resume` match scope is deliberately narrowed to fields whose change could make resumed data incompatible with what is already on disk. Pure throughput/orchestration knobs (concurrency, retries, buffering, profiling, progress) are excluded and may be retuned across a resume — this narrows the contract's scope, it does not add a bypass. Result- and disk-layout-affecting fields (sampling params, seeds, `max_iterations`, `shard_samples`, `record_*`) and `infer_plans.yaml` remain strict.
+* The `--resume` match scope is deliberately narrowed to fields that touch neither the authoritative sample data nor any persisted artifact's content. Only pure scheduling (concurrency limits, shard-I/O parallelism, write-buffer timing) and console-only progress output (`show_progress`, progress log cadence) are excluded and may be retuned across a resume — this narrows the contract's scope, it does not add a bypass. Everything that affects on-disk content stays strict: sampling params, seeds, `max_iterations`, `shard_samples`, `record_*`, `max_retries` (the failure signal), `profile_*`, `detect_anomalies*`, and the `progress.json` dump (`dump_progress` / `progress_dump_interval`) — plus `infer_plans.yaml`.
 * Recovery: "start fresh" or "match the invocation". Escape-hatch proposals must re-justify the contract, not just add a flag.
 
 ## Toolchain

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ SiEval is a **model delivery quality verification system**: eval-side knowledge 
 Precise reproducibility is a product contract, not a nicety.
 
 * Safety guards (e.g. `--resume` strict match) ship strict-only. No `--force-*` flags, no bypass env vars, no "(future)" escape-hatch hints in errors.
-* The `--resume` match scope is deliberately narrowed to fields that touch neither the authoritative sample data nor any persisted artifact's content. Only pure scheduling (concurrency limits, shard-I/O parallelism, write-buffer timing) and console-only progress output (`show_progress`, progress log cadence) are excluded and may be retuned across a resume — this narrows the contract's scope, it does not add a bypass. Everything that affects on-disk content stays strict: sampling params, seeds, `max_iterations`, `shard_samples`, `record_*`, `max_retries` (the failure signal), `profile_*`, `detect_anomalies*`, and the `progress.json` dump (`dump_progress` / `progress_dump_interval`) — plus `infer_plans.yaml`.
+* `--resume` match scope is narrowed, not bypassed: only fields that touch neither sample data nor any persisted artifact may differ across a resume — pure scheduling (concurrency, shard-I/O, write buffers) and console-only progress. Everything affecting on-disk content stays strict (sampling/seeds, `max_iterations`, `shard_samples`, `record_*`, `max_retries`, `profile_*`, `detect_anomalies*`, the `progress.json` dump), as does `infer_plans.yaml`.
 * Recovery: "start fresh" or "match the invocation". Escape-hatch proposals must re-justify the contract, not just add a flag.
 
 ## Toolchain

--- a/sieval/cli/leaderboard/session.py
+++ b/sieval/cli/leaderboard/session.py
@@ -190,6 +190,101 @@ def _brief_diff(existing: str, current: str) -> str:
     return _diff_dicts(e, c)
 
 
+# ── Resume strict-match field policy ──────────────────────────────────────
+# Throughput / orchestration knobs that may change across a --resume without
+# invalidating already-persisted data: they alter how fast and in what order
+# samples are produced, never WHAT is produced or how it is laid out on disk.
+# Stripped from both configs before the strict-match comparison.
+#
+# MUST stay in sync with TaskRunnerConfig — TestRunnerFieldClassification
+# fails if a new dataclass field is left unbucketed. Forgetting to list a
+# genuine throughput field here only causes a spurious resume abort (safe);
+# a result/layout field can never land here except by explicit human edit.
+_THROUGHPUT_RUNNER_KEYS: frozenset[str] = frozenset(
+    {
+        "concurrency_limit",
+        "concurrency_limits",
+        "profile_io",
+        "profile_stages",
+        "profile_usage",
+        "shard_read_concurrency",
+        "shard_write_concurrency",
+        "write_buffer_size",
+        "write_buffer_flush_interval",
+        "show_progress",
+        "progress_log_interval",
+        "progress_log_pct_interval",
+        "dump_progress",
+        "progress_dump_interval",
+        "max_retries",
+        "detect_anomalies",
+        "detect_anomalies_on_resume",
+    }
+)
+
+# Result- or disk-layout-affecting runner_config fields that MUST match.
+_STRICT_RUNNER_KEYS: frozenset[str] = frozenset(
+    {
+        "shard_samples",
+        "record_each_stage",
+        "record_type_metadata",
+        "record_meta",
+        "max_iterations",
+        "deterministic",
+    }
+)
+
+# Fields that never participate in the match: result_dir is the resume
+# target's own location; auto_resume is set on the runtime config only and is
+# never persisted into the body; stage_meta hooks are callables (not
+# YAML-serializable).
+_NONMATCH_RUNNER_KEYS: frozenset[str] = frozenset(
+    {
+        "result_dir",
+        "auto_resume",
+        "stage_meta_hook",
+        "stage_meta_hooks",
+    }
+)
+
+
+def _strip_throughput_fields(cfg: dict[str, Any]) -> dict[str, Any]:
+    """Return a deep copy of ``cfg`` with throughput knobs removed.
+
+    Removes (on the copy only; the input is never mutated):
+      * top-level ``concurrency_limit`` / ``concurrency_limits``
+      * ``models.*.args.concurrency_limit``
+      * ``tasks.*.runner_config.<k>`` for every ``k`` in
+        ``_THROUGHPUT_RUNNER_KEYS``
+
+    Used to compare two effective configs for strict-match resume while
+    tolerating differences that cannot make resumed data incompatible.
+    """
+    out = copy.deepcopy(cfg)
+
+    for key in ("concurrency_limit", "concurrency_limits"):
+        out.pop(key, None)
+
+    models = out.get("models")
+    if isinstance(models, dict):
+        for mcfg in models.values():
+            if isinstance(mcfg, dict):
+                args = mcfg.get("args")
+                if isinstance(args, dict):
+                    args.pop("concurrency_limit", None)
+
+    tasks = out.get("tasks")
+    if isinstance(tasks, dict):
+        for tcfg in tasks.values():
+            if isinstance(tcfg, dict):
+                rc = tcfg.get("runner_config")
+                if isinstance(rc, dict):
+                    for key in _THROUGHPUT_RUNNER_KEYS:
+                        rc.pop(key, None)
+
+    return out
+
+
 def resolve_deterministic(cli_override: bool | None, config: Mapping[str, Any]) -> bool:
     """Effective deterministic flag: monotone OR of YAML and CLI.
 

--- a/sieval/cli/leaderboard/session.py
+++ b/sieval/cli/leaderboard/session.py
@@ -115,24 +115,36 @@ class RootConfigDict(TypedDict, total=False):
     alignment: AlignmentBlockDict
 
 
-def _strip_header(text: str) -> str:
-    """Strip the comment header block written by ``_format_comment_header``.
+def _split_header(text: str) -> tuple[str, str]:
+    """Partition ``text`` into ``(header, body)`` at the comment header block
+    written by ``_format_comment_header``.
 
-    Anchored to the ``# ---...`` border so only OUR header is stripped, not
-    arbitrary user-added top-of-file comments. A leading border with no
-    closing border is treated as malformed and returned unchanged so body
-    comparison detects the tampering instead of silently succeeding.
+    Anchored to the ``# ---...`` border pair so only OUR header is split off,
+    not arbitrary user-added top-of-file comments. A leading border with no
+    closing border is treated as malformed and yields ``("", text)`` so body
+    comparison detects the tampering instead of silently succeeding. When no
+    header is present, returns ``("", text)``. In all cases ``header + body``
+    reconstructs ``text`` exactly.
     """
     lines = text.splitlines(keepends=True)
     if not lines or not lines[0].startswith("# -"):
-        return text
+        return "", text
     for i in range(1, len(lines)):
         if lines[i].startswith("# -"):
             end = i + 1
             if end < len(lines) and lines[end].strip() == "":
                 end += 1
-            return "".join(lines[end:])
-    return text
+            return "".join(lines[:end]), "".join(lines[end:])
+    return "", text
+
+
+def _strip_header(text: str) -> str:
+    """Return ``text`` with the ``_format_comment_header`` block removed.
+
+    Thin wrapper over :func:`_split_header`; see it for border/malformed
+    semantics.
+    """
+    return _split_header(text)[1]
 
 
 def _brief_diff(existing: str, current: str) -> str:

--- a/sieval/cli/leaderboard/session.py
+++ b/sieval/cli/leaderboard/session.py
@@ -241,8 +241,13 @@ _STRICT_RUNNER_KEYS: frozenset[str] = frozenset(
     }
 )
 
-# Never compared: result_dir is the target's location, auto_resume is runtime-
-# only (never persisted), stage_meta hooks are non-serializable callables.
+# Neither adjustable nor strict — listed only so the three buckets partition
+# TaskRunnerConfig exactly (see test_every_field_classified_exactly_once). The
+# strip removes result_dir at top level (reification injects it there); the rest
+# are never reached because they don't survive into a persisted runner_config
+# block: auto_resume is set by the orchestration layer at runtime, stage_meta
+# hooks are non-serializable callables. A hand-authored runner_config field from
+# this set that changed across a resume would still be compared strictly.
 _NONMATCH_RUNNER_KEYS: frozenset[str] = frozenset(
     {
         "result_dir",
@@ -258,9 +263,7 @@ def _strip_noncomparable_fields(cfg: dict[str, Any]) -> dict[str, Any]:
 
     Strips (input never mutated) top-level ``concurrency_limit`` /
     ``concurrency_limits`` / ``result_dir``, ``models.*.args.concurrency_limit``,
-    and ``_THROUGHPUT_RUNNER_KEYS`` from runner_config wherever it lives — the
-    top-level ``runner_config`` defaults block (merged into every task) and each
-    ``tasks.*.runner_config``.
+    and ``_THROUGHPUT_RUNNER_KEYS`` from every ``runner_config`` block.
     """
     out = copy.deepcopy(cfg)
 
@@ -276,7 +279,8 @@ def _strip_noncomparable_fields(cfg: dict[str, Any]) -> dict[str, Any]:
                     args.pop("concurrency_limit", None)
 
     # runner_config carries throughput knobs in two equivalent places: the
-    # top-level defaults block and per-task overrides. Strip both identically.
+    # top-level defaults block (merged into every task) and per-task overrides.
+    # Strip both identically.
     runner_config_blocks = [out.get("runner_config")]
     tasks = out.get("tasks")
     if isinstance(tasks, dict):
@@ -449,16 +453,14 @@ def _format_comment_header(
 def _append_resume_note(header: str, diff_lines: list[str]) -> str:
     """Insert a ``Resumed by …`` audit block into ``header``, before its border.
 
-    Called when ``--resume`` rewrites a persisted file because only resume-
-    mutable (throughput) fields changed. The original provenance is kept and a
-    timestamped record of ``diff_lines`` is appended, so the header accumulates
-    the full lineage of tolerated reconfigurations across resumes. New lines sit
-    inside the ``# ---`` border pair so :func:`_split_header` still treats the
-    whole block as the header on the next resume.
+    Called when ``--resume`` rewrites a file because only resume-mutable fields
+    changed. The original provenance survives and ``diff_lines`` is recorded with
+    a timestamp, so the header accumulates the full lineage across resumes. The
+    note sits inside the ``# ---`` border pair so :func:`_split_header` keeps
+    treating the whole block as the header next time.
 
-    ``header`` is assumed well-formed (two borders) — the caller only passes a
-    header produced by :func:`_format_comment_header` or recovered intact by
-    :func:`_split_header`.
+    Assumes a well-formed ``header`` (two borders) — the only kind the caller
+    passes (from :func:`_format_comment_header` or :func:`_split_header`).
     """
     from sieval import __version__
 
@@ -1512,10 +1514,9 @@ class EvalSession:
                     f"{audit_label}"
                 ) from e
 
-            # We dump a mapping, so current_cfg is always a dict; a tampered
-            # existing file may parse to a scalar/list. Refuse cleanly rather
-            # than let mutable_strip raise an opaque AttributeError — RuntimeError
-            # is the only failure the caller is documented to observe.
+            # current_cfg is always a dict (we dump a mapping); a tampered file
+            # may parse to a scalar/list. Refuse cleanly so mutable_strip can't
+            # raise an opaque AttributeError instead of the documented RuntimeError.
             if not isinstance(existing_cfg, dict) or not isinstance(current_cfg, dict):
                 raise RuntimeError(
                     f"Resume aborted: existing {target} is not a YAML mapping — "
@@ -1540,8 +1541,9 @@ class EvalSession:
             # Only resume-mutable (or formatting) fields differ — rewrite with
             # the new body. When real fields changed (not just formatting) and
             # the file had a header, append a timestamped record of the change
-            # so the header keeps the full resume lineage; otherwise keep the
-            # original header (or synthesize a fresh one for a header-less file).
+            # so the header keeps the full resume lineage. Otherwise no note is
+            # added: a formatting-only diff keeps the original header, and a
+            # header-less file gets a fresh one (it had no lineage to extend).
             logger.info(
                 "Resume: {} resume-mutable fields changed — updating file",
                 target_name,

--- a/sieval/cli/leaderboard/session.py
+++ b/sieval/cli/leaderboard/session.py
@@ -11,7 +11,7 @@ import importlib
 import os
 import shlex
 import sys
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from datetime import UTC, datetime
 from pathlib import Path
 from types import MappingProxyType
@@ -253,6 +253,8 @@ def _strip_throughput_fields(cfg: dict[str, Any]) -> dict[str, Any]:
 
     Removes (on the copy only; the input is never mutated):
       * top-level ``concurrency_limit`` / ``concurrency_limits``
+      * top-level ``result_dir`` (the resume target's own location —
+        never affects what results are produced, only where they go)
       * ``models.*.args.concurrency_limit``
       * ``tasks.*.runner_config.<k>`` for every ``k`` in
         ``_THROUGHPUT_RUNNER_KEYS``
@@ -262,7 +264,7 @@ def _strip_throughput_fields(cfg: dict[str, Any]) -> dict[str, Any]:
     """
     out = copy.deepcopy(cfg)
 
-    for key in ("concurrency_limit", "concurrency_limits"):
+    for key in ("concurrency_limit", "concurrency_limits", "result_dir"):
         out.pop(key, None)
 
     models = out.get("models")
@@ -1410,14 +1412,26 @@ class EvalSession:
         body: str,
         header: str,
         audit_label: str,
+        mutable_strip: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
     ) -> None:
         """Atomically write ``header + body`` to ``result_dir/target_name``.
 
-        Under ``--resume`` with an existing target file, the persisted body
-        (header excluded) MUST match ``body`` byte-for-byte; mismatch raises
-        ``RuntimeError`` (the only failure mode the caller observes — every
-        other failure is best-effort and only logged). On match, the file is
-        not rewritten so existing header timestamps survive the resume.
+        Under ``--resume`` with an existing target file:
+
+        * If the persisted body (header excluded) matches ``body``
+          byte-for-byte, the file is not rewritten so existing header
+          timestamps survive.
+        * If ``mutable_strip`` is ``None`` (byte-for-byte strict, e.g. infer
+          plans), any other difference raises ``RuntimeError``.
+        * If ``mutable_strip`` is provided, the two bodies are parsed and
+          compared with ``mutable_strip`` applied to both. Differences that
+          vanish under stripping (throughput knobs, or pure formatting) are
+          tolerated: the file is rewritten with the new ``body`` while the
+          original header/timestamps are preserved. A residual difference
+          (result- or layout-affecting) raises ``RuntimeError``.
+
+        ``RuntimeError`` is the only failure mode the caller observes — every
+        other failure is best-effort and only logged.
         """
         effective_result_dir = self._resolve_result_dir()
         if effective_result_dir is None:
@@ -1429,39 +1443,71 @@ class EvalSession:
         result_path = anyio.Path(effective_result_dir)
         target = result_path / target_name
 
-        # Strict-match resume check: if --resume was requested and a persisted
-        # file exists, the current invocation's body MUST match the persisted
-        # body byte-for-byte (comment header excluded). Silently resuming under
-        # a different config would mix data from two runs.
+        write_header = header
+
         if self.resume_override and await target.exists():
             try:
                 existing = await target.read_text(encoding="utf-8")
             except OSError as e:
-                # Can't verify the match — refuse to resume. Surfaced as the
-                # same Resume-aborted shape so the user sees a consistent
-                # error class instead of a bare OSError from the persistence
-                # path they may not know exists.
                 raise RuntimeError(
                     f"Resume aborted: cannot read existing {target}: {e}\n"
                     "Either:\n"
                     "  1. Remove the result_dir and start fresh\n"
                     f"  2. Ensure {target} is readable"
                 ) from e
-            existing_body = _strip_header(existing)
-            if existing_body != body:
-                diff_hint = _brief_diff(existing_body, body)
+
+            existing_header, existing_body = _split_header(existing)
+
+            if existing_body == body:
+                logger.info("Resume: {} matches — skipping rewrite", target_name)
+                return
+
+            if mutable_strip is None:
+                # Byte-for-byte strict (e.g. infer plans): any diff aborts.
                 raise RuntimeError(
                     f"Resume aborted: {target} does not match current invocation.\n"
-                    f"{diff_hint}\n"
+                    f"{_brief_diff(existing_body, body)}\n"
                     "Either:\n"
                     "  1. Remove the result_dir and start fresh\n"
                     f"  2. Match the invocation to the persisted {audit_label}"
                 )
-            logger.info("Resume: {} matches — skipping rewrite", target_name)
-            return
+
+            # Tolerate throughput-only diffs: parse BOTH sides through YAML so
+            # type coercion (e.g. tuple→list) can't cause a spurious mismatch.
+            try:
+                existing_cfg = yaml.safe_load(existing_body) or {}
+                current_cfg = yaml.safe_load(body) or {}
+            except yaml.YAMLError as e:
+                raise RuntimeError(
+                    f"Resume aborted: cannot parse existing {target} to verify "
+                    f"match: {e}\n"
+                    "Either:\n"
+                    "  1. Remove the result_dir and start fresh\n"
+                    f"  2. Restore {target} to valid YAML matching the persisted "
+                    f"{audit_label}"
+                ) from e
+
+            stripped_existing = mutable_strip(existing_cfg)
+            stripped_current = mutable_strip(current_cfg)
+            if stripped_existing != stripped_current:
+                raise RuntimeError(
+                    f"Resume aborted: {target} does not match current invocation.\n"
+                    f"{_diff_dicts(stripped_existing, stripped_current)}\n"
+                    "Either:\n"
+                    "  1. Remove the result_dir and start fresh\n"
+                    f"  2. Match the invocation to the persisted {audit_label}"
+                )
+
+            # Result-relevant content is identical; only throughput (or
+            # formatting) differs. Rewrite so the artifact reflects the new
+            # throughput, preserving the original header/timestamps when present.
+            logger.info(
+                "Resume: {} throughput fields changed — updating file", target_name
+            )
+            write_header = existing_header or header
 
         tmp_path = target.with_name(target.name + ".tmp")
-        content = header + body
+        content = write_header + body
 
         try:
             await result_path.mkdir(parents=True, exist_ok=True)
@@ -1506,6 +1552,7 @@ class EvalSession:
             body=body,
             header=header,
             audit_label="effective config",
+            mutable_strip=_strip_throughput_fields,
         )
 
     async def _persist_infer_plans(self) -> None:

--- a/sieval/cli/leaderboard/session.py
+++ b/sieval/cli/leaderboard/session.py
@@ -248,8 +248,9 @@ _NONMATCH_RUNNER_KEYS: frozenset[str] = frozenset(
 )
 
 
-def _strip_throughput_fields(cfg: dict[str, Any]) -> dict[str, Any]:
-    """Return a deep copy of ``cfg`` with throughput knobs removed.
+def _strip_noncomparable_fields(cfg: dict[str, Any]) -> dict[str, Any]:
+    """Return a deep copy of ``cfg`` with fields that may differ across a resume removed
+    (throughput knobs plus the ``result_dir`` location).
 
     Removes (on the copy only; the input is never mutated):
       * top-level ``concurrency_limit`` / ``concurrency_limits``
@@ -1552,7 +1553,7 @@ class EvalSession:
             body=body,
             header=header,
             audit_label="effective config",
-            mutable_strip=_strip_throughput_fields,
+            mutable_strip=_strip_noncomparable_fields,
         )
 
     async def _persist_infer_plans(self) -> None:

--- a/sieval/cli/leaderboard/session.py
+++ b/sieval/cli/leaderboard/session.py
@@ -147,6 +147,33 @@ def _strip_header(text: str) -> str:
     return _split_header(text)[1]
 
 
+def _diff_dicts(a: dict[str, Any], b: dict[str, Any]) -> str:
+    """Return a short human-readable hint describing which keys differ.
+
+    Walks two parsed-config mappings; reports up to 10 differing leaf paths.
+    Returns a "formatting only" sentinel when nothing differs.
+    """
+    diffs: list[str] = []
+
+    def _walk(x: Any, y: Any, path: str) -> None:
+        if isinstance(x, dict) and isinstance(y, dict):
+            for k in sorted(set(x) | set(y)):
+                _walk(x.get(k), y.get(k), f"{path}.{k}" if path else k)
+        elif isinstance(x, list) and isinstance(y, list):
+            if len(x) != len(y):
+                diffs.append(f"  - {path}: list length {len(x)} → {len(y)}")
+            else:
+                for i, (xv, yv) in enumerate(zip(x, y, strict=True)):
+                    _walk(xv, yv, f"{path}[{i}]")
+        elif x != y:
+            diffs.append(f"  - {path}: {x!r} → {y!r}")
+
+    _walk(a, b, "")
+    if not diffs:
+        return "Diff: (whitespace / formatting only)"
+    return "Diff:\n" + "\n".join(diffs[:10])
+
+
 def _brief_diff(existing: str, current: str) -> str:
     """Return a short human-readable hint describing which YAML keys differ.
 
@@ -160,25 +187,7 @@ def _brief_diff(existing: str, current: str) -> str:
         c = yaml.safe_load(current) or {}
     except yaml.YAMLError:
         return "Diff: (existing file is not valid YAML — cannot compute key-level diff)"
-    diffs: list[str] = []
-
-    def _walk(a: Any, b: Any, path: str) -> None:
-        if isinstance(a, dict) and isinstance(b, dict):
-            for k in sorted(set(a) | set(b)):
-                _walk(a.get(k), b.get(k), f"{path}.{k}" if path else k)
-        elif isinstance(a, list) and isinstance(b, list):
-            if len(a) != len(b):
-                diffs.append(f"  - {path}: list length {len(a)} → {len(b)}")
-            else:
-                for i, (av, bv) in enumerate(zip(a, b, strict=True)):
-                    _walk(av, bv, f"{path}[{i}]")
-        elif a != b:
-            diffs.append(f"  - {path}: {a!r} → {b!r}")
-
-    _walk(e, c, "")
-    if not diffs:
-        return "Diff: (whitespace / formatting only)"
-    return "Diff:\n" + "\n".join(diffs[:10])
+    return _diff_dicts(e, c)
 
 
 def resolve_deterministic(cli_override: bool | None, config: Mapping[str, Any]) -> bool:

--- a/sieval/cli/leaderboard/session.py
+++ b/sieval/cli/leaderboard/session.py
@@ -191,38 +191,45 @@ def _brief_diff(existing: str, current: str) -> str:
 
 
 # ── Resume strict-match field policy ──────────────────────────────────────
-# Throughput / orchestration knobs that may change across a --resume without
-# invalidating already-persisted data: they alter how fast and in what order
-# samples are produced, never WHAT is produced or how it is laid out on disk.
+# A field is safe to change across a --resume ONLY if it touches neither the
+# authoritative sample data NOR any persisted artifact's content. That leaves
+# pure scheduling (concurrency, shard-I/O parallelism, write-buffer timing)
+# and console-only progress output (tqdm bar + loguru cadence) — these alter
+# how fast/in what order samples run, never WHAT is written to disk.
 # Stripped from both configs before the strict-match comparison.
 #
 # MUST stay in sync with TaskRunnerConfig — TestRunnerFieldClassification
 # fails if a new dataclass field is left unbucketed. Forgetting to list a
-# genuine throughput field here only causes a spurious resume abort (safe);
-# a result/layout field can never land here except by explicit human edit.
+# genuine scheduling field here only causes a spurious resume abort (safe);
+# a result/artifact field can never land here except by explicit human edit.
 _THROUGHPUT_RUNNER_KEYS: frozenset[str] = frozenset(
     {
         "concurrency_limit",
         "concurrency_limits",
-        "profile_io",
-        "profile_stages",
-        "profile_usage",
         "shard_read_concurrency",
         "shard_write_concurrency",
         "write_buffer_size",
         "write_buffer_flush_interval",
+        # Console-only progress: tqdm bar visibility + loguru log cadence.
+        # These feed neither the progress.json dump (gated by dump_progress)
+        # nor any other on-disk artifact, so they are safe to retune.
         "show_progress",
         "progress_log_interval",
         "progress_log_pct_interval",
-        "dump_progress",
-        "progress_dump_interval",
-        "max_retries",
-        "detect_anomalies",
-        "detect_anomalies_on_resume",
     }
 )
 
-# Result- or disk-layout-affecting runner_config fields that MUST match.
+# Fields that MUST match: they affect the authoritative sample data, an
+# on-disk artifact's content, or the meaning of a recorded outcome.
+#   * shard_samples / record_*       — shard layout & persisted record shape
+#   * max_iterations / deterministic — produced data
+#   * max_retries                    — the failure SIGNAL: a sample that is
+#       FAILED after k retries is itself a result, the value is written into
+#       the FAILED record's reason, and resuming under a different budget
+#       would mix failure criteria across one dataset.
+#   * profile_*                      — per-record timing meta + profiler file
+#   * detect_anomalies*              — the anomaly report artifact
+#   * dump_progress / progress_dump_interval — the progress.json dump
 _STRICT_RUNNER_KEYS: frozenset[str] = frozenset(
     {
         "shard_samples",
@@ -231,6 +238,14 @@ _STRICT_RUNNER_KEYS: frozenset[str] = frozenset(
         "record_meta",
         "max_iterations",
         "deterministic",
+        "max_retries",
+        "profile_io",
+        "profile_stages",
+        "profile_usage",
+        "detect_anomalies",
+        "detect_anomalies_on_resume",
+        "dump_progress",
+        "progress_dump_interval",
     }
 )
 

--- a/sieval/cli/leaderboard/session.py
+++ b/sieval/cli/leaderboard/session.py
@@ -147,11 +147,12 @@ def _strip_header(text: str) -> str:
     return _split_header(text)[1]
 
 
-def _diff_dicts(a: dict[str, Any], b: dict[str, Any]) -> str:
-    """Return a short human-readable hint describing which keys differ.
+def _diff_lines(a: dict[str, Any], b: dict[str, Any]) -> list[str]:
+    """Return ``- <path>: <old> → <new>`` lines for every differing leaf.
 
-    Walks two parsed-config mappings; reports up to 10 differing leaf paths.
-    Returns a "formatting only" sentinel when nothing differs.
+    Walks two parsed-config mappings depth-first. Empty list means the two
+    parse to the same structure (any textual difference was whitespace /
+    formatting only).
     """
     diffs: list[str] = []
 
@@ -161,17 +162,27 @@ def _diff_dicts(a: dict[str, Any], b: dict[str, Any]) -> str:
                 _walk(x.get(k), y.get(k), f"{path}.{k}" if path else k)
         elif isinstance(x, list) and isinstance(y, list):
             if len(x) != len(y):
-                diffs.append(f"  - {path}: list length {len(x)} → {len(y)}")
+                diffs.append(f"- {path}: list length {len(x)} → {len(y)}")
             else:
                 for i, (xv, yv) in enumerate(zip(x, y, strict=True)):
                     _walk(xv, yv, f"{path}[{i}]")
         elif x != y:
-            diffs.append(f"  - {path}: {x!r} → {y!r}")
+            diffs.append(f"- {path}: {x!r} → {y!r}")
 
     _walk(a, b, "")
-    if not diffs:
+    return diffs
+
+
+def _diff_dicts(a: dict[str, Any], b: dict[str, Any]) -> str:
+    """Return a short human-readable hint describing which keys differ.
+
+    Thin wrapper over :func:`_diff_lines`; reports up to 10 differing leaf
+    paths and a "formatting only" sentinel when nothing differs.
+    """
+    lines = _diff_lines(a, b)
+    if not lines:
         return "Diff: (whitespace / formatting only)"
-    return "Diff:\n" + "\n".join(diffs[:10])
+    return "Diff:\n" + "\n".join(f"  {line}" for line in lines[:10])
 
 
 def _brief_diff(existing: str, current: str) -> str:
@@ -247,7 +258,9 @@ def _strip_noncomparable_fields(cfg: dict[str, Any]) -> dict[str, Any]:
 
     Strips (input never mutated) top-level ``concurrency_limit`` /
     ``concurrency_limits`` / ``result_dir``, ``models.*.args.concurrency_limit``,
-    and ``tasks.*.runner_config.<k>`` for ``k`` in ``_THROUGHPUT_RUNNER_KEYS``.
+    and ``_THROUGHPUT_RUNNER_KEYS`` from runner_config wherever it lives — the
+    top-level ``runner_config`` defaults block (merged into every task) and each
+    ``tasks.*.runner_config``.
     """
     out = copy.deepcopy(cfg)
 
@@ -262,14 +275,20 @@ def _strip_noncomparable_fields(cfg: dict[str, Any]) -> dict[str, Any]:
                 if isinstance(args, dict):
                     args.pop("concurrency_limit", None)
 
+    # runner_config carries throughput knobs in two equivalent places: the
+    # top-level defaults block and per-task overrides. Strip both identically.
+    runner_config_blocks = [out.get("runner_config")]
     tasks = out.get("tasks")
     if isinstance(tasks, dict):
-        for tcfg in tasks.values():
-            if isinstance(tcfg, dict):
-                rc = tcfg.get("runner_config")
-                if isinstance(rc, dict):
-                    for key in _THROUGHPUT_RUNNER_KEYS:
-                        rc.pop(key, None)
+        runner_config_blocks.extend(
+            tcfg.get("runner_config")
+            for tcfg in tasks.values()
+            if isinstance(tcfg, dict)
+        )
+    for rc in runner_config_blocks:
+        if isinstance(rc, dict):
+            for key in _THROUGHPUT_RUNNER_KEYS:
+                rc.pop(key, None)
 
     return out
 
@@ -425,6 +444,32 @@ def _format_comment_header(
         lines.extend(f"# {line}" for line in extra_lines)
     lines.extend([border, ""])
     return "\n".join(lines) + "\n"
+
+
+def _append_resume_note(header: str, diff_lines: list[str]) -> str:
+    """Insert a ``Resumed by …`` audit block into ``header``, before its border.
+
+    Called when ``--resume`` rewrites a persisted file because only resume-
+    mutable (throughput) fields changed. The original provenance is kept and a
+    timestamped record of ``diff_lines`` is appended, so the header accumulates
+    the full lineage of tolerated reconfigurations across resumes. New lines sit
+    inside the ``# ---`` border pair so :func:`_split_header` still treats the
+    whole block as the header on the next resume.
+
+    ``header`` is assumed well-formed (two borders) — the caller only passes a
+    header produced by :func:`_format_comment_header` or recovered intact by
+    :func:`_split_header`.
+    """
+    from sieval import __version__
+
+    now = datetime.now(UTC).isoformat()
+    note = [f"# Resumed by sieval {__version__} at {now}:\n"]
+    note.extend(f"#   {line}\n" for line in diff_lines)
+
+    lines = header.splitlines(keepends=True)
+    borders = [i for i, line in enumerate(lines) if line.startswith("# -")]
+    close = borders[-1]
+    return "".join(lines[:close] + note + lines[close:])
 
 
 def _warn_best_effort_deterministic(
@@ -1408,7 +1453,8 @@ class EvalSession:
         plans) any other diff raises. Otherwise both bodies are parsed and
         compared with ``mutable_strip`` applied; a diff that vanishes
         (resume-mutable or formatting) is tolerated — the file is rewritten
-        with the new body, original header preserved — and any residual diff
+        with the new body, and the original header gains an appended
+        ``Resumed by …`` record of what changed — and any residual diff
         raises. ``RuntimeError`` is the only failure the caller observes; all
         else is best-effort and logged.
         """
@@ -1466,6 +1512,20 @@ class EvalSession:
                     f"{audit_label}"
                 ) from e
 
+            # We dump a mapping, so current_cfg is always a dict; a tampered
+            # existing file may parse to a scalar/list. Refuse cleanly rather
+            # than let mutable_strip raise an opaque AttributeError — RuntimeError
+            # is the only failure the caller is documented to observe.
+            if not isinstance(existing_cfg, dict) or not isinstance(current_cfg, dict):
+                raise RuntimeError(
+                    f"Resume aborted: existing {target} is not a YAML mapping — "
+                    "cannot verify match.\n"
+                    "Either:\n"
+                    "  1. Remove the result_dir and start fresh\n"
+                    f"  2. Restore {target} to valid YAML matching the persisted "
+                    f"{audit_label}"
+                )
+
             stripped_existing = mutable_strip(existing_cfg)
             stripped_current = mutable_strip(current_cfg)
             if stripped_existing != stripped_current:
@@ -1478,12 +1538,24 @@ class EvalSession:
                 )
 
             # Only resume-mutable (or formatting) fields differ — rewrite with
-            # the new body, preserving the original header when present.
+            # the new body. When real fields changed (not just formatting) and
+            # the file had a header, append a timestamped record of the change
+            # so the header keeps the full resume lineage; otherwise keep the
+            # original header (or synthesize a fresh one for a header-less file).
             logger.info(
                 "Resume: {} resume-mutable fields changed — updating file",
                 target_name,
             )
-            write_header = existing_header or header
+            # The note records genuine resume-mutable changes only; result_dir is
+            # a never-compared location field (reification injects it), so drop it
+            # to keep it out of the audit trail.
+            note_before = {k: v for k, v in existing_cfg.items() if k != "result_dir"}
+            note_after = {k: v for k, v in current_cfg.items() if k != "result_dir"}
+            change_lines = _diff_lines(note_before, note_after)
+            if existing_header and change_lines:
+                write_header = _append_resume_note(existing_header, change_lines)
+            else:
+                write_header = existing_header or header
 
         tmp_path = target.with_name(target.name + ".tmp")
         content = write_header + body

--- a/sieval/cli/leaderboard/session.py
+++ b/sieval/cli/leaderboard/session.py
@@ -190,18 +190,9 @@ def _brief_diff(existing: str, current: str) -> str:
     return _diff_dicts(e, c)
 
 
-# ── Resume strict-match field policy ──────────────────────────────────────
-# A field is safe to change across a --resume ONLY if it touches neither the
-# authoritative sample data NOR any persisted artifact's content. That leaves
-# pure scheduling (concurrency, shard-I/O parallelism, write-buffer timing)
-# and console-only progress output (tqdm bar + loguru cadence) — these alter
-# how fast/in what order samples run, never WHAT is written to disk.
-# Stripped from both configs before the strict-match comparison.
-#
-# MUST stay in sync with TaskRunnerConfig — TestRunnerFieldClassification
-# fails if a new dataclass field is left unbucketed. Forgetting to list a
-# genuine scheduling field here only causes a spurious resume abort (safe);
-# a result/artifact field can never land here except by explicit human edit.
+# ── Resume strict-match field policy (must partition TaskRunnerConfig) ──
+# Adjustable across --resume only if a field touches neither the sample data
+# nor any persisted artifact: pure scheduling + console-only progress.
 _THROUGHPUT_RUNNER_KEYS: frozenset[str] = frozenset(
     {
         "concurrency_limit",
@@ -210,26 +201,16 @@ _THROUGHPUT_RUNNER_KEYS: frozenset[str] = frozenset(
         "shard_write_concurrency",
         "write_buffer_size",
         "write_buffer_flush_interval",
-        # Console-only progress: tqdm bar visibility + loguru log cadence.
-        # These feed neither the progress.json dump (gated by dump_progress)
-        # nor any other on-disk artifact, so they are safe to retune.
+        # Console-only (tqdm bar + log cadence); not the progress.json dump.
         "show_progress",
         "progress_log_interval",
         "progress_log_pct_interval",
     }
 )
 
-# Fields that MUST match: they affect the authoritative sample data, an
-# on-disk artifact's content, or the meaning of a recorded outcome.
-#   * shard_samples / record_*       — shard layout & persisted record shape
-#   * max_iterations / deterministic — produced data
-#   * max_retries                    — the failure SIGNAL: a sample that is
-#       FAILED after k retries is itself a result, the value is written into
-#       the FAILED record's reason, and resuming under a different budget
-#       would mix failure criteria across one dataset.
-#   * profile_*                      — per-record timing meta + profiler file
-#   * detect_anomalies*              — the anomaly report artifact
-#   * dump_progress / progress_dump_interval — the progress.json dump
+# Must match: affect sample data, an on-disk artifact, or a recorded outcome's
+# meaning — e.g. max_retries is the failure signal written into FAILED records;
+# profile_*/detect_anomalies*/dump_progress write profiler/anomaly/progress files.
 _STRICT_RUNNER_KEYS: frozenset[str] = frozenset(
     {
         "shard_samples",
@@ -249,10 +230,8 @@ _STRICT_RUNNER_KEYS: frozenset[str] = frozenset(
     }
 )
 
-# Fields that never participate in the match: result_dir is the resume
-# target's own location; auto_resume is set on the runtime config only and is
-# never persisted into the body; stage_meta hooks are callables (not
-# YAML-serializable).
+# Never compared: result_dir is the target's location, auto_resume is runtime-
+# only (never persisted), stage_meta hooks are non-serializable callables.
 _NONMATCH_RUNNER_KEYS: frozenset[str] = frozenset(
     {
         "result_dir",
@@ -264,19 +243,11 @@ _NONMATCH_RUNNER_KEYS: frozenset[str] = frozenset(
 
 
 def _strip_noncomparable_fields(cfg: dict[str, Any]) -> dict[str, Any]:
-    """Return a deep copy of ``cfg`` with fields that may differ across a resume removed
-    (throughput knobs plus the ``result_dir`` location).
+    """Deep-copy ``cfg`` with resume-mutable fields removed, for comparison.
 
-    Removes (on the copy only; the input is never mutated):
-      * top-level ``concurrency_limit`` / ``concurrency_limits``
-      * top-level ``result_dir`` (the resume target's own location —
-        never affects what results are produced, only where they go)
-      * ``models.*.args.concurrency_limit``
-      * ``tasks.*.runner_config.<k>`` for every ``k`` in
-        ``_THROUGHPUT_RUNNER_KEYS``
-
-    Used to compare two effective configs for strict-match resume while
-    tolerating differences that cannot make resumed data incompatible.
+    Strips (input never mutated) top-level ``concurrency_limit`` /
+    ``concurrency_limits`` / ``result_dir``, ``models.*.args.concurrency_limit``,
+    and ``tasks.*.runner_config.<k>`` for ``k`` in ``_THROUGHPUT_RUNNER_KEYS``.
     """
     out = copy.deepcopy(cfg)
 
@@ -1432,22 +1403,14 @@ class EvalSession:
     ) -> None:
         """Atomically write ``header + body`` to ``result_dir/target_name``.
 
-        Under ``--resume`` with an existing target file:
-
-        * If the persisted body (header excluded) matches ``body``
-          byte-for-byte, the file is not rewritten so existing header
-          timestamps survive.
-        * If ``mutable_strip`` is ``None`` (byte-for-byte strict, e.g. infer
-          plans), any other difference raises ``RuntimeError``.
-        * If ``mutable_strip`` is provided, the two bodies are parsed and
-          compared with ``mutable_strip`` applied to both. Differences that
-          vanish under stripping (throughput knobs, or pure formatting) are
-          tolerated: the file is rewritten with the new ``body`` while the
-          original header/timestamps are preserved. A residual difference
-          (result- or layout-affecting) raises ``RuntimeError``.
-
-        ``RuntimeError`` is the only failure mode the caller observes — every
-        other failure is best-effort and only logged.
+        Under ``--resume`` with an existing file: an identical body skips the
+        rewrite (timestamps survive). With ``mutable_strip=None`` (e.g. infer
+        plans) any other diff raises. Otherwise both bodies are parsed and
+        compared with ``mutable_strip`` applied; a diff that vanishes
+        (resume-mutable or formatting) is tolerated — the file is rewritten
+        with the new body, original header preserved — and any residual diff
+        raises. ``RuntimeError`` is the only failure the caller observes; all
+        else is best-effort and logged.
         """
         effective_result_dir = self._resolve_result_dir()
         if effective_result_dir is None:
@@ -1488,8 +1451,8 @@ class EvalSession:
                     f"  2. Match the invocation to the persisted {audit_label}"
                 )
 
-            # Tolerate throughput-only diffs: parse BOTH sides through YAML so
-            # type coercion (e.g. tuple→list) can't cause a spurious mismatch.
+            # Parse both sides so YAML type coercion (tuple→list) and key
+            # ordering can't cause a spurious mismatch.
             try:
                 existing_cfg = yaml.safe_load(existing_body) or {}
                 current_cfg = yaml.safe_load(body) or {}
@@ -1514,11 +1477,11 @@ class EvalSession:
                     f"  2. Match the invocation to the persisted {audit_label}"
                 )
 
-            # Result-relevant content is identical; only throughput (or
-            # formatting) differs. Rewrite so the artifact reflects the new
-            # throughput, preserving the original header/timestamps when present.
+            # Only resume-mutable (or formatting) fields differ — rewrite with
+            # the new body, preserving the original header when present.
             logger.info(
-                "Resume: {} throughput fields changed — updating file", target_name
+                "Resume: {} resume-mutable fields changed — updating file",
+                target_name,
             )
             write_header = existing_header or header
 

--- a/tests/unit/cli/leaderboard/test_session.py
+++ b/tests/unit/cli/leaderboard/test_session.py
@@ -21,6 +21,7 @@ from sieval.cli.leaderboard.session import (
     EvalSession,
     _apply_endpoint_injection,
     _brief_diff,
+    _diff_dicts,
     _format_comment_header,
     _guess_submodule_names,
     _reify_cli_overrides,
@@ -2960,6 +2961,21 @@ class TestEvalSessionRawConfig:
         # Reification must survive runner initialization.
         assert session.config["deterministic"] is True
         assert session.config["models"]["base"]["args"]["seed"] == 0
+
+
+class TestDiffDicts:
+    def test_reports_changed_scalar(self):
+        out = _diff_dicts({"a": 1, "b": 2}, {"a": 1, "b": 3})
+        assert "b" in out
+        assert "2" in out and "3" in out
+
+    def test_identical_reports_formatting_only(self):
+        out = _diff_dicts({"a": 1}, {"a": 1})
+        assert "formatting only" in out
+
+    def test_reports_list_length_change(self):
+        out = _diff_dicts({"xs": [1, 2]}, {"xs": [1, 2, 3]})
+        assert "list length 2 → 3" in out
 
 
 class TestBriefDiff:

--- a/tests/unit/cli/leaderboard/test_session.py
+++ b/tests/unit/cli/leaderboard/test_session.py
@@ -30,7 +30,7 @@ from sieval.cli.leaderboard.session import (
     _reify_cli_overrides,
     _split_header,
     _strip_header,
-    _strip_throughput_fields,
+    _strip_noncomparable_fields,
     arun_session,
     load_class_from_name,
     load_class_from_path,
@@ -2404,17 +2404,17 @@ class TestRunnerFieldClassification:
                 assert buckets[i].isdisjoint(buckets[j])
 
 
-class TestStripThroughputFields:
+class TestStripNoncomparableFields:
     def test_removes_top_level_concurrency_without_mutating_input(self):
         cfg = {"concurrency_limit": 8, "concurrency_limits": {"infer": 4}, "models": {}}
-        out = _strip_throughput_fields(cfg)
+        out = _strip_noncomparable_fields(cfg)
         assert "concurrency_limit" not in out
         assert "concurrency_limits" not in out
         assert cfg["concurrency_limit"] == 8  # original untouched
 
     def test_removes_per_model_args_concurrency_only(self):
         cfg = {"models": {"m": {"args": {"concurrency_limit": 64, "temperature": 0.0}}}}
-        out = _strip_throughput_fields(cfg)
+        out = _strip_noncomparable_fields(cfg)
         assert "concurrency_limit" not in out["models"]["m"]["args"]
         assert out["models"]["m"]["args"]["temperature"] == 0.0
 
@@ -2431,7 +2431,7 @@ class TestStripThroughputFields:
                 }
             }
         }
-        out = _strip_throughput_fields(cfg)
+        out = _strip_noncomparable_fields(cfg)
         rc = out["tasks"]["t"]["runner_config"]
         assert "concurrency_limits" not in rc
         assert "max_retries" not in rc

--- a/tests/unit/cli/leaderboard/test_session.py
+++ b/tests/unit/cli/leaderboard/test_session.py
@@ -22,9 +22,11 @@ from sieval.cli.leaderboard.session import (
     _THROUGHPUT_RUNNER_KEYS,
     DETERMINISTIC_DEFAULT_SEED,
     EvalSession,
+    _append_resume_note,
     _apply_endpoint_injection,
     _brief_diff,
     _diff_dicts,
+    _diff_lines,
     _format_comment_header,
     _guess_submodule_names,
     _reify_cli_overrides,
@@ -2450,6 +2452,22 @@ class TestStripNoncomparableFields:
         assert rc["shard_samples"] == 1024
         assert rc["max_iterations"] == 5
 
+    def test_removes_top_level_runner_config_throughput_keeps_strict(self):
+        # The top-level runner_config defaults block is merged into every task,
+        # so it carries the same throughput knobs and must be stripped too.
+        cfg = {
+            "runner_config": {
+                "concurrency_limits": {"infer": 4},
+                "write_buffer_size": 64,
+                "max_retries": 3,  # strict → kept
+            }
+        }
+        out = _strip_noncomparable_fields(cfg)
+        rc = out["runner_config"]
+        assert "concurrency_limits" not in rc
+        assert "write_buffer_size" not in rc
+        assert rc["max_retries"] == 3
+
 
 # ===================================================================
 # Best-effort deterministic warning: fires when the session talks to an
@@ -3047,6 +3065,42 @@ class TestDiffDicts:
     def test_reports_list_length_change(self):
         out = _diff_dicts({"xs": [1, 2]}, {"xs": [1, 2, 3]})
         assert "list length 2 → 3" in out
+
+
+class TestDiffLines:
+    def test_identical_returns_empty(self):
+        assert _diff_lines({"a": 1}, {"a": 1}) == []
+
+    def test_nested_leaf_path(self):
+        lines = _diff_lines({"a": {"b": 1}}, {"a": {"b": 2}})
+        assert lines == ["- a.b: 1 → 2"]
+
+
+class TestAppendResumeNote:
+    def test_note_inserted_before_closing_border_and_split_stable(self):
+        header = _format_comment_header(
+            title="Persisted by", source_config="/x", invocation="sieval run x"
+        )
+        body = "models:\n  base:\n    name: m\n"
+        out = _append_resume_note(header, ["- concurrency_limit: 8 → 2"])
+
+        assert "Persisted by sieval" in out  # origin preserved
+        assert "Resumed by sieval" in out
+        assert "#   - concurrency_limit: 8 → 2" in out
+        # The note sits inside the border pair: the whole block is still parsed
+        # as header (body is not polluted) when prepended to a body.
+        h, b = _split_header(out + body)
+        assert b == body
+        assert "Resumed by sieval" in h
+
+    def test_second_append_accumulates(self):
+        header = _format_comment_header(
+            title="Persisted by", source_config="/x", invocation="sieval run x"
+        )
+        once = _append_resume_note(header, ["- a: 1 → 2"])
+        twice = _append_resume_note(once, ["- a: 2 → 3"])
+        assert twice.count("Resumed by sieval") == 2
+        assert "- a: 1 → 2" in twice and "- a: 2 → 3" in twice
 
 
 class TestBriefDiff:

--- a/tests/unit/cli/leaderboard/test_session.py
+++ b/tests/unit/cli/leaderboard/test_session.py
@@ -17,6 +17,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from sieval.cli.leaderboard.session import (
+    _NONMATCH_RUNNER_KEYS,
+    _STRICT_RUNNER_KEYS,
+    _THROUGHPUT_RUNNER_KEYS,
     DETERMINISTIC_DEFAULT_SEED,
     EvalSession,
     _apply_endpoint_injection,
@@ -27,6 +30,7 @@ from sieval.cli.leaderboard.session import (
     _reify_cli_overrides,
     _split_header,
     _strip_header,
+    _strip_throughput_fields,
     arun_session,
     load_class_from_name,
     load_class_from_path,
@@ -36,6 +40,7 @@ from sieval.cli.leaderboard.session import (
     unwrap_proxies,
 )
 from sieval.core.models.model import Model
+from sieval.core.runners import TaskRunnerConfig
 from sieval.core.runners.multi_runner import MultiTaskRunner
 from tests.conftest import MockChatModel
 
@@ -2378,6 +2383,60 @@ class TestResolveDeterministic:
 
     def test_both_true_is_true(self):
         assert resolve_deterministic(True, {"deterministic": True}) is True
+
+
+# ===================================================================
+# Runner field classification: throughput vs strict vs non-match
+# ===================================================================
+class TestRunnerFieldClassification:
+    def test_every_field_classified_exactly_once(self):
+        all_fields = set(TaskRunnerConfig.__dataclass_fields__)
+        buckets = [
+            _THROUGHPUT_RUNNER_KEYS,
+            _STRICT_RUNNER_KEYS,
+            _NONMATCH_RUNNER_KEYS,
+        ]
+        union = set().union(*buckets)
+        assert union == all_fields, f"unclassified: {all_fields ^ union}"
+        # pairwise disjoint
+        for i in range(len(buckets)):
+            for j in range(i + 1, len(buckets)):
+                assert buckets[i].isdisjoint(buckets[j])
+
+
+class TestStripThroughputFields:
+    def test_removes_top_level_concurrency_without_mutating_input(self):
+        cfg = {"concurrency_limit": 8, "concurrency_limits": {"infer": 4}, "models": {}}
+        out = _strip_throughput_fields(cfg)
+        assert "concurrency_limit" not in out
+        assert "concurrency_limits" not in out
+        assert cfg["concurrency_limit"] == 8  # original untouched
+
+    def test_removes_per_model_args_concurrency_only(self):
+        cfg = {"models": {"m": {"args": {"concurrency_limit": 64, "temperature": 0.0}}}}
+        out = _strip_throughput_fields(cfg)
+        assert "concurrency_limit" not in out["models"]["m"]["args"]
+        assert out["models"]["m"]["args"]["temperature"] == 0.0
+
+    def test_removes_runner_config_throughput_keeps_strict(self):
+        cfg = {
+            "tasks": {
+                "t": {
+                    "runner_config": {
+                        "concurrency_limits": {"infer": 4},
+                        "max_retries": 3,
+                        "shard_samples": 1024,
+                        "max_iterations": 5,
+                    }
+                }
+            }
+        }
+        out = _strip_throughput_fields(cfg)
+        rc = out["tasks"]["t"]["runner_config"]
+        assert "concurrency_limits" not in rc
+        assert "max_retries" not in rc
+        assert rc["shard_samples"] == 1024
+        assert rc["max_iterations"] == 5
 
 
 # ===================================================================

--- a/tests/unit/cli/leaderboard/test_session.py
+++ b/tests/unit/cli/leaderboard/test_session.py
@@ -2423,8 +2423,14 @@ class TestStripNoncomparableFields:
             "tasks": {
                 "t": {
                     "runner_config": {
+                        # Scheduling + console-only → stripped
                         "concurrency_limits": {"infer": 4},
+                        "show_progress": False,
+                        # Affect on-disk content / result semantics → kept strict
                         "max_retries": 3,
+                        "profile_usage": False,
+                        "detect_anomalies": False,
+                        "dump_progress": False,
                         "shard_samples": 1024,
                         "max_iterations": 5,
                     }
@@ -2433,8 +2439,14 @@ class TestStripNoncomparableFields:
         }
         out = _strip_noncomparable_fields(cfg)
         rc = out["tasks"]["t"]["runner_config"]
+        # stripped (adjustable on resume)
         assert "concurrency_limits" not in rc
-        assert "max_retries" not in rc
+        assert "show_progress" not in rc
+        # kept (must match on resume — touch disk content / failure signal)
+        assert rc["max_retries"] == 3
+        assert rc["profile_usage"] is False
+        assert rc["detect_anomalies"] is False
+        assert rc["dump_progress"] is False
         assert rc["shard_samples"] == 1024
         assert rc["max_iterations"] == 5
 

--- a/tests/unit/cli/leaderboard/test_session.py
+++ b/tests/unit/cli/leaderboard/test_session.py
@@ -24,6 +24,7 @@ from sieval.cli.leaderboard.session import (
     _format_comment_header,
     _guess_submodule_names,
     _reify_cli_overrides,
+    _split_header,
     _strip_header,
     arun_session,
     load_class_from_name,
@@ -2842,6 +2843,36 @@ class TestStripHeader:
             "models:\n  m: {}\n"
         )
         assert _strip_header(text) == text
+
+
+class TestSplitHeader:
+    def test_valid_header_is_an_exact_partition(self):
+        header = _format_comment_header(
+            title="Persisted by", source_config="/x", invocation="sieval run x"
+        )
+        body = "models:\n  base:\n    name: m\n"
+        h, b = _split_header(header + body)
+        assert b == body
+        assert h + b == header + body
+
+    def test_no_header_returns_empty_header(self):
+        body = "models:\n  base: {}\n"
+        h, b = _split_header(body)
+        assert h == ""
+        assert b == body
+
+    def test_malformed_header_returns_empty_header(self):
+        broken = "# " + "-" * 70 + "\n# only one border\nmodels: {}\n"
+        h, b = _split_header(broken)
+        assert h == ""
+        assert b == broken
+
+    def test_strip_header_delegates_to_split(self):
+        header = _format_comment_header(
+            title="Persisted by", source_config="/x", invocation="sieval run x"
+        )
+        body = "models:\n  base:\n    name: m\n"
+        assert _strip_header(header + body) == _split_header(header + body)[1]
 
 
 class TestEvalSessionRawConfig:

--- a/tests/unit/cli/leaderboard/test_session_persistence.py
+++ b/tests/unit/cli/leaderboard/test_session_persistence.py
@@ -906,6 +906,23 @@ class TestStrictResumeMatch:
         with pytest.raises(RuntimeError, match=r"not a YAML mapping"):
             await s._persist_effective_config()
 
+    @pytest.mark.anyio
+    async def test_resume_aborts_on_unparseable_existing_file(self, tmp_path: Path):
+        # A tampered persisted body that is not valid YAML must surface as the
+        # documented RuntimeError, not the raw yaml.YAMLError from the strip path.
+        result_dir = tmp_path / "out"
+        result_dir.mkdir()
+        header = _format_comment_header(
+            title="Persisted by", source_config="/x", invocation="sieval run x"
+        )
+        (result_dir / "effective_config.yaml").write_text(header + "key: [unclosed\n")
+        cfg_path = _write_yaml(tmp_path, "cfg.yaml", "models:\n  base:\n    name: m\n")
+        s = EvalSession(
+            config_path=str(cfg_path), resume=True, result_dir_override=str(result_dir)
+        )
+        with pytest.raises(RuntimeError, match=r"cannot parse existing"):
+            await s._persist_effective_config()
+
 
 class TestPersistTimingBeforeRunnerArun:
     """Regression guard for spec §3.7: persistence must happen BEFORE

--- a/tests/unit/cli/leaderboard/test_session_persistence.py
+++ b/tests/unit/cli/leaderboard/test_session_persistence.py
@@ -681,9 +681,7 @@ class TestStrictResumeMatch:
 
     @pytest.mark.anyio
     async def test_resume_aborts_on_max_retries_change(self, tmp_path: Path):
-        # max_retries is the failure SIGNAL: a sample FAILED after k retries is
-        # itself a result and the value is written into the FAILED record's
-        # reason, so it must match on resume.
+        # max_retries is the failure signal (written into FAILED records) — strict.
         base = (
             "models:\n  base:\n    name: m\ntasks:\n  t:\n"
             "    runner_config:\n      max_retries: {}\n"
@@ -702,8 +700,7 @@ class TestStrictResumeMatch:
 
     @pytest.mark.anyio
     async def test_resume_aborts_on_profile_change(self, tmp_path: Path):
-        # profile_* feed per-record timing meta and the saved profiler summary
-        # — toggling mid-run yields inconsistent on-disk profiling artifacts.
+        # profile_* write per-record meta + the profiler summary file — strict.
         base = (
             "models:\n  base:\n    name: m\ntasks:\n  t:\n"
             "    runner_config:\n      profile_usage: {}\n"
@@ -722,8 +719,7 @@ class TestStrictResumeMatch:
 
     @pytest.mark.anyio
     async def test_resume_tolerates_console_progress_change(self, tmp_path: Path):
-        # show_progress is console-only (tqdm bar + loguru cadence) — it never
-        # feeds the progress.json dump, so it may be retuned across a resume.
+        # show_progress is console-only (never the progress.json dump) — adjustable.
         base = (
             "models:\n  base:\n    name: m\ntasks:\n  t:\n"
             "    runner_config:\n      show_progress: {}\n"

--- a/tests/unit/cli/leaderboard/test_session_persistence.py
+++ b/tests/unit/cli/leaderboard/test_session_persistence.py
@@ -650,7 +650,11 @@ class TestStrictResumeMatch:
         after = (result_dir / "effective_config.yaml").read_text()
         loaded = yaml.safe_load(after)
         assert loaded["concurrency_limit"] == 2  # body updated to new value
-        assert _split_header(after)[0] == original_header  # header preserved
+        after_header = _split_header(after)[0]
+        # Origin provenance preserved, and the change is appended as a record.
+        assert "Persisted by sieval" in after_header
+        assert "Resumed by sieval" in after_header
+        assert "concurrency_limit: 8 → 2" in after_header
 
     @pytest.mark.anyio
     async def test_resume_tolerates_per_model_args_concurrency_change(
@@ -824,6 +828,83 @@ class TestStrictResumeMatch:
             config_path=str(cfg_path), resume=True, result_dir_override=str(result_dir)
         )
         await s._persist_effective_config()  # must NOT raise (no semantic change)
+
+        # A formatting-only rewrite records no resume note (nothing changed).
+        after = (result_dir / "effective_config.yaml").read_text()
+        assert "Resumed by sieval" not in _split_header(after)[0]
+
+    @pytest.mark.anyio
+    async def test_resume_tolerates_top_level_runner_config_throughput(
+        self, tmp_path: Path
+    ):
+        # Throughput knobs in the TOP-LEVEL runner_config defaults block (merged
+        # into every task) are as resume-mutable as per-task ones.
+        base = (
+            "runner_config:\n  concurrency_limits:\n    infer: {}\n"
+            "models:\n  base:\n    name: m\n"
+        )
+        cfg_path = _write_yaml(tmp_path, "cfg.yaml", base.format(4))
+        result_dir = tmp_path / "out"
+        s1 = EvalSession(config_path=str(cfg_path), result_dir_override=str(result_dir))
+        await s1._persist_effective_config()
+
+        cfg_path.write_text(base.format(16))
+        s2 = EvalSession(
+            config_path=str(cfg_path), resume=True, result_dir_override=str(result_dir)
+        )
+        await s2._persist_effective_config()  # must NOT raise
+
+        after = (result_dir / "effective_config.yaml").read_text()
+        loaded = yaml.safe_load(after)
+        assert loaded["runner_config"]["concurrency_limits"]["infer"] == 16
+        header = _split_header(after)[0]
+        assert "runner_config.concurrency_limits.infer: 4 → 16" in header
+
+    @pytest.mark.anyio
+    async def test_resume_appends_accumulating_notes(self, tmp_path: Path):
+        base = "concurrency_limit: {}\nmodels:\n  base:\n    name: m\n"
+        cfg_path = _write_yaml(tmp_path, "cfg.yaml", base.format(8))
+        result_dir = tmp_path / "out"
+        s1 = EvalSession(config_path=str(cfg_path), result_dir_override=str(result_dir))
+        await s1._persist_effective_config()
+
+        # Two successive resumes, each changing only throughput.
+        for value in (4, 2):
+            cfg_path.write_text(base.format(value))
+            s = EvalSession(
+                config_path=str(cfg_path),
+                resume=True,
+                result_dir_override=str(result_dir),
+            )
+            await s._persist_effective_config()
+
+        after = (result_dir / "effective_config.yaml").read_text()
+        header, body = _split_header(after)
+        # Origin recorded once; every tolerated change appended in order.
+        assert header.count("Persisted by sieval") == 1
+        assert header.count("Resumed by sieval") == 2
+        assert "concurrency_limit: 8 → 4" in header
+        assert "concurrency_limit: 4 → 2" in header
+        # Body reflects the latest run; header/body partition stays intact.
+        assert yaml.safe_load(body)["concurrency_limit"] == 2
+        assert _split_header(after) == (header, body)
+
+    @pytest.mark.anyio
+    async def test_resume_aborts_on_non_mapping_existing_file(self, tmp_path: Path):
+        # A tampered persisted file that parses to a non-mapping must surface as
+        # the documented RuntimeError, not an opaque AttributeError from the strip.
+        result_dir = tmp_path / "out"
+        result_dir.mkdir()
+        header = _format_comment_header(
+            title="Persisted by", source_config="/x", invocation="sieval run x"
+        )
+        (result_dir / "effective_config.yaml").write_text(header + "- a\n- b\n")
+        cfg_path = _write_yaml(tmp_path, "cfg.yaml", "models:\n  base:\n    name: m\n")
+        s = EvalSession(
+            config_path=str(cfg_path), resume=True, result_dir_override=str(result_dir)
+        )
+        with pytest.raises(RuntimeError, match=r"not a YAML mapping"):
+            await s._persist_effective_config()
 
 
 class TestPersistTimingBeforeRunnerArun:

--- a/tests/unit/cli/leaderboard/test_session_persistence.py
+++ b/tests/unit/cli/leaderboard/test_session_persistence.py
@@ -680,9 +680,10 @@ class TestStrictResumeMatch:
         assert loaded["models"]["base"]["args"]["temperature"] == 0.0
 
     @pytest.mark.anyio
-    async def test_resume_tolerates_runner_config_max_retries_change(
-        self, tmp_path: Path
-    ):
+    async def test_resume_aborts_on_max_retries_change(self, tmp_path: Path):
+        # max_retries is the failure SIGNAL: a sample FAILED after k retries is
+        # itself a result and the value is written into the FAILED record's
+        # reason, so it must match on resume.
         base = (
             "models:\n  base:\n    name: m\ntasks:\n  t:\n"
             "    runner_config:\n      max_retries: {}\n"
@@ -696,10 +697,50 @@ class TestStrictResumeMatch:
         s2 = EvalSession(
             config_path=str(cfg_path), resume=True, result_dir_override=str(result_dir)
         )
+        with pytest.raises(RuntimeError, match=r"Resume aborted"):
+            await s2._persist_effective_config()
+
+    @pytest.mark.anyio
+    async def test_resume_aborts_on_profile_change(self, tmp_path: Path):
+        # profile_* feed per-record timing meta and the saved profiler summary
+        # — toggling mid-run yields inconsistent on-disk profiling artifacts.
+        base = (
+            "models:\n  base:\n    name: m\ntasks:\n  t:\n"
+            "    runner_config:\n      profile_usage: {}\n"
+        )
+        cfg_path = _write_yaml(tmp_path, "cfg.yaml", base.format("true"))
+        result_dir = tmp_path / "out"
+        s1 = EvalSession(config_path=str(cfg_path), result_dir_override=str(result_dir))
+        await s1._persist_effective_config()
+
+        cfg_path.write_text(base.format("false"))
+        s2 = EvalSession(
+            config_path=str(cfg_path), resume=True, result_dir_override=str(result_dir)
+        )
+        with pytest.raises(RuntimeError, match=r"Resume aborted"):
+            await s2._persist_effective_config()
+
+    @pytest.mark.anyio
+    async def test_resume_tolerates_console_progress_change(self, tmp_path: Path):
+        # show_progress is console-only (tqdm bar + loguru cadence) — it never
+        # feeds the progress.json dump, so it may be retuned across a resume.
+        base = (
+            "models:\n  base:\n    name: m\ntasks:\n  t:\n"
+            "    runner_config:\n      show_progress: {}\n"
+        )
+        cfg_path = _write_yaml(tmp_path, "cfg.yaml", base.format("true"))
+        result_dir = tmp_path / "out"
+        s1 = EvalSession(config_path=str(cfg_path), result_dir_override=str(result_dir))
+        await s1._persist_effective_config()
+
+        cfg_path.write_text(base.format("false"))
+        s2 = EvalSession(
+            config_path=str(cfg_path), resume=True, result_dir_override=str(result_dir)
+        )
         await s2._persist_effective_config()  # must NOT raise
 
         loaded = yaml.safe_load((result_dir / "effective_config.yaml").read_text())
-        assert loaded["tasks"]["t"]["runner_config"]["max_retries"] == 10
+        assert loaded["tasks"]["t"]["runner_config"]["show_progress"] is False
 
     @pytest.mark.anyio
     async def test_resume_aborts_on_throughput_plus_result_change(self, tmp_path: Path):

--- a/tests/unit/cli/leaderboard/test_session_persistence.py
+++ b/tests/unit/cli/leaderboard/test_session_persistence.py
@@ -758,6 +758,8 @@ class TestStrictResumeMatch:
             "cfg.yaml",
             "concurrency_limit: 2\nmodels:\n  base:\n    name: m\n",
         )
+        # result_dir is injected into the body by result_dir_override but stripped from
+        # the resume comparison, so it does not count as a diff here.
         s = EvalSession(
             config_path=str(cfg_path), resume=True, result_dir_override=str(result_dir)
         )
@@ -779,6 +781,8 @@ class TestStrictResumeMatch:
             header + "models: {base: {name: m}}\n"
         )
         cfg_path = _write_yaml(tmp_path, "cfg.yaml", "models:\n  base:\n    name: m\n")
+        # result_dir is injected into the body by result_dir_override but stripped from
+        # the resume comparison, so it does not count as a diff here.
         s = EvalSession(
             config_path=str(cfg_path), resume=True, result_dir_override=str(result_dir)
         )

--- a/tests/unit/cli/leaderboard/test_session_persistence.py
+++ b/tests/unit/cli/leaderboard/test_session_persistence.py
@@ -11,7 +11,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 import yaml
 
-from sieval.cli.leaderboard.session import EvalSession
+from sieval.cli.leaderboard.session import (
+    EvalSession,
+    _format_comment_header,
+    _split_header,
+)
 from sieval.infer.topology.models import WellKnownRole
 
 
@@ -621,6 +625,164 @@ class TestStrictResumeMatch:
 
         # File unchanged (including header timestamp from first write)
         assert (result_dir / "infer_plans.yaml").read_text() == original
+
+    @pytest.mark.anyio
+    async def test_resume_tolerates_top_level_concurrency_change(self, tmp_path: Path):
+        cfg_path = _write_yaml(
+            tmp_path,
+            "cfg.yaml",
+            "concurrency_limit: 8\nmodels:\n  base:\n    name: m\n",
+        )
+        result_dir = tmp_path / "out"
+        s1 = EvalSession(config_path=str(cfg_path), result_dir_override=str(result_dir))
+        await s1._persist_effective_config()
+        original = (result_dir / "effective_config.yaml").read_text()
+        original_header = _split_header(original)[0]
+        assert original_header != ""  # sanity: a real header was written
+
+        # User lowers concurrency and resumes.
+        cfg_path.write_text("concurrency_limit: 2\nmodels:\n  base:\n    name: m\n")
+        s2 = EvalSession(
+            config_path=str(cfg_path), resume=True, result_dir_override=str(result_dir)
+        )
+        await s2._persist_effective_config()  # must NOT raise
+
+        after = (result_dir / "effective_config.yaml").read_text()
+        loaded = yaml.safe_load(after)
+        assert loaded["concurrency_limit"] == 2  # body updated to new value
+        assert _split_header(after)[0] == original_header  # header preserved
+
+    @pytest.mark.anyio
+    async def test_resume_tolerates_per_model_args_concurrency_change(
+        self, tmp_path: Path
+    ):
+        cfg_path = _write_yaml(
+            tmp_path,
+            "cfg.yaml",
+            "models:\n  base:\n    name: m\n    args:\n"
+            "      concurrency_limit: 64\n      temperature: 0.0\n",
+        )
+        result_dir = tmp_path / "out"
+        s1 = EvalSession(config_path=str(cfg_path), result_dir_override=str(result_dir))
+        await s1._persist_effective_config()
+
+        cfg_path.write_text(
+            "models:\n  base:\n    name: m\n    args:\n"
+            "      concurrency_limit: 8\n      temperature: 0.0\n"
+        )
+        s2 = EvalSession(
+            config_path=str(cfg_path), resume=True, result_dir_override=str(result_dir)
+        )
+        await s2._persist_effective_config()  # must NOT raise
+
+        loaded = yaml.safe_load((result_dir / "effective_config.yaml").read_text())
+        assert loaded["models"]["base"]["args"]["concurrency_limit"] == 8
+        assert loaded["models"]["base"]["args"]["temperature"] == 0.0
+
+    @pytest.mark.anyio
+    async def test_resume_tolerates_runner_config_max_retries_change(
+        self, tmp_path: Path
+    ):
+        base = (
+            "models:\n  base:\n    name: m\ntasks:\n  t:\n"
+            "    runner_config:\n      max_retries: {}\n"
+        )
+        cfg_path = _write_yaml(tmp_path, "cfg.yaml", base.format(3))
+        result_dir = tmp_path / "out"
+        s1 = EvalSession(config_path=str(cfg_path), result_dir_override=str(result_dir))
+        await s1._persist_effective_config()
+
+        cfg_path.write_text(base.format(10))
+        s2 = EvalSession(
+            config_path=str(cfg_path), resume=True, result_dir_override=str(result_dir)
+        )
+        await s2._persist_effective_config()  # must NOT raise
+
+        loaded = yaml.safe_load((result_dir / "effective_config.yaml").read_text())
+        assert loaded["tasks"]["t"]["runner_config"]["max_retries"] == 10
+
+    @pytest.mark.anyio
+    async def test_resume_aborts_on_throughput_plus_result_change(self, tmp_path: Path):
+        cfg_path = _write_yaml(
+            tmp_path,
+            "cfg.yaml",
+            "concurrency_limit: 8\nmodels:\n  base:\n    name: m\n",
+        )
+        result_dir = tmp_path / "out"
+        s1 = EvalSession(config_path=str(cfg_path), result_dir_override=str(result_dir))
+        await s1._persist_effective_config()
+
+        # Throughput AND a result-affecting field change together.
+        cfg_path.write_text(
+            "concurrency_limit: 2\ndeterministic: true\nmodels:\n  base:\n    name: m\n"
+        )
+        s2 = EvalSession(
+            config_path=str(cfg_path), resume=True, result_dir_override=str(result_dir)
+        )
+        with pytest.raises(RuntimeError, match=r"Resume aborted") as exc:
+            await s2._persist_effective_config()
+        # Diff surfaces the result field, not the throughput noise.
+        assert "deterministic" in str(exc.value)
+        assert "concurrency_limit" not in str(exc.value)
+
+    @pytest.mark.anyio
+    async def test_resume_aborts_on_shard_samples_change(self, tmp_path: Path):
+        base = (
+            "models:\n  base:\n    name: m\ntasks:\n  t:\n"
+            "    runner_config:\n      shard_samples: {}\n"
+        )
+        cfg_path = _write_yaml(tmp_path, "cfg.yaml", base.format(1024))
+        result_dir = tmp_path / "out"
+        s1 = EvalSession(config_path=str(cfg_path), result_dir_override=str(result_dir))
+        await s1._persist_effective_config()
+
+        cfg_path.write_text(base.format(512))
+        s2 = EvalSession(
+            config_path=str(cfg_path), resume=True, result_dir_override=str(result_dir)
+        )
+        with pytest.raises(RuntimeError, match=r"Resume aborted"):
+            await s2._persist_effective_config()
+
+    @pytest.mark.anyio
+    async def test_resume_rewrite_with_missing_header_emits_fresh_header(
+        self, tmp_path: Path
+    ):
+        result_dir = tmp_path / "out"
+        result_dir.mkdir()
+        # Pre-seed a header-less persisted file whose throughput differs.
+        (result_dir / "effective_config.yaml").write_text(
+            "concurrency_limit: 8\nmodels:\n  base:\n    name: m\n"
+        )
+        cfg_path = _write_yaml(
+            tmp_path,
+            "cfg.yaml",
+            "concurrency_limit: 2\nmodels:\n  base:\n    name: m\n",
+        )
+        s = EvalSession(
+            config_path=str(cfg_path), resume=True, result_dir_override=str(result_dir)
+        )
+        await s._persist_effective_config()  # must NOT raise
+
+        after = (result_dir / "effective_config.yaml").read_text()
+        assert after.startswith("# -")  # a fresh header was emitted
+        assert yaml.safe_load(after)["concurrency_limit"] == 2
+
+    @pytest.mark.anyio
+    async def test_resume_tolerates_formatting_only_diff(self, tmp_path: Path):
+        result_dir = tmp_path / "out"
+        result_dir.mkdir()
+        header = _format_comment_header(
+            title="Persisted by", source_config="/x", invocation="sieval run x"
+        )
+        # Flow-style body, semantically identical to the canonical block dump.
+        (result_dir / "effective_config.yaml").write_text(
+            header + "models: {base: {name: m}}\n"
+        )
+        cfg_path = _write_yaml(tmp_path, "cfg.yaml", "models:\n  base:\n    name: m\n")
+        s = EvalSession(
+            config_path=str(cfg_path), resume=True, result_dir_override=str(result_dir)
+        )
+        await s._persist_effective_config()  # must NOT raise (no semantic change)
 
 
 class TestPersistTimingBeforeRunnerArun:


### PR DESCRIPTION
## Type

- feature — new benchmark, task, or capability

## Summary

- Relaxes the `--resume` strict-match guard so a resume no longer aborts when only **pure scheduling / console-progress knobs** differ from the persisted `effective_config.yaml` — concurrency (`concurrency_limit` / `concurrency_limits`), shard read/write concurrency, write-buffer sizing/flush, and console progress (`show_progress`, log intervals).
- **Why:** a run that partially fails because the inference service was over-subscribed (rate-limit / OOM) could previously only be recovered by starting completely fresh (discarding all completed samples) or reverting the concurrency change (re-triggering the same failure). Now you lower `concurrency_limit` / `concurrency_limits` and resume.
- The match scope is **narrowed**, not bypassed: no `--force` flag or env var. A field is resume-mutable iff changing it touches neither sample data nor any persisted artifact. Everything affecting on-disk content stays strict — sampling/seeds, `max_iterations`, `shard_samples`, `record_*`, `max_retries` (the failure signal in FAILED records), `profile_*`, `detect_anomalies*`, `dump_progress` / `progress_dump_interval`, and `deterministic`; `infer_plans.yaml` stays byte-for-byte strict. A classification-completeness test guards that **every** `TaskRunnerConfig` field is bucketed (throughput / strict / non-match), so a future field added without classification fails CI.
- Throughput knobs are recognized **wherever they live** — top-level `concurrency_limit(s)`, the top-level `runner_config` defaults block, per-task `runner_config`, and `models.*.args.concurrency_limit`.
- On a tolerated diff, the `effective_config.yaml` body is rewritten with the new values and the header gains an appended `# Resumed by sieval <ver> at <T>:` record of exactly which fields changed — original provenance is preserved and the lineage accumulates across resumes. A tampered persisted file that no longer parses to a YAML mapping aborts as the same `Resume aborted` RuntimeError rather than an opaque error.

## Test Plan

### Automated

- [x] Lint/format clean (`ruff check && ruff format --check`)
- [x] Type check clean (`ty check`)
- [x] Unit + integration tests pass (`pdm run pytest`) — 353 passing across `tests/unit/cli/leaderboard/` + `tests/integration/resume/`, including the `TestStrictResumeMatch` resume cases and 6 helper test classes (`TestRunnerFieldClassification`, `TestStripNoncomparableFields`, `TestSplitHeader`, `TestDiffDicts`, `TestDiffLines`, `TestAppendResumeNote`).

### Manual

- [x] Covered by automated tests — `TestStrictResumeMatch` exercises resuming with changed top-level / top-level-`runner_config` / per-task / per-model concurrency and console-progress (succeeds, body updated, resume note appended + accumulated across resumes), and aborts on a result-affecting (`deterministic`) or layout-affecting (`shard_samples`, `max_retries`, `profile_*`) change, and on a non-mapping persisted file. No manual run required.

## Checklist

### Required (all PRs)

- [x] PR title follows conventional format (`type(scope): description`)
- [x] No internal paths, credentials, or personal info in committed files
- [x] AI-generated code has `AI-Generated Code - <model> (<provider>)` in module docstring
- [x] No new upper-layer dependencies added to `core/` (changes confined to `cli/`)
- [x] Deleted code verified — `_strip_header`, `_brief_diff`, and `_diff_dicts` are preserved as thin delegating wrappers (over `_split_header` / `_diff_lines`); no call sites broken
