### PR TITLE
feat(datasets): pin HF revisions + checksum URL datasets, enforced in preflight

### DIFF
--- a/.claude/rules/datasets.md
+++ b/.claude/rules/datasets.md
@@ -16,9 +16,7 @@ paths:
 - The sample `TypedDict` is the reverse-lookup key for `@sieval_task`; it must be globally unique across registered Datasets. `name` is also globally unique across Datasets and Tasks.
 - `source` must use scheme `hf:` / `url:` / `local:` and is consumed by `sieval dataset download` to stage data into `$SIEVAL_DATA_DIR`.
 - `deps_group` here is **loader-side** deps; evaluator-side deps stay on the Task.
-- `hf:` sources MUST be revision-pinned (`hf:org/name@<sha>`); `url:` sources MUST declare a
-  `checksums={basename: "sha256:<hex>"}` entry per downloaded file. Enforced by
-  `check_preflight.py --check check_datasets`.
-- After editing any `source` or `checksums`, run `python scripts/sync_meta_index.py` — the
-  runtime reads `sieval/meta/index.json`, not the live registry; `check_meta_index_sync`
-  fails until you regenerate.
+- `hf:` sources MUST be revision-pinned (`hf:org/name@<sha>`); `url:` sources MUST declare
+  per-file `checksums` (sha256). `check_datasets` enforces both.
+- Re-run `scripts/sync_meta_index.py` after editing `source`/`checksums` (the runtime reads
+  the generated `index.json`).

--- a/.claude/rules/datasets.md
+++ b/.claude/rules/datasets.md
@@ -16,3 +16,9 @@ paths:
 - The sample `TypedDict` is the reverse-lookup key for `@sieval_task`; it must be globally unique across registered Datasets. `name` is also globally unique across Datasets and Tasks.
 - `source` must use scheme `hf:` / `url:` / `local:` and is consumed by `sieval dataset download` to stage data into `$SIEVAL_DATA_DIR`.
 - `deps_group` here is **loader-side** deps; evaluator-side deps stay on the Task.
+- `hf:` sources MUST be revision-pinned (`hf:org/name@<sha>`); `url:` sources MUST declare a
+  `checksums={basename: "sha256:<hex>"}` entry per downloaded file. Enforced by
+  `check_preflight.py --check check_datasets`.
+- After editing any `source` or `checksums`, run `python scripts/sync_meta_index.py` — the
+  runtime reads `sieval/meta/index.json`, not the live registry; `check_meta_index_sync`
+  fails until you regenerate.

--- a/scripts/check_preflight.py
+++ b/scripts/check_preflight.py
@@ -74,6 +74,28 @@ def format_json(results: list[CheckResult]) -> str:
     )
 
 
+def _dataset_integrity_violations(metas: list) -> list[str]:
+    """Each hf: source must be revision-pinned; each url: source must have a
+    checksum. local: sources are exempt. Returns human-readable violations."""
+    from sieval.core.datasets.meta import url_path_basename
+    from sieval.datasets.downloaders.hf import parse_hf_source
+
+    violations: list[str] = []
+    for meta in metas:
+        declared = {basename for basename, _ in meta.checksums}
+        for src in meta.source:
+            if src.startswith("hf:"):
+                if parse_hf_source(src).revision is None:
+                    violations.append(f"{meta.name}: hf source not pinned: {src}")
+            elif src.startswith("url:"):
+                basename = url_path_basename(src[len("url:") :])
+                if basename not in declared:
+                    violations.append(
+                        f"{meta.name}: url source missing checksum: {src}"
+                    )
+    return violations
+
+
 class PreflightRunner:
     """Orchestrates preflight checks."""
 
@@ -826,6 +848,28 @@ class PreflightRunner:
                     "PASS",
                     "check_datasets",
                     "all dataset exports follow naming convention",
+                )
+            )
+
+        # Step 4: source-integrity policy (hf pinned, url checksummed)
+        from sieval.core.datasets.meta import iter_dataset_metas
+
+        integrity = _dataset_integrity_violations(list(iter_dataset_metas()))
+        if integrity:
+            results.append(
+                CheckResult(
+                    "FAIL",
+                    "check_datasets",
+                    f"{len(integrity)} dataset source(s) not pinned/checksummed",
+                    integrity,
+                )
+            )
+        else:
+            results.append(
+                CheckResult(
+                    "PASS",
+                    "check_datasets",
+                    "all dataset sources pinned (hf) / checksummed (url)",
                 )
             )
 

--- a/scripts/check_preflight.py
+++ b/scripts/check_preflight.py
@@ -18,7 +18,10 @@ import sys
 import tomllib
 import warnings
 from pathlib import Path
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from sieval.core.datasets.meta import DatasetMeta
 
 # Known import-name → package-name mismatches
 _IMPORT_TO_PACKAGE: dict[str, str] = {
@@ -74,7 +77,7 @@ def format_json(results: list[CheckResult]) -> str:
     )
 
 
-def _dataset_integrity_violations(metas: list) -> list[str]:
+def _dataset_integrity_violations(metas: "list[DatasetMeta]") -> list[str]:
     """Each hf: source must be revision-pinned; each url: source must have a
     checksum. local: sources are exempt. Returns human-readable violations."""
     from sieval.core.datasets.meta import url_path_basename
@@ -85,7 +88,13 @@ def _dataset_integrity_violations(metas: list) -> list[str]:
         declared = {basename for basename, _ in meta.checksums}
         for src in meta.source:
             if src.startswith("hf:"):
-                if parse_hf_source(src).revision is None:
+                # A malformed pin (e.g. trailing '@') is itself a violation,
+                # not a reason to abort the whole check with a traceback.
+                try:
+                    pinned = parse_hf_source(src).revision is not None
+                except ValueError:
+                    pinned = False
+                if not pinned:
                     violations.append(f"{meta.name}: hf source not pinned: {src}")
             elif src.startswith("url:"):
                 basename = url_path_basename(src[len("url:") :])

--- a/sieval/cli/dataset/commands.py
+++ b/sieval/cli/dataset/commands.py
@@ -19,6 +19,7 @@ from sieval.core.utils.logging import configure_logging
 from sieval.core.utils.paths import resolve_data_dir
 from sieval.datasets.downloaders import resolve as resolve_handler
 from sieval.datasets.downloaders.resolver import extras_unsatisfied
+from sieval.datasets.downloaders.verify import verify_checksums
 from sieval.meta import load_index
 
 dataset_app = typer.Typer(help="Dataset discovery and download.")
