### PR TITLE
feat(datasets): add stratified_sample op, rename select→slice

### DIFF
--- a/examples/hardware/a100_qwen2.5_1.5b.yaml
+++ b/examples/hardware/a100_qwen2.5_1.5b.yaml
@@ -33,19 +33,19 @@ datasets:
     class: MMLUDataset
     path: "${SIEVAL_DATA_DIR}/mmlu"
     operations:
-      - select: { num: 100 }
+      - slice: { num: 100 }
 
   aime_2024:
     class: AIME2024Dataset
     path: "HuggingFaceH4/aime_2024"
     operations:
-      - select: { num: 5 }
+      - slice: { num: 5 }
 
   aime_2025:
     class: AIME2025Dataset
     path: "opencompass/AIME2025"
     operations:
-      - select: { num: 5 }
+      - slice: { num: 5 }
 
 tasks:
   mmlu_0shot_gen:

--- a/examples/quickstart.yaml
+++ b/examples/quickstart.yaml
@@ -32,7 +32,7 @@ datasets:
     class: AIME2024Dataset
     path: "HuggingFaceH4/aime_2024"   # `sieval dataset download aime_2024` stages this
     operations:
-      - select: { num: 5 }
+      - slice: { num: 5 }
 
 tasks:
   aime_2024_smoke:

--- a/leaderboards/sft_fast_202511.yaml
+++ b/leaderboards/sft_fast_202511.yaml
@@ -106,7 +106,7 @@ datasets:
     #   path: "${SIEVAL_DATA_DIR}/mmlu"
     #   operations:
     #     - shuffle: { seed: 42 }
-    #     - select: { num: 100 }
+    #     - slice: { num: 100 }
 
 # =============================================================================
 # Tasks

--- a/sieval/cli/leaderboard/session.py
+++ b/sieval/cli/leaderboard/session.py
@@ -1233,12 +1233,6 @@ class EvalSession:
                         f"to 'slice'; update your config."
                     )
 
-                case "stratified_select":
-                    raise ValueError(
-                        f"Dataset '{dataset_name}': operation 'stratified_select' "
-                        f"was renamed to 'stratified_sample'; update your config."
-                    )
-
                 case "slice":
                     num = op_args.get("num", op_args.get("n"))
                     split = op_args.get("split", "test")

--- a/sieval/cli/leaderboard/session.py
+++ b/sieval/cli/leaderboard/session.py
@@ -1266,30 +1266,44 @@ class EvalSession:
                     logger.debug("Dataset '{}': repeated {} times", dataset_name, times)
 
                 case "stratified_sample":
-                    num = op_args.get("num", op_args.get("n"))
                     by = op_args.get("by")
-                    if num is None or by is None:
+                    num = op_args.get("num", op_args.get("n"))
+                    per_group = op_args.get("per_group")
+                    min_per_group = op_args.get("min_per_group")
+                    if by is None:
                         raise ValueError(
                             f"Dataset '{dataset_name}': 'stratified_sample' "
-                            f"requires 'num' and 'by'"
+                            f"requires 'by'"
                         )
-                    min_per_group = op_args.get("min_per_group", 1)
+                    if (num is None) == (per_group is None):
+                        raise ValueError(
+                            f"Dataset '{dataset_name}': 'stratified_sample' "
+                            f"requires exactly one of 'num' or 'per_group'"
+                        )
+                    if per_group is not None and min_per_group is not None:
+                        raise ValueError(
+                            f"Dataset '{dataset_name}': 'stratified_sample' "
+                            f"'min_per_group' cannot be combined with 'per_group'"
+                        )
                     seed = op_args.get("seed", 0)
                     split = op_args.get("split", "test")
                     dataset = dataset.stratified_sample(
-                        num,
-                        by=by,
+                        by,
+                        num=num,
+                        per_group=per_group,
                         min_per_group=min_per_group,
                         seed=seed,
                         split=split,
                     )
                     logger.debug(
-                        "Dataset '{}': stratified-sampled {} by '{}' "
-                        "(min_per_group={}, seed={})",
+                        "Dataset '{}': stratified-sampled by '{}' ({}, seed={})",
                         dataset_name,
-                        num,
                         by,
-                        min_per_group,
+                        (
+                            f"per_group={per_group}"
+                            if per_group is not None
+                            else f"num={num}, min_per_group={min_per_group}"
+                        ),
                         seed,
                     )
 

--- a/sieval/cli/leaderboard/session.py
+++ b/sieval/cli/leaderboard/session.py
@@ -704,7 +704,7 @@ class EvalSession:
         path: "./data/aime_2024"
         operations:
           - shuffle: {seed: 42}
-          - select: {num: 100}
+          - slice: {num: 100}
 
     tasks:
       aime_2024_eval:
@@ -1228,14 +1228,28 @@ class EvalSession:
 
             match op_name:
                 case "select":
+                    raise ValueError(
+                        f"Dataset '{dataset_name}': operation 'select' was renamed "
+                        f"to 'slice'; update your config."
+                    )
+
+                case "stratified_select":
+                    raise ValueError(
+                        f"Dataset '{dataset_name}': operation 'stratified_select' "
+                        f"was renamed to 'stratified_sample'; update your config."
+                    )
+
+                case "slice":
                     num = op_args.get("num", op_args.get("n"))
                     split = op_args.get("split", "test")
                     if num is None:
                         raise ValueError(
-                            f"Dataset '{dataset_name}': 'select' requires 'num'"
+                            f"Dataset '{dataset_name}': 'slice' requires 'num'"
                         )
-                    dataset = dataset.select(num, split=split)
-                    logger.debug("Dataset '{}': selected {} samples", dataset_name, num)
+                    dataset = dataset.slice(num, split=split)
+                    logger.debug(
+                        "Dataset '{}': sliced to first {} samples", dataset_name, num
+                    )
 
                 case "shuffle":
                     seed = op_args.get("seed", 0)
@@ -1257,18 +1271,18 @@ class EvalSession:
                     dataset = dataset.repeat(times, split=split)
                     logger.debug("Dataset '{}': repeated {} times", dataset_name, times)
 
-                case "stratified_select":
+                case "stratified_sample":
                     num = op_args.get("num", op_args.get("n"))
                     by = op_args.get("by")
                     if num is None or by is None:
                         raise ValueError(
-                            f"Dataset '{dataset_name}': 'stratified_select' "
+                            f"Dataset '{dataset_name}': 'stratified_sample' "
                             f"requires 'num' and 'by'"
                         )
                     min_per_group = op_args.get("min_per_group", 1)
                     seed = op_args.get("seed", 0)
                     split = op_args.get("split", "test")
