### PR TITLE
ci(sanitize): detect hardcoded absolute paths; scan tracked files only

### DIFF
--- a/scripts/sanitize.sh
+++ b/scripts/sanitize.sh
@@ -17,7 +17,19 @@ PATTERNS=(
   "Private IPv4 (192.168)|\\b192\.168\.\d{1,3}\.\d{1,3}\\b"
   "Hardcoded home path|/home/[a-z][a-z0-9_-]+/"
   "Hardcoded macOS path|/Users/[A-Za-z][A-Za-z0-9_-]+/"
+  "Hardcoded shared-mount path|/(mnt|volume|scratch|nfs)/[A-Za-z0-9._-]+/"
   "Hardcoded credential|(?i)(password|secret|token)\s*=\s*['\"][^'\"]{8,}"
+)
+
+# Config files must NEVER hardcode an absolute filesystem path — use a
+# ${ENV_VAR}, a /path/to/... placeholder, or a HuggingFace repo id instead.
+# Scanned only over config formats (CONFIG_INCLUDES). This is the inverse of an
+# allowlist: flag any absolute path whose first segment is not a safe system
+# root, so it catches every mount root (/mnt, /volume, /data4, ...) without
+# enumerating them — unlike the line above, which is a best-effort blocklist for
+# code/docs where illustrative example paths are legitimate.
+CONFIG_PATTERNS=(
+  'Hardcoded absolute path in config|(?<![\w./:$}])/(?!(?:usr|bin|sbin|etc|tmp|var|proc|sys|dev|opt|run|srv|lib|lib64|root|path)/)[A-Za-z][A-Za-z0-9._-]*/[A-Za-z0-9._-]+'
 )
 
 # Lines matching ANY of these are silently ignored.
@@ -38,20 +50,38 @@ ALLOWLIST=(
 ALLOWLIST_PATTERN="$(IFS='|'; echo "${ALLOWLIST[*]}")"
 FAIL=0
 
+# Pathspecs for git grep. We scan only tracked files, so local artifacts
+# (.venv/, .mypy_cache/, outputs/, __pycache__/) are never matched — only what
+# would actually ship. New cache dirs need no allowlist upkeep.
+ALL_PATHS=(
+  '*.py' '*.yaml' '*.yml' '*.toml' '*.json' '*.md' '*.sh' '*.cfg' '*.ini'
+)
+# Config formats only.
+CONFIG_PATHS=(
+  '*.yaml' '*.yml' '*.toml' '*.json' '*.cfg' '*.ini'
+)
+
+# scan DESCRIPTION REGEX PATHSPEC... — report any non-allowlisted hits, set FAIL.
+scan() {
+  local description="$1" pattern="$2"
+  shift 2
+  local hits
+  hits=$(git grep -nIP -e "$pattern" -- "$@" 2>/dev/null | grep -Ev "$ALLOWLIST_PATTERN" || true)
+  [[ -z "$hits" ]] && return 0
+  local lines
+  mapfile -t -n 20 lines <<<"$hits"
+  echo "❌ $description ($pattern):"
+  printf '%s\n' "${lines[@]}"
+  echo ""
+  FAIL=1
+}
+
 for entry in "${PATTERNS[@]}"; do
-  description="${entry%%|*}"
-  pattern="${entry#*|}"
-  hits=$(grep -rnPI "$pattern" \
-    --include='*.py' --include='*.yaml' --include='*.yml' \
-    --include='*.toml' --include='*.json' --include='*.md' \
-    --include='*.sh' --include='*.cfg' --include='*.ini' \
-    . 2>/dev/null | grep -Ev "$ALLOWLIST_PATTERN" || true)
-  if [[ -n "$hits" ]]; then
-    echo "❌ $description ($pattern):"
-    echo "$hits" | head -20
-    echo ""
-    FAIL=1
-  fi
+  scan "${entry%%|*}" "${entry#*|}" "${ALL_PATHS[@]}"
+done
+
+for entry in "${CONFIG_PATTERNS[@]}"; do
+  scan "${entry%%|*}" "${entry#*|}" "${CONFIG_PATHS[@]}"
 done
 
 if [[ "$FAIL" -eq 1 ]]; then


### PR DESCRIPTION
## Type

- chore — CI, tooling, dependencies, config

## Summary

- Add two path-leak guards to `scripts/sanitize.sh` so machine-specific filesystem paths can't slip into the public repo:
  - **Config files** (`*.yaml/yml/toml/json/cfg/ini`): an inverted-allowlist rule — flag any absolute path whose first segment is not a safe system root (`/usr`, `/tmp`, `/path/to`, …). Catches every mount root (`/mnt`, `/volume`, `/data4`, …) without enumerating them. Configs must use `${ENV}`, `/path/to` placeholders, or HF repo ids.
  - **Code/docs**: extend the existing `/home/` and `/Users/` rules with common shared mounts (`/mnt`, `/volume`, `/scratch`, `/nfs`).
- Switch the scanner from `grep -r .` to `git grep`, so only tracked files are scanned. Local artifacts (`.venv/`, `.mypy_cache/`, `outputs/`) are no longer matched — this removes a class of false positives and the need to allowlist cache dirs.

## Test Plan

### Automated

- [x] N/A for ruff/ty/pytest — shell-only change. The `sanitize` CI job runs the updated script; the rest of the matrix runs because `scripts/**` is in the `code` paths filter.

### Manual

- [x] Clean tree → `./scripts/sanitize.sh` passes (exit 0)
- [x] Injected a tracked config with `/mnt/...` and a tracked `.py` comment with `/volume/...` → script fails (exit 1) and names both new rules
- [x] Confirmed URLs, `${VAR}/a/b`, HF ids, and `/path/to` placeholders are NOT flagged
- [x] Confirmed `git grep` does not scan `.venv/` / `.mypy_cache/` / `outputs/`

## Checklist

### Required (all PRs)

- [x] PR title follows conventional format (`type(scope): description`)
- [x] No internal paths, credentials, or personal info in committed files
- [x] AI-generated code has `AI-Generated Code - <model> (<provider>)` in module docstring
- [x] No new upper-layer dependencies added to `core/`
- [x] Deleted code verified — no remaining call sites depend on it