@@ -186,6 +187,20 @@ def _download_one(m: DatasetMeta, dest_root: Path, force: bool) -> None:
             continue
         typer.echo(f"[{m.name}] fetching {src}")
         h.download(src, dest_root, m.name, force=force)
+
+    mismatches = verify_checksums(m, dest_root)
+    if mismatches:
+        for mm in mismatches:
+            (dest_root / m.name / mm.basename).unlink(missing_ok=True)
+        details = "; ".join(
+            f"{mm.basename}: expected {mm.expected}, got {mm.actual or 'MISSING'}"
+            for mm in mismatches
+        )
+        raise RuntimeError(
+            f"checksum verification failed for {m.name!r} ({details}); "
+            f"deleted the mismatched file(s) — re-run "
+            f"`sieval dataset download {m.name}` to refetch"
+        )
 
     # Post-download hint; print-only, never installs.
     if m.deps_group:

--- a/sieval/core/datasets/meta.py
+++ b/sieval/core/datasets/meta.py
@@ -20,6 +20,7 @@ AI-Generated Code - Claude Sonnet 4.6 (Anthropic)
 
 import importlib
 import pkgutil
+import re
 import types
 import typing
 from collections import Counter
@@ -125,6 +126,7 @@ class DatasetMeta:
     tags: tuple[str, ...] = ()
     deps_group: str | None = None
     license: str | None = None
+    checksums: tuple[tuple[str, str], ...] = ()
 
 
 def _normalize_source(source: str | tuple[str, ...] | list[str]) -> tuple[str, ...]:
@@ -204,6 +206,47 @@ def _validate_url_basenames_unique(name: str, source: tuple[str, ...]) -> None:
         )
 
 
+_CHECKSUM_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+def _normalize_checksums(
+    checksums: dict[str, str] | None,
+) -> tuple[tuple[str, str], ...]:
+    """Normalize the decorator's dict to a sorted tuple-of-pairs (mirrors
+    ``_normalize_source``); keeps ``DatasetMeta`` immutable and ``index.json``
+    deterministic."""
+    if not checksums:
+        return ()
+    return tuple(sorted(checksums.items()))
+
+
+def _validate_checksums(
+    name: str,
+    source: tuple[str, ...],
+    checksums: tuple[tuple[str, str], ...],
+) -> None:
+    """Each value is a ``sha256:<hex>`` digest; each key is the basename of a
+    declared ``url:`` source in this dataset."""
+    if not checksums:
+        return
+    url_basenames = {
+        url_path_basename(src[len("url:") :])
+        for src in source
+        if src.startswith("url:")
+    }
+    for basename, digest in checksums:
+        if not _CHECKSUM_RE.match(digest):
+            raise ValueError(
+                f"dataset {name!r} checksum for {basename!r} must be "
+                f"'sha256:<64 hex>', got {digest!r}"
+            )
+        if basename not in url_basenames:
+            raise ValueError(
+                f"dataset {name!r} checksum key {basename!r} is not the basename "
+                f"of any declared url: source {sorted(url_basenames)}"
+            )
+
+
 def extract_sample_type(cls: type) -> type:
     """First concrete (non-TypeVar) generic arg on any parameterized base in
     the MRO. Shared by ``@sieval_dataset`` (``Dataset[TSample]``) and
@@ -236,6 +279,7 @@ def sieval_dataset[T: type](
     tags: tuple[str, ...] = (),
     deps_group: str | None = None,
     license: str | None = None,
+    checksums: dict[str, str] | None = None,
 ) -> Callable[[T], T]:
     """Decorate a Dataset subclass to register its DatasetMeta.
 
@@ -255,6 +299,8 @@ def sieval_dataset[T: type](
         categories=categories,
         source=normalized_source,
     )
+    normalized_checksums = _normalize_checksums(checksums)
+    _validate_checksums(name, normalized_source, normalized_checksums)
     meta = DatasetMeta(
         name=name,
         display_name=display_name,
@@ -264,6 +310,7 @@ def sieval_dataset[T: type](
         tags=tags,
         deps_group=deps_group,
         license=license,
+        checksums=normalized_checksums,
     )
 
     def decorator(cls: T) -> T:
@@ -331,6 +378,7 @@ def dataset_meta_to_dict(meta: DatasetMeta) -> dict[str, Any]:
         "tags": list(meta.tags),
         "deps_group": meta.deps_group,
         "license": meta.license,
+        "checksums": dict(meta.checksums),
     }
 
 
@@ -356,6 +404,7 @@ def dataset_meta_from_dict(payload: dict[str, Any]) -> DatasetMeta:
         tags=tuple(payload.get("tags", ())),
         deps_group=payload.get("deps_group"),
         license=payload.get("license"),
+        checksums=tuple(sorted(payload.get("checksums", {}).items())),
     )
 
 

--- a/sieval/datasets/CLAUDE.md
+++ b/sieval/datasets/CLAUDE.md
@@ -12,5 +12,4 @@
 - `source` must use scheme `hf:` / `url:` / `local:` and is the authoritative origin consumed by `sieval dataset download`.
 - `deps_group` here is **loader-side** deps; evaluator-side deps stay on the Task.
 - `hf:` sources are revision-pinned; `url:` sources carry per-file `checksums` (sha256).
-  Edits to `source`/`checksums` require `python scripts/sync_meta_index.py` (runtime reads
-  `sieval/meta/index.json`).
+  Regenerate the meta index (`scripts/sync_meta_index.py`) after editing either.

--- a/sieval/datasets/CLAUDE.md
+++ b/sieval/datasets/CLAUDE.md
@@ -11,3 +11,6 @@
 - The sample `TypedDict` is the reverse-lookup key for `@sieval_task`; it must be globally unique across registered Datasets. `name` is also globally unique across Datasets and Tasks.
 - `source` must use scheme `hf:` / `url:` / `local:` and is the authoritative origin consumed by `sieval dataset download`.
 - `deps_group` here is **loader-side** deps; evaluator-side deps stay on the Task.
+- `hf:` sources are revision-pinned; `url:` sources carry per-file `checksums` (sha256).
+  Edits to `source`/`checksums` require `python scripts/sync_meta_index.py` (runtime reads
+  `sieval/meta/index.json`).

--- a/sieval/datasets/aime_2024.py
+++ b/sieval/datasets/aime_2024.py
@@ -13,6 +13,8 @@ from sieval.core.datasets import (
 )
 from sieval.core.utils.hf import ensure_dataset
 
+AIME_2024_REVISION = "2fe88a2f1091d5048c0f36abc874fb997b3dd99a"
+
 
 class AIME2024DatasetSample(TypedDict):
     problem: str