-                    dataset = dataset.stratified_select(
+                    dataset = dataset.stratified_sample(
                         num,
                         by=by,
                         min_per_group=min_per_group,
@@ -1276,7 +1290,7 @@ class EvalSession:
                         split=split,
                     )
                     logger.debug(
-                        "Dataset '{}': stratified-selected {} by '{}' "
+                        "Dataset '{}': stratified-sampled {} by '{}' "
                         "(min_per_group={}, seed={})",
                         dataset_name,
                         num,
@@ -1288,8 +1302,8 @@ class EvalSession:
                 case _:
                     raise ValueError(
                         f"Dataset '{dataset_name}': Unknown operation '{op_name}'. "
-                        f"Valid operations: select, shuffle, repeat, "
-                        f"stratified_select"
+                        f"Valid operations: slice, shuffle, repeat, "
+                        f"stratified_sample"
                     )
 
         return dataset

--- a/sieval/cli/leaderboard/session.py
+++ b/sieval/cli/leaderboard/session.py
@@ -1257,10 +1257,39 @@ class EvalSession:
                     dataset = dataset.repeat(times, split=split)
                     logger.debug("Dataset '{}': repeated {} times", dataset_name, times)
 
+                case "stratified_select":
+                    num = op_args.get("num", op_args.get("n"))
+                    by = op_args.get("by")
+                    if num is None or by is None:
+                        raise ValueError(
+                            f"Dataset '{dataset_name}': 'stratified_select' "
+                            f"requires 'num' and 'by'"
+                        )
+                    min_per_group = op_args.get("min_per_group", 1)
+                    seed = op_args.get("seed", 0)
+                    split = op_args.get("split", "test")
+                    dataset = dataset.stratified_select(
+                        num,
+                        by=by,
+                        min_per_group=min_per_group,
+                        seed=seed,
+                        split=split,
+                    )
+                    logger.debug(
+                        "Dataset '{}': stratified-selected {} by '{}' "
+                        "(min_per_group={}, seed={})",
+                        dataset_name,
+                        num,
+                        by,
+                        min_per_group,
+                        seed,
+                    )
+
                 case _:
                     raise ValueError(
                         f"Dataset '{dataset_name}': Unknown operation '{op_name}'. "
-                        f"Valid operations: select, shuffle, repeat"
+                        f"Valid operations: select, shuffle, repeat, "
+                        f"stratified_select"
                     )
 
         return dataset

--- a/sieval/cli/validation.py
+++ b/sieval/cli/validation.py
@@ -32,7 +32,14 @@ _ROOT_KEYS: set[str] = set(RootConfigDict.__annotations__)
 _CONCURRENCY_KEYS: set[str] = {a.value for a in TaskAction}
 
 # Valid dataset operations
-_VALID_OPERATIONS: set[str] = {"select", "shuffle", "repeat", "stratified_select"}
+_VALID_OPERATIONS: set[str] = {"slice", "shuffle", "repeat", "stratified_sample"}
+
+# Operations renamed away from earlier names; map old -> new so stale configs
+# get a migration hint instead of a bare "unknown operation".
+_RENAMED_OPERATIONS: dict[str, str] = {
+    "select": "slice",
+    "stratified_select": "stratified_sample",
+}
 
 # Valid TaskRunnerConfig field names
 _RUNNER_CONFIG_FIELDS: set[str] = set(TaskRunnerConfig.__dataclass_fields__)
@@ -234,7 +241,12 @@ def _validate_operations(
             )
             continue
         op_name = next(iter(op))
-        if op_name not in _VALID_OPERATIONS:
+        if op_name in _RENAMED_OPERATIONS:
+            result.errors.append(
+                f"Dataset '{dataset_name}': operation '{op_name}' was renamed to "
+                f"'{_RENAMED_OPERATIONS[op_name]}'; update your config."
+            )
+        elif op_name not in _VALID_OPERATIONS:
             result.errors.append(
                 f"Dataset '{dataset_name}': unknown operation '{op_name}'. "
                 f"Valid: {', '.join(sorted(_VALID_OPERATIONS))}"

--- a/sieval/cli/validation.py
+++ b/sieval/cli/validation.py
@@ -38,7 +38,6 @@ _VALID_OPERATIONS: set[str] = {"slice", "shuffle", "repeat", "stratified_sample"
 # get a migration hint instead of a bare "unknown operation".
 _RENAMED_OPERATIONS: dict[str, str] = {
     "select": "slice",
-    "stratified_select": "stratified_sample",
 }
 
 # Valid TaskRunnerConfig field names

--- a/sieval/cli/validation.py
+++ b/sieval/cli/validation.py
@@ -32,7 +32,7 @@ _ROOT_KEYS: set[str] = set(RootConfigDict.__annotations__)
 _CONCURRENCY_KEYS: set[str] = {a.value for a in TaskAction}
 
 # Valid dataset operations
-_VALID_OPERATIONS: set[str] = {"select", "shuffle", "repeat"}
+_VALID_OPERATIONS: set[str] = {"select", "shuffle", "repeat", "stratified_select"}
 
 # Valid TaskRunnerConfig field names
 _RUNNER_CONFIG_FIELDS: set[str] = set(TaskRunnerConfig.__dataclass_fields__)

--- a/sieval/core/datasets/dataset.py
+++ b/sieval/core/datasets/dataset.py
@@ -1,6 +1,7 @@
 """Abstract Dataset base class backed by HuggingFace DatasetDict."""
 
 import copy
+import random
 from abc import ABC, abstractmethod
 from collections.abc import Iterator
 from typing import Literal, Self, overload
@@ -90,6 +91,71 @@ class Dataset[TSample](ABC):
             return self
         new_dict = HFDatasetDict(self.dataset_dict)
         new_dict[split] = new_dict[split].shuffle(seed=seed)
+        return self._clone_with_new_dict(new_dict)
+
+    def stratified_select(
+        self,
+        num: int,
+        by: str,
+        min_per_group: int = 1,
+        seed: int = 0,
+        split: str = "test",
+    ) -> Self:
+        """Return a clone keeping a proportional, group-balanced subsample.
+
+        Rows in *split* are grouped by column *by*. Each group is guaranteed at
+        least ``min(min_per_group, group_size)`` rows; the remaining budget
+        toward *num* is distributed proportionally to group size (capped by
+        availability). If the per-group floors already sum above *num*, the
+        total is raised to honour them. Within each group, rows are chosen by a
+        deterministic *seed*-driven shuffle, so the selection reproduces across
+        runs and processes.
+
+        Returns ``self`` unchanged if *split* is absent.
+        """
+        if split not in self._dataset_dict:
+            return self
+        hf = self._dataset_dict[split]
+        if by not in hf.column_names:
+            raise ValueError(
+                f"stratified_select: column {by!r} not found; "
+                f"available columns: {hf.column_names}"
+            )
+
+        # Group row indices by value (first-seen order preserved per group).
+        groups: dict[object, list[int]] = {}
+        for index, value in enumerate(hf[by]):
+            groups.setdefault(value, []).append(index)
+
+        total = len(hf)
+        keys = sorted(groups, key=str)
+        sizes = {key: len(groups[key]) for key in keys}
+
+        # Floor allocation (capped by group size), then proportional fill toward
+        # the target. Floors take priority: the target rises to meet them.
+        alloc = {key: min(min_per_group, sizes[key]) for key in keys}
+        target = min(max(num, sum(alloc.values())), total)
+        while sum(alloc.values()) < target:
+            candidates = [key for key in keys if alloc[key] < sizes[key]]
+            if not candidates:
+                break
+            # Group furthest below its proportional quota; ties → smallest key.
+            chosen = max(
+                candidates,
+                key=lambda key: sizes[key] * target / total - alloc[key],
+            )
+            alloc[chosen] += 1
+
+        # Deterministic within-group selection.
+        selected: list[int] = []
+        for key in keys:
+            indices = list(groups[key])
+            random.Random(f"{seed}:{key}").shuffle(indices)
+            selected.extend(indices[: alloc[key]])
+        selected.sort()
+
+        new_dict = HFDatasetDict(self._dataset_dict)
+        new_dict[split] = hf.select(selected)
         return self._clone_with_new_dict(new_dict)
 
     def _clone_with_new_dict(self, new_dict: HFDatasetDict) -> Self:

--- a/sieval/core/datasets/dataset.py
+++ b/sieval/core/datasets/dataset.py
@@ -101,67 +101,116 @@ class Dataset[TSample](ABC):
 
     def stratified_sample(
         self,
-        num: int,
-        by: str,
-        min_per_group: int = 1,
+        by: str | list[str],
+        *,
+        num: int | None = None,
+        per_group: int | None = None,
+        min_per_group: int | None = None,
         seed: int = 0,
         split: str = "test",
     ) -> Self:
-        """Return a clone keeping a proportional, group-balanced subsample.
+        """Return a clone keeping a group-balanced subsample of *split*.
 
-        Rows in *split* are grouped by column *by*. Each group is guaranteed at
-        least ``min(min_per_group, group_size)`` rows; the remaining budget
-        toward *num* is distributed proportionally to group size (capped by
-        availability). If the per-group floors already sum above *num*, the
-        total is raised to honour them and a warning is logged. Within each
-        group, rows are chosen by a deterministic *seed*-driven shuffle, so the
-        selection reproduces across runs and processes.
+        Rows are grouped into strata by the column(s) named in *by* (a single
+        name, or a list whose values form a composite key). Exactly one budget
+        must be given:
+
+        * ``num`` — **proportional** allocation. Each stratum gets a floor of
+          ``min(min_per_group, stratum_size)`` (``min_per_group`` defaults to 1);
+          the remaining budget toward *num* is distributed proportionally to
+          stratum size (capped by availability). If the floors already sum above
+          *num*, the total rises to honour them and a warning is logged.
+        * ``per_group`` — **equal** allocation. Each stratum keeps exactly
+          ``min(per_group, stratum_size)`` rows; strata smaller than *per_group*
+          keep all their rows and a single summary warning is logged.
+
+        ``min_per_group`` applies only to the proportional (``num``) path and may
+        not be combined with ``per_group``. Within each stratum rows are chosen by
+        a deterministic *seed*-driven shuffle, so the selection reproduces across
+        runs and processes.
 
         Returns ``self`` unchanged if *split* is absent or empty.
         """
+        if (num is None) == (per_group is None):
+            raise ValueError(
+                "stratified_sample: provide exactly one of 'num' or 'per_group'"
+            )
+        if per_group is not None and min_per_group is not None:
+            raise ValueError(
+                "stratified_sample: 'min_per_group' applies only to proportional "
+                "('num') sampling and cannot be combined with 'per_group'"
+            )
+
         if split not in self._dataset_dict:
             return self
         hf = self._dataset_dict[split]
         if len(hf) == 0:
             return self
-        if by not in hf.column_names:
+
+        cols = [by] if isinstance(by, str) else list(by)
+        if not cols:
+            raise ValueError("stratified_sample: 'by' must name at least one column")
+        missing = [c for c in cols if c not in hf.column_names]
+        if missing:
             raise ValueError(
-                f"stratified_sample: column {by!r} not found; "
+                f"stratified_sample: column(s) {missing!r} not found; "
                 f"available columns: {hf.column_names}"
             )
 
-        # Group row indices by value (first-seen order preserved per group).
+        # Group row indices by composite key. A single column keeps a scalar key
+        # (not a 1-tuple) so the within-stratum seed string stays byte-identical
+        # with the pre-multikey behaviour.
+        column_data = [hf[c] for c in cols]
+        single = len(cols) == 1
         groups: dict[object, list[int]] = {}
-        for index, value in enumerate(hf[by]):
-            groups.setdefault(value, []).append(index)
+        for index in range(len(hf)):
+            values = tuple(col[index] for col in column_data)
+            key = values[0] if single else values
+            groups.setdefault(key, []).append(index)
 
-        total = len(hf)
         keys = sorted(groups, key=str)
         sizes = {key: len(groups[key]) for key in keys}
 
-        # Floor allocation (capped by group size), then proportional fill toward
-        # the target. Floors take priority: the target rises to meet them.
-        alloc = {key: min(min_per_group, sizes[key]) for key in keys}
-        target = min(max(num, sum(alloc.values())), total)
-        if target > num:
-            logger.warning(
-                "stratified_sample: min_per_group={} across {} groups requires "
-                "{} rows, exceeding the requested num={}",
-                min_per_group,
-                len(keys),
-                target,
-                num,
-            )
-        while sum(alloc.values()) < target:
-            candidates = [key for key in keys if alloc[key] < sizes[key]]
-            if not candidates:
-                break
-            # Group furthest below its proportional quota; ties → smallest key.
-            chosen = max(
-                candidates,
-                key=lambda key: sizes[key] * target / total - alloc[key],
-            )
-            alloc[chosen] += 1
+        if per_group is not None:
+            # Equal allocation: K per stratum, capped at availability.
+            alloc = {key: min(per_group, sizes[key]) for key in keys}
+            short = [key for key in keys if sizes[key] < per_group]
+            if short:
+                logger.warning(
+                    "stratified_sample: per_group={} unmet for {} of {} strata "
+                    "(short {} rows total); kept all available in those",
+                    per_group,
+                    len(short),
+                    len(keys),
+                    sum(per_group - sizes[key] for key in short),
+                )
+        else:
+            # Proportional allocation toward num, honouring the floor.
+            # num is non-None here (the per_group is None branch guarantees it).
+            assert num is not None
+            floor = 1 if min_per_group is None else min_per_group
+            total = len(hf)
+            alloc = {key: min(floor, sizes[key]) for key in keys}
+            target = min(max(num, sum(alloc.values())), total)
+            if target > num:
+                logger.warning(
+                    "stratified_sample: min_per_group={} across {} groups requires "
+                    "{} rows, exceeding the requested num={}",
+                    floor,
+                    len(keys),
+                    target,
+                    num,
+                )
+            while sum(alloc.values()) < target:
+                candidates = [key for key in keys if alloc[key] < sizes[key]]
+                if not candidates:
+                    break
+                # Group furthest below its proportional quota; ties → smallest key.
+                chosen = max(
+                    candidates,
+                    key=lambda key: sizes[key] * target / total - alloc[key],
+                )
+                alloc[chosen] += 1
 
         # Deterministic within-group selection.
         selected: list[int] = []

--- a/sieval/core/datasets/dataset.py
+++ b/sieval/core/datasets/dataset.py
@@ -18,7 +18,8 @@ TRetrieveStrategy = Literal["random", "fixed"]
 class Dataset[TSample](ABC):
     """Abstract evaluation dataset backed by a HuggingFace DatasetDict.
 
-    Transformations (repeat/select/shuffle) return immutable shallow copies.
+    Transformations (repeat/slice/shuffle/stratified_sample) return immutable
+    shallow copies.
     """
 
     def __init__(
@@ -74,17 +75,17 @@ class Dataset[TSample](ABC):
         new_dict[split] = new_dict[split].repeat(times)
         return self._clone_with_new_dict(new_dict)
 
-    def select(self, num: int, split: str = "test") -> Self:
+    def slice(self, num: int, split: str = "test") -> Self:
         """Return a shallow clone with only the first *num* samples of *split*.
 
-        Keeps all samples if *num* exceeds split length. Returns ``self``
-        unchanged if *split* is absent.
+        Positional, deterministic prefix. Keeps all samples if *num* exceeds
+        split length. Returns ``self`` unchanged if *split* is absent.
         """
         if split not in self._dataset_dict:
             return self
         new_dict = HFDatasetDict(self.dataset_dict)
-        num_to_select = min(num, len(new_dict[split]))
-        new_dict[split] = new_dict[split].select(range(num_to_select))
+        num_to_keep = min(num, len(new_dict[split]))
+        new_dict[split] = new_dict[split].select(range(num_to_keep))
         return self._clone_with_new_dict(new_dict)
 
     def shuffle(self, seed: int = 0, split: str = "test") -> Self:
@@ -98,7 +99,7 @@ class Dataset[TSample](ABC):
         new_dict[split] = new_dict[split].shuffle(seed=seed)
         return self._clone_with_new_dict(new_dict)
 
-    def stratified_select(
+    def stratified_sample(
         self,
         num: int,
         by: str,
@@ -125,7 +126,7 @@ class Dataset[TSample](ABC):
             return self
         if by not in hf.column_names:
             raise ValueError(
-                f"stratified_select: column {by!r} not found; "
+                f"stratified_sample: column {by!r} not found; "
                 f"available columns: {hf.column_names}"
             )
 
@@ -144,7 +145,7 @@ class Dataset[TSample](ABC):
         target = min(max(num, sum(alloc.values())), total)
         if target > num:
             logger.warning(
-                "stratified_select: min_per_group={} across {} groups requires "
+                "stratified_sample: min_per_group={} across {} groups requires "
                 "{} rows, exceeding the requested num={}",
                 min_per_group,
                 len(keys),

--- a/sieval/core/datasets/dataset.py
+++ b/sieval/core/datasets/dataset.py
@@ -8,6 +8,7 @@ from typing import Literal, Self, overload
 
 from datasets import Dataset as HFDataset
 from datasets import DatasetDict as HFDatasetDict
+from loguru import logger
 
 from sieval.core.utils.hf import maybe_resolve_hf_path
 
@@ -65,9 +66,9 @@ class Dataset[TSample](ABC):
     def repeat(self, times: int, split: str = "test") -> Self:
         """Return a shallow clone with *split* repeated *times* times.
 
-        Returns ``self`` unchanged if the test set is absent.
+        Returns ``self`` unchanged if *split* is absent.
         """
-        if self.test_set is None:
+        if split not in self._dataset_dict:
             return self
         new_dict = HFDatasetDict(self.dataset_dict)
         new_dict[split] = new_dict[split].repeat(times)
@@ -76,9 +77,10 @@ class Dataset[TSample](ABC):
     def select(self, num: int, split: str = "test") -> Self:
         """Return a shallow clone with only the first *num* samples of *split*.
 
-        Keeps all samples if *num* exceeds split length.
+        Keeps all samples if *num* exceeds split length. Returns ``self``
+        unchanged if *split* is absent.
         """
-        if self.test_set is None:
+        if split not in self._dataset_dict:
             return self
         new_dict = HFDatasetDict(self.dataset_dict)
         num_to_select = min(num, len(new_dict[split]))
@@ -86,8 +88,11 @@ class Dataset[TSample](ABC):
         return self._clone_with_new_dict(new_dict)
 
     def shuffle(self, seed: int = 0, split: str = "test") -> Self:
-        """Return a shallow clone with *split* shuffled (deterministic via *seed*)."""
-        if self.test_set is None:
+        """Return a shallow clone with *split* shuffled (deterministic via *seed*).
+
+        Returns ``self`` unchanged if *split* is absent.
+        """
+        if split not in self._dataset_dict:
             return self
         new_dict = HFDatasetDict(self.dataset_dict)
         new_dict[split] = new_dict[split].shuffle(seed=seed)
@@ -107,15 +112,17 @@ class Dataset[TSample](ABC):
         least ``min(min_per_group, group_size)`` rows; the remaining budget
         toward *num* is distributed proportionally to group size (capped by
         availability). If the per-group floors already sum above *num*, the
-        total is raised to honour them. Within each group, rows are chosen by a
-        deterministic *seed*-driven shuffle, so the selection reproduces across
-        runs and processes.
+        total is raised to honour them and a warning is logged. Within each
+        group, rows are chosen by a deterministic *seed*-driven shuffle, so the
+        selection reproduces across runs and processes.
 
-        Returns ``self`` unchanged if *split* is absent.
+        Returns ``self`` unchanged if *split* is absent or empty.
         """
         if split not in self._dataset_dict:
             return self
         hf = self._dataset_dict[split]
+        if len(hf) == 0:
+            return self
         if by not in hf.column_names:
             raise ValueError(
                 f"stratified_select: column {by!r} not found; "
@@ -135,6 +142,15 @@ class Dataset[TSample](ABC):
         # the target. Floors take priority: the target rises to meet them.
         alloc = {key: min(min_per_group, sizes[key]) for key in keys}
         target = min(max(num, sum(alloc.values())), total)
+        if target > num:
+            logger.warning(
+                "stratified_select: min_per_group={} across {} groups requires "
+                "{} rows, exceeding the requested num={}",
+                min_per_group,
+                len(keys),
+                target,
+                num,
+            )
         while sum(alloc.values()) < target:
             candidates = [key for key in keys if alloc[key] < sizes[key]]
             if not candidates:

--- a/tests/unit/cli/leaderboard/test_session.py
+++ b/tests/unit/cli/leaderboard/test_session.py
@@ -315,6 +315,51 @@ class TestDatasetOperations:
         runner._apply_dataset_operations(ds_none_args, [{"shuffle": None}], "test_ds")
         ds_none_args.shuffle.assert_called_once_with(seed=0, split="test")
 
+    def test_stratified_select_dispatch(self):
+        runner = self._make_runner()
+        ds = MagicMock()
+        ds.stratified_select.return_value = ds
+        runner._apply_dataset_operations(
+            ds,
+            [
+                {
+                    "stratified_select": {
+                        "by": "Subject",
+                        "num": 800,
+                        "min_per_group": 5,
+                        "seed": 42,
+                    }
+                }
+            ],
+            "test_ds",
+        )
+        ds.stratified_select.assert_called_once_with(
+            800, by="Subject", min_per_group=5, seed=42, split="test"
+        )
+
+    def test_stratified_select_defaults(self):
+        runner = self._make_runner()
+        ds = MagicMock()
+        ds.stratified_select.return_value = ds
+        runner._apply_dataset_operations(
+            ds, [{"stratified_select": {"by": "category", "num": 600}}], "test_ds"
+        )
+        ds.stratified_select.assert_called_once_with(
+            600, by="category", min_per_group=1, seed=0, split="test"
+        )
+
+    @pytest.mark.parametrize(
+        "op_args",
+        [{"num": 5}, {"by": "Subject"}, {}],
+    )
+    def test_stratified_select_requires_num_and_by(self, op_args):
+        runner = self._make_runner()
+        ds = MagicMock()
+        with pytest.raises(ValueError, match="requires 'num' and 'by'"):
+            runner._apply_dataset_operations(
+                ds, [{"stratified_select": op_args}], "test_ds"
+            )
+
 
 # ===================================================================
 # Model type inference

--- a/tests/unit/cli/leaderboard/test_session.py
+++ b/tests/unit/cli/leaderboard/test_session.py
@@ -350,7 +350,7 @@ class TestDatasetOperations:
             "test_ds",
         )
         ds.stratified_sample.assert_called_once_with(
-            800, by="Subject", min_per_group=5, seed=42, split="test"
+            "Subject", num=800, per_group=None, min_per_group=5, seed=42, split="test"
         )
 
     def test_stratified_sample_defaults(self):
@@ -361,20 +361,79 @@ class TestDatasetOperations:
             ds, [{"stratified_sample": {"by": "category", "num": 600}}], "test_ds"
         )
         ds.stratified_sample.assert_called_once_with(
-            600, by="category", min_per_group=1, seed=0, split="test"
+            "category",
+            num=600,
+            per_group=None,
+            min_per_group=None,
+            seed=0,
+            split="test",
         )
 
-    @pytest.mark.parametrize(
-        "op_args",
-        [{"num": 5}, {"by": "Subject"}, {}],
-    )
-    def test_stratified_sample_requires_num_and_by(self, op_args):
+    def test_stratified_sample_requires_by(self):
         runner = self._make_runner()
         ds = MagicMock()
-        with pytest.raises(ValueError, match="requires 'num' and 'by'"):
+        with pytest.raises(ValueError, match="requires 'by'"):
             runner._apply_dataset_operations(
-                ds, [{"stratified_sample": op_args}], "test_ds"
+                ds, [{"stratified_sample": {"num": 5}}], "test_ds"
             )
+
+    def test_stratified_sample_requires_exactly_one_budget(self):
+        runner = self._make_runner()
+        ds = MagicMock()
+        with pytest.raises(ValueError, match="exactly one of 'num' or 'per_group'"):
+            runner._apply_dataset_operations(
+                ds, [{"stratified_sample": {"by": "Subject"}}], "test_ds"
+            )
+        with pytest.raises(ValueError, match="exactly one of 'num' or 'per_group'"):
+            runner._apply_dataset_operations(
+                ds,
+                [{"stratified_sample": {"by": "Subject", "num": 5, "per_group": 2}}],
+                "test_ds",
+            )
+
+    def test_stratified_sample_min_per_group_excludes_per_group(self):
+        runner = self._make_runner()
+        ds = MagicMock()
+        with pytest.raises(ValueError, match="cannot be combined with 'per_group'"):
+            runner._apply_dataset_operations(
+                ds,
+                [
+                    {
+                        "stratified_sample": {
+                            "by": "Subject",
+                            "per_group": 5,
+                            "min_per_group": 1,
+                        }
+                    }
+                ],
+                "test_ds",
+            )
+
+    def test_stratified_sample_per_group_dispatch(self):
+        runner = self._make_runner()
+        ds = MagicMock()
+        ds.stratified_sample.return_value = ds
+        runner._apply_dataset_operations(
+            ds,
+            [
+                {
+                    "stratified_sample": {
+                        "by": ["locale", "subject"],
+                        "per_group": 20,
+                        "seed": 42,
+                    }
+                }
+            ],
+            "test_ds",
+        )
+        ds.stratified_sample.assert_called_once_with(
+            ["locale", "subject"],
+            num=None,
+            per_group=20,
+            min_per_group=None,
+            seed=42,
+            split="test",
+        )
 
 
 # ===================================================================

--- a/tests/unit/cli/leaderboard/test_session.py
+++ b/tests/unit/cli/leaderboard/test_session.py
@@ -219,9 +219,9 @@ class TestDatasetOperations:
         "op,op_args,method_name,method_args,method_kwargs",
         [
             (
-                "select",
+                "slice",
                 {"num": 10},
-                "select",
+                "slice",
                 (10,),
                 {"split": "test"},
             ),
@@ -266,11 +266,21 @@ class TestDatasetOperations:
         with pytest.raises(ValueError, match=error_match):
             runner._apply_dataset_operations(ds, operations, "test_ds")
 
+    @pytest.mark.parametrize(
+        "op,new_name",
+        [("select", "slice"), ("stratified_select", "stratified_sample")],
+    )
+    def test_renamed_operation_raises_migration_hint(self, op, new_name):
+        runner = self._make_runner()
+        ds = MagicMock()
+        with pytest.raises(ValueError, match=f"'{op}' was renamed to '{new_name}'"):
+            runner._apply_dataset_operations(ds, [{op: {"num": 5}}], "test_ds")
+
     # (op_name, missing_args, expected_error_pattern)
     @pytest.mark.parametrize(
         "op,missing_args,error_match",
         [
-            ("select", {}, "'select' requires 'num'"),
+            ("slice", {}, "'slice' requires 'num'"),
             ("repeat", {}, "'repeat' requires 'times'"),
         ],
     )
@@ -284,46 +294,46 @@ class TestDatasetOperations:
         runner = self._make_runner()
         ds = MagicMock()
         ds.shuffle.return_value = ds
-        ds.select.return_value = ds
+        ds.slice.return_value = ds
 
         _result = runner._apply_dataset_operations(
             ds,
-            [{"shuffle": {"seed": 0}}, {"select": {"num": 5}}],
+            [{"shuffle": {"seed": 0}}, {"slice": {"num": 5}}],
             "test_ds",
         )
         ds.shuffle.assert_called_once()
-        ds.select.assert_called_once()
+        ds.slice.assert_called_once()
 
     def test_operation_argument_variants(self):
         """Validate alias, custom split, and None-arg default behaviors."""
         runner = self._make_runner()
 
         ds_alias = MagicMock()
-        ds_alias.select.return_value = ds_alias
-        runner._apply_dataset_operations(ds_alias, [{"select": {"n": 7}}], "test_ds")
-        ds_alias.select.assert_called_once_with(7, split="test")
+        ds_alias.slice.return_value = ds_alias
+        runner._apply_dataset_operations(ds_alias, [{"slice": {"n": 7}}], "test_ds")
+        ds_alias.slice.assert_called_once_with(7, split="test")
 
         ds_custom_split = MagicMock()
-        ds_custom_split.select.return_value = ds_custom_split
+        ds_custom_split.slice.return_value = ds_custom_split
         runner._apply_dataset_operations(
-            ds_custom_split, [{"select": {"num": 5, "split": "train"}}], "test_ds"
+            ds_custom_split, [{"slice": {"num": 5, "split": "train"}}], "test_ds"
         )
-        ds_custom_split.select.assert_called_once_with(5, split="train")
+        ds_custom_split.slice.assert_called_once_with(5, split="train")
 
         ds_none_args = MagicMock()
         ds_none_args.shuffle.return_value = ds_none_args
         runner._apply_dataset_operations(ds_none_args, [{"shuffle": None}], "test_ds")
         ds_none_args.shuffle.assert_called_once_with(seed=0, split="test")
 
-    def test_stratified_select_dispatch(self):
+    def test_stratified_sample_dispatch(self):
         runner = self._make_runner()
         ds = MagicMock()
-        ds.stratified_select.return_value = ds
+        ds.stratified_sample.return_value = ds
         runner._apply_dataset_operations(
             ds,
             [
                 {
-                    "stratified_select": {
+                    "stratified_sample": {
                         "by": "Subject",
                         "num": 800,
                         "min_per_group": 5,
@@ -333,18 +343,18 @@ class TestDatasetOperations:
             ],
             "test_ds",
         )
-        ds.stratified_select.assert_called_once_with(
+        ds.stratified_sample.assert_called_once_with(
             800, by="Subject", min_per_group=5, seed=42, split="test"
         )
 
-    def test_stratified_select_defaults(self):
+    def test_stratified_sample_defaults(self):
         runner = self._make_runner()
         ds = MagicMock()
-        ds.stratified_select.return_value = ds
+        ds.stratified_sample.return_value = ds
         runner._apply_dataset_operations(
-            ds, [{"stratified_select": {"by": "category", "num": 600}}], "test_ds"
+            ds, [{"stratified_sample": {"by": "category", "num": 600}}], "test_ds"
         )
-        ds.stratified_select.assert_called_once_with(
+        ds.stratified_sample.assert_called_once_with(
             600, by="category", min_per_group=1, seed=0, split="test"
         )
 
@@ -352,12 +362,12 @@ class TestDatasetOperations:
         "op_args",
         [{"num": 5}, {"by": "Subject"}, {}],
     )
-    def test_stratified_select_requires_num_and_by(self, op_args):
+    def test_stratified_sample_requires_num_and_by(self, op_args):
         runner = self._make_runner()
         ds = MagicMock()
         with pytest.raises(ValueError, match="requires 'num' and 'by'"):
             runner._apply_dataset_operations(
-                ds, [{"stratified_select": op_args}], "test_ds"
+                ds, [{"stratified_sample": op_args}], "test_ds"
             )
 
 
@@ -691,7 +701,7 @@ tasks:
 
     @pytest.mark.anyio
     async def test_yaml_dataset_operations(self, tmp_path):
-        """Dataset operations (shuffle, select) should be applied from YAML."""
+        """Dataset operations (shuffle, slice) should be applied from YAML."""
         yaml_content = """\
 result_dir: "{result_dir}"
 
@@ -708,7 +718,7 @@ datasets:
     args: {{}}
     operations:
       - shuffle: {{seed: 42}}
-      - select: {{num: 2}}
+      - slice: {{num: 2}}
 
 tasks:
   ops_eval:
@@ -732,7 +742,7 @@ tasks:
         results = await task_runner.arun()
 
         assert "ops_eval" in results
-        # select num=2 should reduce dataset to 2 samples
+        # slice num=2 should reduce dataset to 2 samples
         assert results["ops_eval"]["total"] == 2
 
     @pytest.mark.anyio

--- a/tests/unit/cli/leaderboard/test_session.py
+++ b/tests/unit/cli/leaderboard/test_session.py
@@ -376,6 +376,8 @@ class TestDatasetOperations:
             runner._apply_dataset_operations(
                 ds, [{"stratified_sample": {"num": 5}}], "test_ds"
             )
+        with pytest.raises(ValueError, match="requires 'by'"):
+            runner._apply_dataset_operations(ds, [{"stratified_sample": {}}], "test_ds")
 
     def test_stratified_sample_requires_exactly_one_budget(self):
         runner = self._make_runner()

--- a/tests/unit/cli/leaderboard/test_session.py
+++ b/tests/unit/cli/leaderboard/test_session.py
@@ -266,15 +266,21 @@ class TestDatasetOperations:
         with pytest.raises(ValueError, match=error_match):
             runner._apply_dataset_operations(ds, operations, "test_ds")
 
-    @pytest.mark.parametrize(
-        "op,new_name",
-        [("select", "slice"), ("stratified_select", "stratified_sample")],
-    )
-    def test_renamed_operation_raises_migration_hint(self, op, new_name):
+    def test_renamed_operation_raises_migration_hint(self):
         runner = self._make_runner()
         ds = MagicMock()
-        with pytest.raises(ValueError, match=f"'{op}' was renamed to '{new_name}'"):
-            runner._apply_dataset_operations(ds, [{op: {"num": 5}}], "test_ds")
+        with pytest.raises(ValueError, match="'select' was renamed to 'slice'"):
+            runner._apply_dataset_operations(ds, [{"select": {"num": 5}}], "test_ds")
+
+    def test_never_shipped_operation_raises_unknown_not_renamed(self):
+        # 'stratified_select' never shipped, so it must hit the generic unknown
+        # branch — no migration hint for a name users never saw.
+        runner = self._make_runner()
+        ds = MagicMock()
+        with pytest.raises(ValueError, match="Unknown operation 'stratified_select'"):
+            runner._apply_dataset_operations(
+                ds, [{"stratified_select": {"num": 5}}], "test_ds"
+            )
 
     # (op_name, missing_args, expected_error_pattern)
     @pytest.mark.parametrize(

--- a/tests/unit/cli/test_validation.py
+++ b/tests/unit/cli/test_validation.py
@@ -480,6 +480,28 @@ class TestValidateDatasets:
         result = validate_eval_config(cfg)
         assert result.ok
 
+    def test_valid_stratified_sample_equal_composite_operation(self):
+        cfg = {
+            "models": {},
+            "tasks": {},
+            "datasets": {
+                "d": {
+                    "class": "X",
+                    "operations": [
+                        {
+                            "stratified_sample": {
+                                "by": ["locale", "subject"],
+                                "per_group": 20,
+                                "seed": 42,
+                            }
+                        }
+                    ],
+                }
+            },
+        }
+        result = validate_eval_config(cfg)
+        assert result.ok
+
 
 # ---------------------------------------------------------------------------
 # Schema validation — tasks

--- a/tests/unit/cli/test_validation.py
+++ b/tests/unit/cli/test_validation.py
@@ -364,7 +364,7 @@ class TestValidateDatasets:
         cfg = {
             "models": {},
             "tasks": {},
-            "datasets": {"d": {"class": "X", "operations": [{"select": "bad"}]}},
+            "datasets": {"d": {"class": "X", "operations": [{"slice": "bad"}]}},
         }
         result = validate_eval_config(cfg)
         assert not result.ok
@@ -397,7 +397,7 @@ class TestValidateDatasets:
             "datasets": {
                 "d": {
                     "class": "X",
-                    "operations": [{"select": {"num": 10}, "shuffle": {}}],
+                    "operations": [{"slice": {"num": 10}, "shuffle": {}}],
                 }
             },
         }
@@ -414,6 +414,20 @@ class TestValidateDatasets:
         assert not result.ok
         assert any("sort" in e for e in result.errors)
 
+    @pytest.mark.parametrize(
+        "old,new",
+        [("select", "slice"), ("stratified_select", "stratified_sample")],
+    )
+    def test_operations_renamed_op_gives_migration_hint(self, old, new):
+        cfg = {
+            "models": {},
+            "tasks": {},
+            "datasets": {"d": {"class": "X", "operations": [{old: {"num": 5}}]}},
+        }
+        result = validate_eval_config(cfg)
+        assert not result.ok
+        assert any(f"'{old}' was renamed to '{new}'" in e for e in result.errors)
+
     def test_valid_operations(self):
         cfg = {
             "models": {},
@@ -423,7 +437,7 @@ class TestValidateDatasets:
                     "class": "X",
                     "operations": [
                         {"shuffle": {"seed": 42}},
-                        {"select": {"num": 100}},
+                        {"slice": {"num": 100}},
                     ],
                 }
             },
@@ -431,7 +445,7 @@ class TestValidateDatasets:
         result = validate_eval_config(cfg)
         assert result.ok
 
-    def test_valid_stratified_select_operation(self):
+    def test_valid_stratified_sample_operation(self):
         cfg = {
             "models": {},
             "tasks": {},
@@ -440,7 +454,7 @@ class TestValidateDatasets:
                     "class": "X",
                     "operations": [
                         {
-                            "stratified_select": {
+                            "stratified_sample": {
                                 "by": "Subject",
                                 "num": 800,
                                 "min_per_group": 5,

--- a/tests/unit/cli/test_validation.py
+++ b/tests/unit/cli/test_validation.py
@@ -414,19 +414,31 @@ class TestValidateDatasets:
         assert not result.ok
         assert any("sort" in e for e in result.errors)
 
-    @pytest.mark.parametrize(
-        "old,new",
-        [("select", "slice"), ("stratified_select", "stratified_sample")],
-    )
-    def test_operations_renamed_op_gives_migration_hint(self, old, new):
+    def test_operations_renamed_op_gives_migration_hint(self):
         cfg = {
             "models": {},
             "tasks": {},
-            "datasets": {"d": {"class": "X", "operations": [{old: {"num": 5}}]}},
+            "datasets": {"d": {"class": "X", "operations": [{"select": {"num": 5}}]}},
         }
         result = validate_eval_config(cfg)
         assert not result.ok
-        assert any(f"'{old}' was renamed to '{new}'" in e for e in result.errors)
+        assert any("'select' was renamed to 'slice'" in e for e in result.errors)
+
+    def test_operations_never_shipped_name_is_unknown_not_renamed(self):
+        # 'stratified_select' never shipped (introduced and renamed within the
+        # same unreleased change), so it must read as an unknown op, not carry a
+        # migration hint for a name users never saw.
+        cfg = {
+            "models": {},
+            "tasks": {},
+            "datasets": {
+                "d": {"class": "X", "operations": [{"stratified_select": {"num": 5}}]}
+            },
+        }
+        result = validate_eval_config(cfg)
+        assert not result.ok
+        assert any("unknown operation 'stratified_select'" in e for e in result.errors)
+        assert not any("was renamed" in e for e in result.errors)
 
     def test_valid_operations(self):
         cfg = {

--- a/tests/unit/cli/test_validation.py
+++ b/tests/unit/cli/test_validation.py
@@ -431,6 +431,29 @@ class TestValidateDatasets:
         result = validate_eval_config(cfg)
         assert result.ok
 
+    def test_valid_stratified_select_operation(self):
+        cfg = {
+            "models": {},
+            "tasks": {},
+            "datasets": {
+                "d": {
+                    "class": "X",
+                    "operations": [
+                        {
+                            "stratified_select": {
+                                "by": "Subject",
+                                "num": 800,
+                                "min_per_group": 5,
+                                "seed": 42,
+                            }
+                        }
+                    ],
+                }
+            },
+        }
+        result = validate_eval_config(cfg)
+        assert result.ok
+
 
 # ---------------------------------------------------------------------------
 # Schema validation — tasks

--- a/tests/unit/core/test_datasets.py
+++ b/tests/unit/core/test_datasets.py
@@ -326,6 +326,12 @@ class TestStratifiedSample:
         )
         assert "exceeding the requested num=2" in log
 
+    def test_default_floor_overshoot_logs_warning(self):
+        ds = _make_grouped({"a": 1, "b": 1, "c": 1})
+        log = _capture_logs(lambda: ds.stratified_sample(num=2, by="subject", seed=0))
+        assert "min_per_group=1" in log
+        assert "exceeding the requested num=2" in log
+
     def test_proportional_target_does_not_warn(self):
         ds = _make_grouped({"a": 100, "b": 50, "c": 50})
         log = _capture_logs(
@@ -401,12 +407,15 @@ class TestStratifiedSample:
 
     def test_equal_allocation_caps_short_stratum_and_warns(self):
         ds = _make_grouped({"a": 2, "b": 5})
-        log = _capture_logs(
-            lambda: ds.stratified_sample(by="subject", per_group=3, seed=0)
-        )
-        result = ds.stratified_sample(by="subject", per_group=3, seed=0)
-        assert _subject_counts(result) == {"a": 2, "b": 3}
+        result = {}
+
+        def run():
+            result["ds"] = ds.stratified_sample(by="subject", per_group=3, seed=0)
+
+        log = _capture_logs(run)
+        assert _subject_counts(result["ds"]) == {"a": 2, "b": 3}
         assert "per_group=3 unmet for 1 of 2 strata" in log
+        assert "short 1 rows total" in log
 
     def test_composite_key_same_seed_deterministic(self):
         ds = _make_grouped2({("en", "math"): 10, ("fr", "math"): 10})

--- a/tests/unit/core/test_datasets.py
+++ b/tests/unit/core/test_datasets.py
@@ -154,6 +154,86 @@ class TestShuffle:
 
 
 # ===================================================================
+# stratified_select
+# ===================================================================
+def _make_grouped(group_sizes):
+    """Build a _ListDataset with a 'subject' column per {group: size} mapping."""
+    samples = []
+    idx = 0
+    for group, n in group_sizes.items():
+        for _ in range(n):
+            samples.append({"id": idx, "subject": group})
+            idx += 1
+    return _ListDataset(samples)
+
+
+def _subject_counts(ds):
+    counts: dict = {}
+    for row in ds.test_set:
+        counts[row["subject"]] = counts.get(row["subject"], 0) + 1
+    return counts
+
+
+class TestStratifiedSelect:
+    def test_proportional_allocation_with_zero_floor(self):
+        ds = _make_grouped({"a": 100, "b": 50, "c": 50})
+        result = ds.stratified_select(num=40, by="subject", min_per_group=0, seed=0)
+        assert _subject_counts(result) == {"a": 20, "b": 10, "c": 10}
+        assert type(result) is type(ds)
+
+    def test_floor_guarantees_small_groups_capped_by_size(self):
+        ds = _make_grouped({"a": 100, "b": 2, "c": 2})
+        result = ds.stratified_select(num=12, by="subject", min_per_group=3, seed=0)
+        # small groups capped at their full size (< floor); big group takes the rest
+        assert _subject_counts(result) == {"a": 8, "b": 2, "c": 2}
+
+    def test_floor_sum_exceeding_num_raises_total_to_floor(self):
+        ds = _make_grouped({"a": 5, "b": 5, "c": 5})
+        result = ds.stratified_select(num=2, by="subject", min_per_group=2, seed=0)
+        # 3 groups x floor 2 = 6 > num 2 → total raised to 6 to honour the floor
+        assert _subject_counts(result) == {"a": 2, "b": 2, "c": 2}
+
+    def test_num_exceeding_total_returns_all(self):
+        ds = _make_grouped({"a": 3, "b": 2})
+        result = ds.stratified_select(num=999, by="subject", min_per_group=1, seed=0)
+        assert len(result.test_set) == 5
+
+    def test_same_seed_is_deterministic(self):
+        ds = _make_grouped({"a": 100, "b": 50, "c": 50})
+        ids1 = sorted(
+            r["id"] for r in ds.stratified_select(num=40, by="subject", seed=7).test_set
+        )
+        ids2 = sorted(
+            r["id"] for r in ds.stratified_select(num=40, by="subject", seed=7).test_set
+        )
+        assert ids1 == ids2
+
+    def test_different_seed_changes_rows_not_counts(self):
+        ds = _make_grouped({"a": 100, "b": 50, "c": 50})
+        r0 = ds.stratified_select(num=40, by="subject", min_per_group=0, seed=0)
+        r1 = ds.stratified_select(num=40, by="subject", min_per_group=0, seed=1)
+        assert _subject_counts(r0) == _subject_counts(r1)
+        ids0 = sorted(x["id"] for x in r0.test_set)
+        ids1 = sorted(x["id"] for x in r1.test_set)
+        assert ids0 != ids1
+
+    def test_missing_by_column_raises(self):
+        ds = _make_grouped({"a": 3})
+        with pytest.raises(ValueError, match="nonexistent"):
+            ds.stratified_select(num=2, by="nonexistent", seed=0)
+
+    def test_no_test_set_returns_self(self):
+        class _NoTestDataset(_ListDataset):
+            def load(self, name_or_path, **kwargs):
+                return HFDatasetDict(
+                    {"train": HFDataset.from_list([{"id": 0, "subject": "a"}])}
+                )
+
+        ds = _NoTestDataset([], None)
+        assert ds.stratified_select(num=2, by="subject", seed=0) is ds
+
+
+# ===================================================================
 # retrieve_samples
 # ===================================================================
 class TestRetrieveSamples:

--- a/tests/unit/core/test_datasets.py
+++ b/tests/unit/core/test_datasets.py
@@ -226,6 +226,28 @@ def _make_grouped(group_sizes):
     return _ListDataset(samples)
 
 
+def _make_grouped2(cell_sizes):
+    """Build a _ListDataset with 'locale'+'subject' columns per {(locale, subject): n}.
+
+    cell_sizes maps (locale, subject) tuples to row counts.
+    """
+    samples = []
+    idx = 0
+    for (locale, subject), n in cell_sizes.items():
+        for _ in range(n):
+            samples.append({"id": idx, "locale": locale, "subject": subject})
+            idx += 1
+    return _ListDataset(samples)
+
+
+def _cell_counts(ds):
+    counts: dict = {}
+    for row in ds.test_set:
+        key = (row["locale"], row["subject"])
+        counts[key] = counts.get(key, 0) + 1
+    return counts
+
+
 def _subject_counts(ds):
     counts: dict = {}
     for row in ds.test_set:
@@ -310,6 +332,119 @@ class TestStratifiedSample:
             lambda: ds.stratified_sample(num=40, by="subject", min_per_group=0, seed=0)
         )
         assert log == ""
+
+    def test_single_field_proportional_is_byte_identical(self):
+        # Reproducibility lock: golden ids captured from the pre-change
+        # implementation. a=ids 0..99, b=100..149, c=150..199.
+        ds = _make_grouped({"a": 100, "b": 50, "c": 50})
+        result = ds.stratified_sample(num=40, by="subject", min_per_group=0, seed=0)
+        ids = sorted(r["id"] for r in result.test_set)
+        assert ids == [
+            5,
+            11,
+            15,
+            17,
+            20,
+            27,
+            28,
+            34,
+            41,
+            54,
+            59,
+            68,
+            75,
+            76,
+            77,
+            83,
+            88,
+            93,
+            97,
+            98,
+            106,
+            111,
+            125,
+            130,
+            133,
+            135,
+            136,
+            137,
+            140,
+            145,
+            150,
+            152,
+            155,
+            160,
+            161,
+            166,
+            178,
+            183,
+            187,
+            194,
+        ]
+
+    def test_equal_allocation_per_group_single_field(self):
+        ds = _make_grouped({"a": 100, "b": 50, "c": 50})
+        result = ds.stratified_sample(by="subject", per_group=20, seed=42)
+        assert _subject_counts(result) == {"a": 20, "b": 20, "c": 20}
+
+    def test_equal_allocation_composite_key(self):
+        ds = _make_grouped2(
+            {("en", "math"): 5, ("en", "bio"): 5, ("fr", "math"): 5, ("fr", "bio"): 5}
+        )
+        result = ds.stratified_sample(by=["locale", "subject"], per_group=2, seed=42)
+        assert _cell_counts(result) == {
+            ("en", "math"): 2,
+            ("en", "bio"): 2,
+            ("fr", "math"): 2,
+            ("fr", "bio"): 2,
+        }
+
+    def test_equal_allocation_caps_short_stratum_and_warns(self):
+        ds = _make_grouped({"a": 2, "b": 5})
+        log = _capture_logs(
+            lambda: ds.stratified_sample(by="subject", per_group=3, seed=0)
+        )
+        result = ds.stratified_sample(by="subject", per_group=3, seed=0)
+        assert _subject_counts(result) == {"a": 2, "b": 3}
+        assert "per_group=3 unmet for 1 of 2 strata" in log
+
+    def test_composite_key_same_seed_deterministic(self):
+        ds = _make_grouped2({("en", "math"): 10, ("fr", "math"): 10})
+        ids1 = sorted(
+            r["id"]
+            for r in ds.stratified_sample(
+                by=["locale", "subject"], per_group=3, seed=7
+            ).test_set
+        )
+        ids2 = sorted(
+            r["id"]
+            for r in ds.stratified_sample(
+                by=["locale", "subject"], per_group=3, seed=7
+            ).test_set
+        )
+        assert ids1 == ids2
+
+    def test_requires_exactly_one_budget(self):
+        ds = _make_grouped({"a": 5})
+        with pytest.raises(ValueError, match="exactly one of 'num' or 'per_group'"):
+            ds.stratified_sample(by="subject", seed=0)
+        with pytest.raises(ValueError, match="exactly one of 'num' or 'per_group'"):
+            ds.stratified_sample(by="subject", num=2, per_group=2, seed=0)
+
+    def test_min_per_group_excludes_per_group(self):
+        ds = _make_grouped({"a": 5})
+        with pytest.raises(ValueError, match="cannot be combined with 'per_group'"):
+            ds.stratified_sample(by="subject", per_group=2, min_per_group=1, seed=0)
+
+    def test_empty_by_list_raises(self):
+        ds = _make_grouped({"a": 5})
+        with pytest.raises(ValueError, match="at least one column"):
+            ds.stratified_sample(by=[], per_group=2, seed=0)
+
+    def test_missing_composite_column_raises(self):
+        ds = _make_grouped2({("en", "math"): 5})
+        with pytest.raises(ValueError, match="nonexistent"):
+            ds.stratified_sample(by=["locale", "nonexistent"], per_group=2, seed=0)
 
 
 # ===================================================================

--- a/tests/unit/core/test_datasets.py
+++ b/tests/unit/core/test_datasets.py
@@ -7,11 +7,24 @@ _clone_with_new_dict, property accessors.
 AI-Generated Code - Claude Opus 4.6 (Anthropic)
 """
 
+import io
+
 import pytest
 from datasets import Dataset as HFDataset
 from datasets import DatasetDict as HFDatasetDict
+from loguru import logger
 
 from sieval.core.datasets import Dataset
+
+
+def _capture_logs(fn) -> str:
+    sink = io.StringIO()
+    logger_id = logger.add(sink, format="{message}")
+    try:
+        fn()
+    finally:
+        logger.remove(logger_id)
+    return sink.getvalue()
 
 
 # ===================================================================
@@ -104,6 +117,21 @@ class TestSelect:
         result = ds.select(3)
         assert result is ds
 
+    def test_select_acts_on_explicit_non_test_split(self):
+        ds = _BypassLoadDataset(
+            _hf_dict=HFDatasetDict(
+                {"validation": HFDataset.from_list([{"id": i} for i in range(10)])}
+            )
+        )
+        result = ds.select(3, split="validation")
+        assert len(result.dataset_dict["validation"]) == 3
+
+    def test_select_missing_split_returns_self(self):
+        ds = _BypassLoadDataset(
+            _hf_dict=HFDatasetDict({"test": HFDataset.from_list([{"id": 0}])})
+        )
+        assert ds.select(1, split="train") is ds
+
 
 # ===================================================================
 # repeat
@@ -122,6 +150,21 @@ class TestRepeat:
 
         ds = _NoTestDataset([], None)
         assert ds.repeat(3) is ds
+
+    def test_repeat_acts_on_explicit_non_test_split(self):
+        ds = _BypassLoadDataset(
+            _hf_dict=HFDatasetDict(
+                {"validation": HFDataset.from_list([{"id": i} for i in range(3)])}
+            )
+        )
+        result = ds.repeat(2, split="validation")
+        assert len(result.dataset_dict["validation"]) == 6
+
+    def test_repeat_missing_split_returns_self(self):
+        ds = _BypassLoadDataset(
+            _hf_dict=HFDatasetDict({"test": HFDataset.from_list([{"id": 0}])})
+        )
+        assert ds.repeat(2, split="train") is ds
 
 
 # ===================================================================
@@ -151,6 +194,22 @@ class TestShuffle:
 
         ds = _NoTestDataset([], None)
         assert ds.shuffle(seed=123) is ds
+
+    def test_shuffle_acts_on_explicit_non_test_split(self):
+        ds = _BypassLoadDataset(
+            _hf_dict=HFDatasetDict(
+                {"validation": HFDataset.from_list([{"id": i} for i in range(10)])}
+            )
+        )
+        result = ds.shuffle(seed=1, split="validation")
+        assert result is not ds
+        assert len(result.dataset_dict["validation"]) == 10
+
+    def test_shuffle_missing_split_returns_self(self):
+        ds = _BypassLoadDataset(
+            _hf_dict=HFDatasetDict({"test": HFDataset.from_list([{"id": 0}])})
+        )
+        assert ds.shuffle(seed=1, split="train") is ds
 
 
 # ===================================================================
@@ -231,6 +290,26 @@ class TestStratifiedSelect:
 
         ds = _NoTestDataset([], None)
         assert ds.stratified_select(num=2, by="subject", seed=0) is ds
+
+    def test_empty_split_returns_self(self):
+        # An empty split is schema-less; the guard must short-circuit before the
+        # column check so it doesn't misreport 'by' as a missing column.
+        ds = _ListDataset([])
+        assert ds.stratified_select(num=2, by="subject", seed=0) is ds
+
+    def test_floor_overshoot_logs_warning(self):
+        ds = _make_grouped({"a": 5, "b": 5, "c": 5})
+        log = _capture_logs(
+            lambda: ds.stratified_select(num=2, by="subject", min_per_group=2, seed=0)
+        )
+        assert "exceeding the requested num=2" in log
+
+    def test_proportional_target_does_not_warn(self):
+        ds = _make_grouped({"a": 100, "b": 50, "c": 50})
+        log = _capture_logs(
+            lambda: ds.stratified_select(num=40, by="subject", min_per_group=0, seed=0)
+        )
+        assert log == ""
 
 
 # ===================================================================

--- a/tests/unit/core/test_datasets.py
+++ b/tests/unit/core/test_datasets.py
@@ -1,7 +1,7 @@
 """
 Unit tests for sieval/core/datasets.py.
 
-Covers: Dataset.repeat, select, shuffle, retrieve_samples (random/fixed/lazy),
+Covers: Dataset.repeat, slice, shuffle, retrieve_samples (random/fixed/lazy),
 _clone_with_new_dict, property accessors.
 
 AI-Generated Code - Claude Opus 4.6 (Anthropic)
@@ -95,42 +95,42 @@ class TestDatasetProperties:
 
 
 # ===================================================================
-# select
+# slice
 # ===================================================================
-class TestSelect:
-    def test_select_size_behavior_and_type(self):
+class TestSlice:
+    def test_slice_size_behavior_and_type(self):
         ds = _make(10)
-        result = ds.select(4)
+        result = ds.slice(4)
         assert len(result.test_set) == 4
         assert type(result) is type(ds)
 
         ds = _make(3)
-        result = ds.select(100)
+        result = ds.slice(100)
         assert len(result.test_set) == 3
 
-    def test_select_no_test_set_returns_self(self):
+    def test_slice_no_test_set_returns_self(self):
         class _NoTestDataset(_ListDataset):
             def load(self, name_or_path, **kwargs):
                 return HFDatasetDict({"train": HFDataset.from_list([{"id": 0}])})
 
         ds = _NoTestDataset([], None)
-        result = ds.select(3)
+        result = ds.slice(3)
         assert result is ds
 
-    def test_select_acts_on_explicit_non_test_split(self):
+    def test_slice_acts_on_explicit_non_test_split(self):
         ds = _BypassLoadDataset(
             _hf_dict=HFDatasetDict(
                 {"validation": HFDataset.from_list([{"id": i} for i in range(10)])}
             )
         )
-        result = ds.select(3, split="validation")
+        result = ds.slice(3, split="validation")
         assert len(result.dataset_dict["validation"]) == 3
 
-    def test_select_missing_split_returns_self(self):
+    def test_slice_missing_split_returns_self(self):
         ds = _BypassLoadDataset(
             _hf_dict=HFDatasetDict({"test": HFDataset.from_list([{"id": 0}])})
         )
-        assert ds.select(1, split="train") is ds
+        assert ds.slice(1, split="train") is ds
 
 
 # ===================================================================
@@ -213,7 +213,7 @@ class TestShuffle:
 
 
 # ===================================================================
-# stratified_select
+# stratified_sample
 # ===================================================================
 def _make_grouped(group_sizes):
     """Build a _ListDataset with a 'subject' column per {group: size} mapping."""
@@ -233,44 +233,44 @@ def _subject_counts(ds):
     return counts
 
 
-class TestStratifiedSelect:
+class TestStratifiedSample:
     def test_proportional_allocation_with_zero_floor(self):
         ds = _make_grouped({"a": 100, "b": 50, "c": 50})
-        result = ds.stratified_select(num=40, by="subject", min_per_group=0, seed=0)
+        result = ds.stratified_sample(num=40, by="subject", min_per_group=0, seed=0)
         assert _subject_counts(result) == {"a": 20, "b": 10, "c": 10}
         assert type(result) is type(ds)
 
     def test_floor_guarantees_small_groups_capped_by_size(self):
         ds = _make_grouped({"a": 100, "b": 2, "c": 2})
-        result = ds.stratified_select(num=12, by="subject", min_per_group=3, seed=0)
+        result = ds.stratified_sample(num=12, by="subject", min_per_group=3, seed=0)
         # small groups capped at their full size (< floor); big group takes the rest
         assert _subject_counts(result) == {"a": 8, "b": 2, "c": 2}
 
     def test_floor_sum_exceeding_num_raises_total_to_floor(self):
         ds = _make_grouped({"a": 5, "b": 5, "c": 5})
-        result = ds.stratified_select(num=2, by="subject", min_per_group=2, seed=0)
+        result = ds.stratified_sample(num=2, by="subject", min_per_group=2, seed=0)
         # 3 groups x floor 2 = 6 > num 2 → total raised to 6 to honour the floor
         assert _subject_counts(result) == {"a": 2, "b": 2, "c": 2}
 
     def test_num_exceeding_total_returns_all(self):
         ds = _make_grouped({"a": 3, "b": 2})
-        result = ds.stratified_select(num=999, by="subject", min_per_group=1, seed=0)
+        result = ds.stratified_sample(num=999, by="subject", min_per_group=1, seed=0)
         assert len(result.test_set) == 5
 
     def test_same_seed_is_deterministic(self):
         ds = _make_grouped({"a": 100, "b": 50, "c": 50})
         ids1 = sorted(
-            r["id"] for r in ds.stratified_select(num=40, by="subject", seed=7).test_set
+            r["id"] for r in ds.stratified_sample(num=40, by="subject", seed=7).test_set
         )
         ids2 = sorted(
-            r["id"] for r in ds.stratified_select(num=40, by="subject", seed=7).test_set
+            r["id"] for r in ds.stratified_sample(num=40, by="subject", seed=7).test_set
         )
         assert ids1 == ids2
 
     def test_different_seed_changes_rows_not_counts(self):
         ds = _make_grouped({"a": 100, "b": 50, "c": 50})
-        r0 = ds.stratified_select(num=40, by="subject", min_per_group=0, seed=0)
-        r1 = ds.stratified_select(num=40, by="subject", min_per_group=0, seed=1)
+        r0 = ds.stratified_sample(num=40, by="subject", min_per_group=0, seed=0)
+        r1 = ds.stratified_sample(num=40, by="subject", min_per_group=0, seed=1)
         assert _subject_counts(r0) == _subject_counts(r1)
         ids0 = sorted(x["id"] for x in r0.test_set)
         ids1 = sorted(x["id"] for x in r1.test_set)
@@ -279,7 +279,7 @@ class TestStratifiedSelect:
     def test_missing_by_column_raises(self):
         ds = _make_grouped({"a": 3})
         with pytest.raises(ValueError, match="nonexistent"):
-            ds.stratified_select(num=2, by="nonexistent", seed=0)
+            ds.stratified_sample(num=2, by="nonexistent", seed=0)
 
     def test_no_test_set_returns_self(self):
         class _NoTestDataset(_ListDataset):
@@ -289,25 +289,25 @@ class TestStratifiedSelect:
                 )
 
         ds = _NoTestDataset([], None)
-        assert ds.stratified_select(num=2, by="subject", seed=0) is ds
+        assert ds.stratified_sample(num=2, by="subject", seed=0) is ds
 
     def test_empty_split_returns_self(self):
         # An empty split is schema-less; the guard must short-circuit before the
         # column check so it doesn't misreport 'by' as a missing column.
         ds = _ListDataset([])
-        assert ds.stratified_select(num=2, by="subject", seed=0) is ds
+        assert ds.stratified_sample(num=2, by="subject", seed=0) is ds
 
     def test_floor_overshoot_logs_warning(self):
         ds = _make_grouped({"a": 5, "b": 5, "c": 5})
         log = _capture_logs(
-            lambda: ds.stratified_select(num=2, by="subject", min_per_group=2, seed=0)
+            lambda: ds.stratified_sample(num=2, by="subject", min_per_group=2, seed=0)
         )
         assert "exceeding the requested num=2" in log
 
     def test_proportional_target_does_not_warn(self):
         ds = _make_grouped({"a": 100, "b": 50, "c": 50})
         log = _capture_logs(
-            lambda: ds.stratified_select(num=40, by="subject", min_per_group=0, seed=0)
+            lambda: ds.stratified_sample(num=40, by="subject", min_per_group=0, seed=0)
         )
         assert log == ""
 


### PR DESCRIPTION
## Type

- feature — new capability (`stratified_sample` dataset operation)
- breaking — dataset `operations` vocabulary rename (`select` → `slice`)

## Summary

Two related changes to the leaderboard `operations` pipeline:

**1. Add `stratified_sample`** — proportional, group-balanced subsampling (args: `by`, `num`, `min_per_group`, `seed`).
- **Why:** plain `shuffle`+`slice` under-represents small groups in multi-domain benches (MMLU's 57 subjects, MMLU-Pro's 14 categories) — a random 800-sample can leave some subjects with a handful of items. `stratified_sample` guarantees every group is represented (per-group floor), then allocates the remaining budget proportionally to group size, so the aggregate stays comparable to the full-set (micro-average) score while small groups aren't missed.
- Deterministic given `seed` (per-group shuffle) → reproduces across runs and processes.

**2. Rename the operations vocabulary** for honest semantics:
- `select` (deterministic "keep first *N*") → **`slice`**. The name `select` is freed and reserved for a future predicate-filter op (`select rows where …`).
- the new sampling op is **`stratified_sample`**, not `stratified_select` — it's seeded *random* sampling, and reads as a `*_sample` family alongside future `weighted_sample` / `uniform_sample`.
- **No deprecation alias** (consistent with the repo's strict-only stance; a working alias would also block reusing `select`). A stale `select` / `stratified_select` op instead **fails fast** with `operation 'select' was renamed to 'slice'; update your config` — in both `--dry-run` validation and at runtime.

Example:

```yaml
operations:
  - shuffle: { seed: 42 }
  - slice: { num: 100 }
  # ...or group-balanced instead of a plain prefix:
  - stratified_sample: { by: Subject, num: 800, min_per_group: 5, seed: 42 }
```

## Review follow-ups

Addressed after review:
- **`stratified_sample` overshoot is no longer silent** — `num` is a soft target (the per-group floor guarantee wins over the budget), but when `min_per_group × #groups > num` the op logs a `WARNING` naming requested vs. actual count.
- **Empty split** — `stratified_sample` early-returns `self` on an empty split, so a schema-less empty split isn't misreported as a missing `by` column.
- **Split-aware guards** — `slice` / `shuffle` / `repeat` previously guarded on `self.test_set is None` while operating on the `split` arg, so a non-`test` split was silently skipped (and a missing non-default split raised `KeyError`). All ops now guard on the split they act on. Default `split: test` behavior is unchanged.

## Test Plan

### Automated

- [x] Lint/format clean (`ruff format --check`; `ruff check`)
- [x] Type check clean (`ty check`)
- [x] Unit tests pass — full core+cli unit suite green (1368). New coverage: `stratified_sample` semantics (proportional / floor / cap / num>total / determinism / empty-split / overshoot-warning / missing-column), split-aware guards for `slice`/`shuffle`/`repeat`, dispatch, validation, and the renamed-op migration-hint errors (validation + runtime).

### Manual

- [x] `sieval eval <leaderboard> --dry-run` accepts the new ops and validates MMLU (`by: Subject`) and MMLU-Pro (`by: category`) configs; a stale `select:` config reports the rename hint.

## Migration

Replace the old operation keys in any dataset/leaderboard `operations`:

| before | after |
|---|---|
| `- select: { num: N }` | `- slice: { num: N }` |
| `- stratified_select: { … }` | `- stratified_sample: { … }` |

Behavior is unchanged — only the key names. Note: renaming an op key changes a config's `--resume` identity, so an in-flight run under the old key won't resume against the renamed config; start it fresh.

## Checklist

### Required (all PRs)

- [x] PR title follows conventional format (`feat(datasets)!: …`)
- [x] No internal paths, credentials, or personal info in committed files
- [x] AI-generated code marker — new test code lives in files already carrying the marker; `dataset.py` / `session.py` / `validation.py` are pre-existing modules extended in place.
- [x] No new upper-layer dependencies added to `core/` (stdlib `random` + the already-imported `datasets`; `loguru` already used across `core/`)
- [x] Deleted code verified — none (rename + addition)
- [x] Breaking change staged for release notes (pending-changelog)