@@ -23,7 +25,7 @@ class AIME2024DatasetSample(TypedDict):
     name="aime_2024",
     display_name="AIME 2024",
     description="American Invitational Mathematics Examination 2024, 30 problems.",
-    source="hf:HuggingFaceH4/aime_2024",
+    source=f"hf:HuggingFaceH4/aime_2024@{AIME_2024_REVISION}",
     categories=(Category(Level1Category.MATHEMATICS, "CompetitionMath"),),
     tags=("english", "open-ended"),
     # Inherited from upstream AI-MO/aimo-validation-aime (Apache-2.0 on HF).

--- a/sieval/datasets/aime_2025.py
+++ b/sieval/datasets/aime_2025.py
@@ -13,6 +13,8 @@ from sieval.core.datasets import (
 )
 from sieval.core.utils.hf import ensure_dataset_list
 
+AIME_2025_REVISION = "a6ad95f611d72cf628a80b58bd0432ef6638f958"
+
 
 class AIME2025DatasetSample(TypedDict):
     question: str
@@ -23,7 +25,7 @@ class AIME2025DatasetSample(TypedDict):
     name="aime_2025",
     display_name="AIME 2025",
     description="American Invitational Mathematics Examination 2025, 30 problems.",
-    source="hf:opencompass/AIME2025",
+    source=f"hf:opencompass/AIME2025@{AIME_2025_REVISION}",
     categories=(Category(Level1Category.MATHEMATICS, "CompetitionMath"),),
     tags=("english", "open-ended"),
     license="MIT",

--- a/sieval/datasets/cmmlu.py
+++ b/sieval/datasets/cmmlu.py
@@ -42,6 +42,12 @@ class CMMLUDatasetSample(TypedDict):
     display_name="CMMLU",
     description="CMMLU Chinese multi-domain exam benchmark with 67 subjects.",
     source=f"url:{CMMLU_SOURCE_URL}",
+    # Key is the archive basename, which embeds the pinned commit SHA; bumping
+    # CMMLU_REVISION requires refreshing this digest (the key must equal the
+    # url: basename or @sieval_dataset registration fails).
+    checksums={
+        "d6e7b716d8ac694f38969a6c0407437d1fded799.zip": "sha256:154593336d5074d793ed990222876b83490b0aed97638a62618d1fe2da7c2cac",  # noqa: E501
+    },
     categories=(Category(Level1Category.KNOWLEDGE, "Multi-domain"),),
     tags=("chinese", "multiple-choice"),
     license="CC-BY-NC-SA-4.0",

--- a/sieval/datasets/cmmlu.py
+++ b/sieval/datasets/cmmlu.py
@@ -42,9 +42,8 @@ class CMMLUDatasetSample(TypedDict):
     display_name="CMMLU",
     description="CMMLU Chinese multi-domain exam benchmark with 67 subjects.",
     source=f"url:{CMMLU_SOURCE_URL}",
-    # Key is the archive basename, which embeds the pinned commit SHA; bumping
-    # CMMLU_REVISION requires refreshing this digest (the key must equal the
-    # url: basename or @sieval_dataset registration fails).
+    # Basename embeds the pinned commit SHA, so bumping CMMLU_REVISION also
+    # means refreshing this digest.
     checksums={
         "d6e7b716d8ac694f38969a6c0407437d1fded799.zip": "sha256:154593336d5074d793ed990222876b83490b0aed97638a62618d1fe2da7c2cac",  # noqa: E501
     },

--- a/sieval/datasets/downloaders/verify.py
+++ b/sieval/datasets/downloaders/verify.py
@@ -1,0 +1,49 @@
+"""Content-checksum verification for staged dataset files.
+
+Pure: hashes files under ``dest_root/<dataset_name>/`` and compares to
+``DatasetMeta.checksums``. Side effects (deleting a bad file, raising) are the
+caller's responsibility, so this stays reusable from read-only contexts.
+
+AI-Generated Code - Claude Opus 4.8 (Anthropic)
+"""
+
+import hashlib
+from dataclasses import dataclass
+from pathlib import Path
+
+from sieval.core.datasets.meta import DatasetMeta
+
+_CHUNK = 1 << 20
+
+
+def compute_sha256(path: Path) -> str:
+    """``sha256:<hex>`` of *path*'s bytes, streamed in chunks."""
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(_CHUNK), b""):
+            h.update(chunk)
+    return f"sha256:{h.hexdigest()}"
+
+
+@dataclass(frozen=True)
+class ChecksumMismatch:
+    basename: str
+    expected: str
+    actual: str | None  # None => declared file is missing
+
+
+def verify_checksums(meta: DatasetMeta, dest_root: Path) -> list[ChecksumMismatch]:
+    """Compare each declared checksum to the staged file; return mismatches.
+
+    Empty ``meta.checksums`` (all-``hf:`` datasets) returns ``[]``.
+    """
+    mismatches: list[ChecksumMismatch] = []
+    for basename, expected in meta.checksums:
+        path = dest_root / meta.name / basename
+        if not path.is_file():
+            mismatches.append(ChecksumMismatch(basename, expected, None))
+            continue
+        actual = compute_sha256(path)
+        if actual != expected:
+            mismatches.append(ChecksumMismatch(basename, expected, actual))
+    return mismatches

--- a/sieval/datasets/drop.py
+++ b/sieval/datasets/drop.py
@@ -27,6 +27,10 @@ class DROPDatasetSample(TypedDict):
         "url:https://openaipublic.blob.core.windows.net/simple-evals/drop_v0_train.jsonl.gz",
         "url:https://openaipublic.blob.core.windows.net/simple-evals/drop_v0_dev.jsonl.gz",
     ),
+    checksums={
+        "drop_v0_train.jsonl.gz": "sha256:d4a3a00ea2cfbe69d11f0bd24f5ba069731c645489bd39248b480d8eb34e1fb6",  # noqa: E501
+        "drop_v0_dev.jsonl.gz": "sha256:7a58d35552dc476699d87ee8af0254f63e9f00f5a7f6b8b033e11c933157e186",  # noqa: E501
+    },
     categories=(Category(Level1Category.LOGIC, "TextualReasoning"),),
     tags=("english", "open-ended"),
     license="CC-BY-SA-4.0",

--- a/sieval/datasets/gpqa_diamond.py
+++ b/sieval/datasets/gpqa_diamond.py
@@ -29,6 +29,9 @@ GPQADiamondDatasetSample = TypedDict(
     display_name="GPQA Diamond",
     description="Graduate-level science MCQ — diamond subset, 198 questions.",
     source="url:https://openaipublic.blob.core.windows.net/simple-evals/gpqa_diamond.csv",
+    checksums={
+        "gpqa_diamond.csv": "sha256:41d1213cd7a4998605a26c2798500652572007161b3a92817ba46b35befcd305",  # noqa: E501
+    },
     categories=(
         Category(Level1Category.LOGIC, "ComplexLogic"),
         Category(Level1Category.KNOWLEDGE, "STEM"),

--- a/sieval/datasets/ifeval.py
+++ b/sieval/datasets/ifeval.py
@@ -11,6 +11,8 @@ from sieval.core.datasets import (
 )
 from sieval.core.utils.hf import ensure_dataset
 
+IFEVAL_REVISION = "966cd89545d6b6acfd7638bc708b98261ca58e84"
+
 
 class IFEvalDatasetSample(TypedDict):
     key: str
@@ -23,7 +25,7 @@ class IFEvalDatasetSample(TypedDict):
     name="ifeval",
     display_name="IFEval",
     description="Instruction-Following Eval — 541 prompts with verifiable constraints.",
-    source="hf:google/IFEval",
+    source=f"hf:google/IFEval@{IFEVAL_REVISION}",
     categories=(Category(Level1Category.LANGUAGE, "InstructionFollowing"),),
     tags=("english", "open-ended"),
     license="Apache-2.0",

--- a/sieval/datasets/math_500.py
+++ b/sieval/datasets/math_500.py
@@ -13,6 +13,8 @@ from sieval.core.datasets import (
 )
 from sieval.core.utils.hf import ensure_dataset_dict
 
+MATH_500_REVISION = "6e4ed1a2a79af7d8630a6b768ec859cb5af4d3be"
+
 
 class MATH500DatasetSample(TypedDict):
     problem: str
@@ -23,7 +25,7 @@ class MATH500DatasetSample(TypedDict):
     name="math_500",
     display_name="MATH-500",
     description="Hendrycks MATH-500 subset — 500 problems across difficulty levels.",
-    source="hf:HuggingFaceH4/MATH-500",
+    source=f"hf:HuggingFaceH4/MATH-500@{MATH_500_REVISION}",
     categories=(Category(Level1Category.MATHEMATICS, "AdvancedMath"),),
     tags=("english", "open-ended"),
     license="MIT",

--- a/sieval/datasets/mmlu.py
+++ b/sieval/datasets/mmlu.py
@@ -75,6 +75,9 @@ def _process_sample(sample: dict) -> MMLUDatasetSample:
     display_name="MMLU",
     description="Massive Multitask Language Understanding — 57 academic subjects, MCQ.",
     source="url:https://openaipublic.blob.core.windows.net/simple-evals/mmlu.csv",
+    checksums={
+        "mmlu.csv": "sha256:15b6785d49e0012602e089558a7a0dfb916baf97e9295aa25b48062f13c6afbb",  # noqa: E501
+    },
     categories=(Category(Level1Category.KNOWLEDGE, "Multi-domain"),),
     tags=("english", "multiple-choice"),
     license="MIT",

--- a/sieval/datasets/mmlu_pro.py
+++ b/sieval/datasets/mmlu_pro.py
@@ -11,6 +11,10 @@ from sieval.core.datasets import (
 )
 from sieval.core.utils.hf import apply_eval_split, ensure_dataset_dict
 
+# Pinned to the snapshot behind current results. HF main has advanced since
+# (an eval.yaml-only change; sample data is byte-identical) — don't bump blindly.
+MMLU_PRO_REVISION = "54611cde22c74cca43dd78732198de6abe971398"
+
 
 class MMLUProDatasetSample(TypedDict):
     question: str
@@ -23,7 +27,7 @@ class MMLUProDatasetSample(TypedDict):
     name="mmlu_pro",
     display_name="MMLU-Pro",
     description="MMLU-Pro — harder MCQ with 10 options, filtered for reasoning.",
-    source="hf:TIGER-Lab/MMLU-Pro",
+    source=f"hf:TIGER-Lab/MMLU-Pro@{MMLU_PRO_REVISION}",
     categories=(Category(Level1Category.KNOWLEDGE, "Multi-domain"),),
     tags=("english", "multiple-choice"),
     license="MIT",

--- a/sieval/datasets/t_eval.py
+++ b/sieval/datasets/t_eval.py
@@ -13,6 +13,8 @@ from sieval.core.datasets import (
     sieval_dataset,
 )
 
+T_EVAL_REVISION = "af355ab2b62cdbae4262ac41c7529ffeae395012"
+
 
 class TEvalBeforeCallingDatasetSampleMetaData(TypedDict):
     response_format: Literal["json"]
@@ -29,7 +31,7 @@ class TEvalBeforeCallingDatasetSample(TypedDict):
     name="t_eval_before_calling",
     display_name="T-Eval Before-Calling",
     description="T-Eval tool-use benchmark — before-calling stage (plan/reason).",
-    source="hf:lovesnowbest/T-Eval",
+    source=f"hf:lovesnowbest/T-Eval@{T_EVAL_REVISION}",
     categories=(Category(Level1Category.AGENT, "ToolUseSimple"),),
     tags=("chinese", "english", "open-ended"),
     license="Apache-2.0",

--- a/sieval/meta/index.json
+++ b/sieval/meta/index.json
@@ -6,7 +6,7 @@
       "display_name": "AIME 2024",
       "description": "American Invitational Mathematics Examination 2024, 30 problems.",
       "source": [
-        "hf:HuggingFaceH4/aime_2024"
+        "hf:HuggingFaceH4/aime_2024@2fe88a2f1091d5048c0f36abc874fb997b3dd99a"
       ],
       "categories": [
         {
@@ -19,14 +19,15 @@
         "open-ended"
       ],
       "deps_group": null,
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "checksums": {}
     },
     {
       "name": "aime_2025",
       "display_name": "AIME 2025",
       "description": "American Invitational Mathematics Examination 2025, 30 problems.",
       "source": [
-        "hf:opencompass/AIME2025"
+        "hf:opencompass/AIME2025@a6ad95f611d72cf628a80b58bd0432ef6638f958"
       ],
       "categories": [
         {
@@ -39,7 +40,8 @@
         "open-ended"
       ],
       "deps_group": null,
-      "license": "MIT"
+      "license": "MIT",
+      "checksums": {}
     },
     {
       "name": "aime_2026",
@@ -59,7 +61,8 @@
         "open-ended"
       ],
       "deps_group": null,
-      "license": "CC-BY-NC-SA-4.0"
+      "license": "CC-BY-NC-SA-4.0",
+      "checksums": {}
     },
     {
       "name": "cmmlu",
@@ -79,7 +82,8 @@
         "multiple-choice"
       ],
       "deps_group": null,
-      "license": "CC-BY-NC-SA-4.0"
+      "license": "CC-BY-NC-SA-4.0",
+      "checksums": {}
     },
     {
       "name": "drop",
@@ -100,7 +104,11 @@
         "open-ended"
       ],
       "deps_group": null,
-      "license": "CC-BY-SA-4.0"
+      "license": "CC-BY-SA-4.0",
+      "checksums": {
+        "drop_v0_dev.jsonl.gz": "sha256:7a58d35552dc476699d87ee8af0254f63e9f00f5a7f6b8b033e11c933157e186",
+        "drop_v0_train.jsonl.gz": "sha256:d4a3a00ea2cfbe69d11f0bd24f5ba069731c645489bd39248b480d8eb34e1fb6"
+      }
     },
     {
       "name": "gpqa_diamond",
@@ -125,7 +133,10 @@
         "graduate-level"
       ],
       "deps_group": null,
-      "license": "CC-BY-4.0"
+      "license": "CC-BY-4.0",
+      "checksums": {
+        "gpqa_diamond.csv": "sha256:41d1213cd7a4998605a26c2798500652572007161b3a92817ba46b35befcd305"
+      }
     },
     {
       "name": "gsm8k",
@@ -146,7 +157,8 @@
         "open-ended"
       ],
       "deps_group": null,
-      "license": "MIT"
+      "license": "MIT",
+      "checksums": {}
     },
     {
       "name": "hmmt_feb_2026",
@@ -166,7 +178,8 @@
         "open-ended"
       ],
       "deps_group": null,
-      "license": "CC-BY-NC-SA-4.0"
+      "license": "CC-BY-NC-SA-4.0",
+      "checksums": {}
     },
     {
       "name": "human_eval",
@@ -187,14 +200,15 @@
         "code-exec"
       ],
       "deps_group": null,
-      "license": "MIT"
+      "license": "MIT",
+      "checksums": {}
     },
     {
       "name": "ifeval",
       "display_name": "IFEval",
       "description": "Instruction-Following Eval — 541 prompts with verifiable constraints.",
       "source": [
-        "hf:google/IFEval"
+        "hf:google/IFEval@966cd89545d6b6acfd7638bc708b98261ca58e84"
       ],
       "categories": [
         {
@@ -207,7 +221,8 @@
         "open-ended"
       ],
       "deps_group": null,
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "checksums": {}
     },
     {
       "name": "livecodebench_code_generation",
@@ -228,14 +243,15 @@
         "code-exec"
       ],
       "deps_group": null,
-      "license": "cc"
+      "license": "cc",
+      "checksums": {}
     },
     {
       "name": "math_500",
       "display_name": "MATH-500",
       "description": "Hendrycks MATH-500 subset — 500 problems across difficulty levels.",
       "source": [
-        "hf:HuggingFaceH4/MATH-500"
+        "hf:HuggingFaceH4/MATH-500@6e4ed1a2a79af7d8630a6b768ec859cb5af4d3be"
       ],
       "categories": [
         {
@@ -248,7 +264,8 @@
         "open-ended"
       ],
       "deps_group": null,
-      "license": "MIT"
+      "license": "MIT",
+      "checksums": {}
     },
     {
       "name": "mmlu",
@@ -268,14 +285,17 @@
         "multiple-choice"
       ],
       "deps_group": null,
-      "license": "MIT"
+      "license": "MIT",
+      "checksums": {
+        "mmlu.csv": "sha256:15b6785d49e0012602e089558a7a0dfb916baf97e9295aa25b48062f13c6afbb"
+      }
     },
     {
       "name": "mmlu_pro",
       "display_name": "MMLU-Pro",
       "description": "MMLU-Pro — harder MCQ with 10 options, filtered for reasoning.",
       "source": [
-        "hf:TIGER-Lab/MMLU-Pro"
+        "hf:TIGER-Lab/MMLU-Pro@54611cde22c74cca43dd78732198de6abe971398"
       ],
       "categories": [
         {
@@ -288,14 +308,15 @@
         "multiple-choice"
       ],
       "deps_group": null,
-      "license": "MIT"
+      "license": "MIT",
+      "checksums": {}
     },
     {
       "name": "t_eval_before_calling",
       "display_name": "T-Eval Before-Calling",
       "description": "T-Eval tool-use benchmark — before-calling stage (plan/reason).",
       "source": [
-        "hf:lovesnowbest/T-Eval"
+        "hf:lovesnowbest/T-Eval@af355ab2b62cdbae4262ac41c7529ffeae395012"
       ],
       "categories": [
         {
@@ -309,7 +330,8 @@
         "open-ended"
       ],
       "deps_group": null,
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "checksums": {}
     },
     {
       "name": "theoremqa",
@@ -334,7 +356,8 @@
         "theorem-driven"
       ],
       "deps_group": null,
-      "license": "MIT"
+      "license": "MIT",
+      "checksums": {}
     }
   ],
   "tasks": [

--- a/sieval/meta/index.json
+++ b/sieval/meta/index.json
@@ -83,7 +83,9 @@
       ],
       "deps_group": null,
       "license": "CC-BY-NC-SA-4.0",
-      "checksums": {}
+      "checksums": {
+        "d6e7b716d8ac694f38969a6c0407437d1fded799.zip": "sha256:154593336d5074d793ed990222876b83490b0aed97638a62618d1fe2da7c2cac"
+      }
     },
     {
       "name": "drop",

--- a/tests/unit/cli/dataset/test_commands.py
+++ b/tests/unit/cli/dataset/test_commands.py
@@ -452,6 +452,32 @@ def test_download_one_deletes_and_raises_on_checksum_mismatch(tmp_path):
     assert not (tmp_path / "ds" / "f.csv").exists()  # bad file deleted
 
 
+def test_download_one_verifies_even_when_already_present(tmp_path):
+    import pytest
+
+    from sieval.cli.dataset.commands import _download_one
+    from sieval.core.datasets.meta import Category, DatasetMeta, Level1Category
+
+    meta = DatasetMeta(
+        name="ds",
+        display_name="ds",
+        description="d",
+        source=("url:https://example.com/f.csv",),
+        categories=(Category(Level1Category.CODE, "CodeGeneration"),),
+        checksums=(("f.csv", "sha256:" + "a" * 64),),
+    )
+    fake_handler = MagicMock()
+    fake_handler.is_downloaded.return_value = True  # already present, download skipped
+
+    with (
+        patch("sieval.cli.dataset.commands.resolve_handler", return_value=fake_handler),
+        pytest.raises(RuntimeError, match="checksum verification failed"),
+    ):
+        _download_one(meta, tmp_path, force=False)
+
+    fake_handler.download.assert_not_called()  # verify ran despite the skip
+
+
 def test_dataset_show_text_renders_ready_and_missing(tmp_path, monkeypatch):
     """ready=no path renders the Missing: block + suppresses downloaded."""
     monkeypatch.setenv("SIEVAL_DATA_DIR", str(tmp_path))

--- a/tests/unit/cli/dataset/test_commands.py
+++ b/tests/unit/cli/dataset/test_commands.py
@@ -82,6 +82,7 @@ def test_dataset_download_by_name_invokes_handler(tmp_path):
             "sieval.datasets.downloaders.url.URLHandler.is_downloaded",
             return_value=False,
         ),
+        patch("sieval.cli.dataset.commands.verify_checksums", return_value=[]),
     ):
         mock_url_dl.return_value = tmp_path
         result = runner.invoke(
@@ -104,6 +105,7 @@ def test_dataset_download_skips_when_already_present(tmp_path):
             "sieval.datasets.downloaders.hf.HFHandler.is_downloaded", return_value=True
         ),
         patch("sieval.datasets.downloaders.hf.HFHandler.download") as mock_hf_dl,
+        patch("sieval.cli.dataset.commands.verify_checksums", return_value=[]),
     ):
         result = runner.invoke(
             dataset_app,
@@ -121,6 +123,7 @@ def test_dataset_download_force_redownloads(tmp_path):
             return_value=True,
         ),
         patch("sieval.datasets.downloaders.url.URLHandler.download") as mock_url_dl,
+        patch("sieval.cli.dataset.commands.verify_checksums", return_value=[]),
     ):
         mock_url_dl.return_value = tmp_path
         result = runner.invoke(
@@ -156,6 +159,7 @@ def test_dataset_download_all_iterates_all_pilots(tmp_path):
         ) as mock_url_probe,
         patch("sieval.datasets.downloaders.hf.HFHandler.download") as mock_hf,
         patch("sieval.datasets.downloaders.url.URLHandler.download") as mock_url,
+        patch("sieval.cli.dataset.commands.verify_checksums", return_value=[]),
     ):
         result = runner.invoke(
             dataset_app,

--- a/tests/unit/cli/dataset/test_commands.py
+++ b/tests/unit/cli/dataset/test_commands.py
@@ -4,7 +4,7 @@ AI-Generated Code - Claude Sonnet 4.6 (Anthropic)
 """
 
 import json
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from typer.testing import CliRunner
 
@@ -414,6 +414,38 @@ def test_dataset_list_text_shows_ready_and_drops_downloaded(tmp_path, monkeypatc
     assert result.exit_code == 0
     assert "READY" in result.output
     assert "DOWNLOADED" not in result.output
+
+
+def test_download_one_deletes_and_raises_on_checksum_mismatch(tmp_path):
+    import pytest
+
+    from sieval.cli.dataset.commands import _download_one
+    from sieval.core.datasets.meta import Category, DatasetMeta, Level1Category
+
+    meta = DatasetMeta(
+        name="ds",
+        display_name="ds",
+        description="d",
+        source=("url:https://example.com/f.csv",),
+        categories=(Category(Level1Category.CODE, "CodeGeneration"),),
+        checksums=(("f.csv", "sha256:" + "a" * 64),),
+    )
+
+    def fake_download(_source, dest_root, dataset_name, **_kwargs):  # noqa: ARG001
+        (dest_root / dataset_name).mkdir(parents=True, exist_ok=True)
+        (dest_root / dataset_name / "f.csv").write_bytes(b"wrong-bytes")
+
+    fake_handler = MagicMock()
+    fake_handler.is_downloaded.return_value = False
+    fake_handler.download.side_effect = fake_download
+
+    with (
+        patch("sieval.cli.dataset.commands.resolve_handler", return_value=fake_handler),
+        pytest.raises(RuntimeError, match="checksum verification failed"),
+    ):
+        _download_one(meta, tmp_path, force=False)
+
+    assert not (tmp_path / "ds" / "f.csv").exists()  # bad file deleted
 
 
 def test_dataset_show_text_renders_ready_and_missing(tmp_path, monkeypatch):

--- a/tests/unit/core/datasets/test_meta.py
+++ b/tests/unit/core/datasets/test_meta.py
@@ -502,8 +502,6 @@ class CkSample(TypedDict):
 
 
 def test_checksums_normalized_sorted_and_round_trips():
-    from sieval.core.datasets.meta import dataset_meta_to_dict
-
     digest = "sha256:" + "a" * 64
 
     @sieval_dataset(

--- a/tests/unit/core/datasets/test_meta.py
+++ b/tests/unit/core/datasets/test_meta.py
@@ -15,6 +15,7 @@ from sieval.core.datasets.meta import (
     Category,
     DatasetMeta,
     Level1Category,
+    dataset_meta_from_dict,
     dataset_meta_to_dict,
     get_dataset_meta,
     iter_dataset_metas,
@@ -100,6 +101,7 @@ def test_dataset_meta_to_dict_roundtrip():
         "tags": [],
         "deps_group": None,
         "license": None,
+        "checksums": {},
     }
 
 
@@ -493,3 +495,64 @@ def test_sieval_dataset_accepts_different_url_basenames():
     # Must not have raised; cleanup: remove from registry to avoid polluting later tests
     DATASET_REGISTRY.pop("ok_test_distinct_basenames", None)
     SAMPLE_TO_DATASET.pop(OkSample, None)
+
+
+class CkSample(TypedDict):
+    prompt: str
+
+
+def test_checksums_normalized_sorted_and_round_trips():
+    from sieval.core.datasets.meta import dataset_meta_to_dict
+
+    digest = "sha256:" + "a" * 64
+
+    @sieval_dataset(
+        name="ck",
+        display_name="Ck",
+        description="checksum dataset.",
+        source="url:https://example.com/y.csv",
+        categories=(Category(Level1Category.CODE, "CodeGeneration"),),
+        checksums={"y.csv": digest},
+    )
+    class CkDataset(Dataset[CkSample]):
+        pass
+
+    meta = get_dataset_meta(CkDataset)
+    assert meta.checksums == (("y.csv", digest),)
+
+    wire = dataset_meta_to_dict(meta)
+    assert wire["checksums"] == {"y.csv": digest}
+    assert dataset_meta_from_dict(wire).checksums == meta.checksums
+    # absent key defaults to empty tuple
+    no_ck = {k: v for k, v in wire.items() if k != "checksums"}
+    assert dataset_meta_from_dict(no_ck).checksums == ()
+
+
+def test_checksums_bad_format_rejected():
+    with pytest.raises(ValueError, match="sha256"):
+
+        @sieval_dataset(
+            name="ckbad",
+            display_name="CkBad",
+            description="bad checksum.",
+            source="url:https://example.com/y.csv",
+            categories=(Category(Level1Category.CODE, "CodeGeneration"),),
+            checksums={"y.csv": "deadbeef"},
+        )
+        class CkBadDataset(Dataset[CkSample]):
+            pass
+
+
+def test_checksums_key_must_be_url_basename():
+    with pytest.raises(ValueError, match="basename"):
+
+        @sieval_dataset(
+            name="ckkey",
+            display_name="CkKey",
+            description="bad key.",
+            source="url:https://example.com/y.csv",
+            categories=(Category(Level1Category.CODE, "CodeGeneration"),),
+            checksums={"other.csv": "sha256:" + "a" * 64},
+        )
+        class CkKeyDataset(Dataset[CkSample]):
+            pass

--- a/tests/unit/datasets/downloaders/test_verify.py
+++ b/tests/unit/datasets/downloaders/test_verify.py
@@ -1,0 +1,53 @@
+from sieval.core.datasets.meta import Category, DatasetMeta, Level1Category
+from sieval.datasets.downloaders.verify import (
+    ChecksumMismatch,
+    compute_sha256,
+    verify_checksums,
+)
+
+
+def _meta(name: str, checksums: tuple[tuple[str, str], ...]) -> DatasetMeta:
+    return DatasetMeta(
+        name=name,
+        display_name=name,
+        description="d",
+        source=("url:https://example.com/f.bin",),
+        categories=(Category(Level1Category.CODE, "CodeGeneration"),),
+        checksums=checksums,
+    )
+
+
+def test_compute_sha256_format(tmp_path):
+    p = tmp_path / "f.bin"
+    p.write_bytes(b"hello")
+    digest = compute_sha256(p)
+    assert digest.startswith("sha256:")
+    assert len(digest) == len("sha256:") + 64
+
+
+def test_verify_match_returns_empty(tmp_path):
+    (tmp_path / "ds").mkdir()
+    f = tmp_path / "ds" / "f.bin"
+    f.write_bytes(b"hello")
+    meta = _meta("ds", (("f.bin", compute_sha256(f)),))
+    assert verify_checksums(meta, tmp_path) == []
+
+
+def test_verify_corruption_detected(tmp_path):
+    (tmp_path / "ds").mkdir()
+    f = tmp_path / "ds" / "f.bin"
+    f.write_bytes(b"hello")
+    good = compute_sha256(f)
+    f.write_bytes(b"tampered")
+    out = verify_checksums(_meta("ds", (("f.bin", good),)), tmp_path)
+    assert len(out) == 1 and out[0].basename == "f.bin"
+    assert out[0].actual is not None and out[0].actual != good
+
+
+def test_verify_missing_file(tmp_path):
+    out = verify_checksums(_meta("ds", (("f.bin", "sha256:" + "a" * 64),)), tmp_path)
+    assert out == [ChecksumMismatch("f.bin", "sha256:" + "a" * 64, None)]
+
+
+def test_verify_empty_checksums_is_noop(tmp_path):
+    assert verify_checksums(_meta("ds", ()), tmp_path) == []

--- a/tests/unit/datasets/downloaders/test_verify.py
+++ b/tests/unit/datasets/downloaders/test_verify.py
@@ -23,6 +23,9 @@ def test_compute_sha256_format(tmp_path):
     digest = compute_sha256(p)
     assert digest.startswith("sha256:")
     assert len(digest) == len("sha256:") + 64
+    assert digest == (
+        "sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+    )
 
 
 def test_verify_match_returns_empty(tmp_path):
@@ -42,6 +45,7 @@ def test_verify_corruption_detected(tmp_path):
     out = verify_checksums(_meta("ds", (("f.bin", good),)), tmp_path)
     assert len(out) == 1 and out[0].basename == "f.bin"
     assert out[0].actual is not None and out[0].actual != good
+    assert out[0].expected == good
 
 
 def test_verify_missing_file(tmp_path):

--- a/tests/unit/meta/test_loader.py
+++ b/tests/unit/meta/test_loader.py
@@ -44,7 +44,9 @@ def test_aime_2024_dataset_round_trips():
     assert aime.display_name == "AIME 2024"
     assert aime.license == "Apache-2.0"
     # Single-source on wire = 1-element list → reconstructed as 1-tuple.
-    assert aime.source == ("hf:HuggingFaceH4/aime_2024",)
+    assert aime.source == (
+        "hf:HuggingFaceH4/aime_2024@2fe88a2f1091d5048c0f36abc874fb997b3dd99a",
+    )
     assert any(c.level1 is Level1Category.MATHEMATICS for c in aime.categories)
 
 

--- a/tests/unit/scripts/test_check_preflight.py
+++ b/tests/unit/scripts/test_check_preflight.py
@@ -21,6 +21,7 @@ if _SCRIPTS_DIR not in sys.path:
 from check_preflight import (  # noqa: E402  # type: ignore[unresolved-import]  # scripts/ added to sys.path at runtime
     CheckResult,
     PreflightRunner,
+    _dataset_integrity_violations,
     format_json,
     format_text,
     main,
@@ -1354,28 +1355,20 @@ class TestDatasetIntegrity:
         )
 
     def test_unpinned_hf_flagged(self):
-        from check_preflight import _dataset_integrity_violations
-
         out = _dataset_integrity_violations([self._meta("a", ["hf:org/a"])])
         assert len(out) == 1 and "a" in out[0]
         assert "hf source not pinned" in out[0]
 
     def test_url_without_checksum_flagged(self):
-        from check_preflight import _dataset_integrity_violations
-
         out = _dataset_integrity_violations([self._meta("b", ["url:https://x/y.csv"])])
         assert len(out) == 1 and "b" in out[0]
         assert "url source missing checksum" in out[0]
 
     def test_local_source_exempt(self):
-        from check_preflight import _dataset_integrity_violations
-
         out = _dataset_integrity_violations([self._meta("c", ["local:/data/c"])])
         assert out == []
 
     def test_pinned_and_checksummed_pass(self):
-        from check_preflight import _dataset_integrity_violations
-
         metas = [
             self._meta("a", ["hf:org/a@" + "0" * 40]),
             self._meta(

--- a/tests/unit/scripts/test_check_preflight.py
+++ b/tests/unit/scripts/test_check_preflight.py
@@ -1358,12 +1358,20 @@ class TestDatasetIntegrity:
 
         out = _dataset_integrity_violations([self._meta("a", ["hf:org/a"])])
         assert len(out) == 1 and "a" in out[0]
+        assert "hf source not pinned" in out[0]
 
     def test_url_without_checksum_flagged(self):
         from check_preflight import _dataset_integrity_violations
 
         out = _dataset_integrity_violations([self._meta("b", ["url:https://x/y.csv"])])
         assert len(out) == 1 and "b" in out[0]
+        assert "url source missing checksum" in out[0]
+
+    def test_local_source_exempt(self):
+        from check_preflight import _dataset_integrity_violations
+
+        out = _dataset_integrity_violations([self._meta("c", ["local:/data/c"])])
+        assert out == []
 
     def test_pinned_and_checksummed_pass(self):
         from check_preflight import _dataset_integrity_violations

--- a/tests/unit/scripts/test_check_preflight.py
+++ b/tests/unit/scripts/test_check_preflight.py
@@ -1364,6 +1364,13 @@ class TestDatasetIntegrity:
         assert len(out) == 1 and "b" in out[0]
         assert "url source missing checksum" in out[0]
 
+    def test_malformed_hf_pin_flagged_not_raised(self):
+        # Trailing '@' makes parse_hf_source raise; the check must report it as
+        # a violation, not abort the whole preflight with a traceback.
+        out = _dataset_integrity_violations([self._meta("d", ["hf:org/d@"])])
+        assert len(out) == 1 and "d" in out[0]
+        assert "hf source not pinned" in out[0]
+
     def test_local_source_exempt(self):
         out = _dataset_integrity_violations([self._meta("c", ["local:/data/c"])])
         assert out == []

--- a/tests/unit/scripts/test_check_preflight.py
+++ b/tests/unit/scripts/test_check_preflight.py
@@ -1338,3 +1338,43 @@ class TestMainNameGuard:
         assert code in (0, 1)
         captured = capsys.readouterr()
         assert "check_links" in captured.out
+
+
+class TestDatasetIntegrity:
+    def _meta(self, name, source, checksums=()):
+        from sieval.core.datasets.meta import Category, DatasetMeta, Level1Category
+
+        return DatasetMeta(
+            name=name,
+            display_name=name,
+            description="d",
+            source=tuple(source),
+            categories=(Category(Level1Category.CODE, "CodeGeneration"),),
+            checksums=tuple(checksums),
+        )
+
+    def test_unpinned_hf_flagged(self):
+        from check_preflight import _dataset_integrity_violations
+
+        out = _dataset_integrity_violations([self._meta("a", ["hf:org/a"])])
+        assert len(out) == 1 and "a" in out[0]
+
+    def test_url_without_checksum_flagged(self):
+        from check_preflight import _dataset_integrity_violations
+
+        out = _dataset_integrity_violations([self._meta("b", ["url:https://x/y.csv"])])
+        assert len(out) == 1 and "b" in out[0]
+
+    def test_pinned_and_checksummed_pass(self):
+        from check_preflight import _dataset_integrity_violations
+
+        metas = [
+            self._meta("a", ["hf:org/a@" + "0" * 40]),
+            self._meta(
+                "b",
+                ["url:https://x/y.csv"],
+                checksums=[("y.csv", "sha256:" + "a" * 64)],
+            ),
+            self._meta("c", ["local:/data/c"]),  # local exempt
+        ]
+        assert _dataset_integrity_violations(metas) == []


### PR DESCRIPTION
## Type

- feature — new benchmark, task, or capability

## Summary

Make the data behind a score reproducible by pinning dataset origins and verifying content.

- **Pin all HF dataset sources to a revision** (`hf:org/name@<sha>`) so `sieval dataset download` fetches a fixed snapshot, not whatever `main` points to at download time.
- **Add `checksums={basename: "sha256:<hex>"}` to `@sieval_dataset`** for `url:` datasets (which have no commit to pin). Dict on the decorator surface; stored as a sorted tuple-of-pairs on the frozen `DatasetMeta`; validated at registration; round-tripped through the `index.json` wire format (`schema_version` stays `1` — additive optional field).
- **Verify staged `url:` files against their sha256 at download time** — strict, delete-on-mismatch, with a re-run hint. The verifier (`sieval/datasets/downloaders/verify.py`) is pure/scheme-agnostic; deletion+raise live in `_download_one`. No `SourceHandler` Protocol change.
- **Enforce the convention in preflight `check_datasets`**: every `hf:` source must be pinned, every `url:` source must be checksummed (`local:` exempt) — so new datasets can't regress.
- **Regenerate `sieval/meta/index.json`** — the runtime reads metas from the index, not the live registry, so pins/checksums are inert until regeneration (`check_meta_index_sync` guards this).
- `human_eval` was the one remaining unpinned `hf:` source on `main`; this PR pins it too, so the new preflight gate is green repo-wide (pin set: 9 HF datasets + 4 URL checksums).
- Content verification targets data-payload files only (commit drift ≠ data drift): e.g. MMLU-Pro's local snapshot differs from HF `main` solely by an `eval.yaml` annotation while the sample parquets are byte-identical, so it is deliberately pinned to the snapshot behind current results.

## Test Plan

### Automated

- [x] Lint/format clean (`ruff check && ruff format --check`)
- [x] Type check clean (`ty check`)
- [x] Unit tests pass (`pdm run pytest`) — 1946 passed

### Manual

- [x] All 4 URL checksums (`drop` ×2, `gpqa_diamond`, `mmlu`) verified against the canonical files via `sha256sum`.
- [x] `sieval dataset download` verified end-to-end (no false checksum failures on matching data).
- [x] Full `python scripts/check_preflight.py` exits 0 — all checks PASS, including `check_meta_index_sync` and the new `check_datasets` source-integrity step.

## Checklist

### Required (all PRs)

- [x] PR title follows conventional format (`type(scope): description`)
- [x] No internal paths, credentials, or personal info in committed files
- [x] AI-generated code has `AI-Generated Code - <model> (<provider>)` in module docstring (new file `verify.py`)
- [x] No new upper-layer dependencies added to `core/`
- [x] Deleted code verified — no production code deleted (only stale test expectations updated)

### If: Breaking Change

- [x] Behavior change noted: `sieval dataset download` now fetches the pinned revision and a `url:` download aborts (deleting the bad file) if its sha256 does not match. Recovery is the reproducibility contract's standard pair — re-run the download, or reconcile the declared revision/checksum. Existing on-disk mirrors are not auto-refreshed (the `is_downloaded` path-existence check is unchanged); a fresh download gets the pinned/verified data.
