### PR TITLE
feat(cmmlu): add CMMLU few-shot base-model task and dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ SiEval is a **model delivery quality verification system** with an asynchronous 
 - **Asynchronous streaming** — process samples concurrently without waiting for batch completion
 - **Iterative feedback loop** — multi-turn evaluation with feedback
 - **Resilient persistence** — sharded, append-only storage for crash recovery
-- **11 mainstream benchmarks** — AIME 2024/2025, DROP, GPQA-Diamond, HumanEval, IFEval, LiveCodeBench, MATH-500, MMLU, MMLU-Pro, T-Eval (math, code, reasoning, knowledge, instruction-following, tool-use)
+- **13 registered benchmark datasets** — AIME 2024, AIME 2025, CMMLU, DROP, GPQA-Diamond, GSM8K, HumanEval, IFEval, LiveCodeBench, MATH-500, MMLU, MMLU-Pro, T-Eval (math, code, reasoning, knowledge, instruction-following, tool-use)
 - **Type-safe pipelines** — fully typed task stages (preprocess → infer → postprocess → feedback)
 - **YAML-based configuration** — batch evaluation with model derivation and quota allocation
 - **Inference orchestration** — recipe-driven inference with auto-resolve and backend abstraction (vLLM, SGLang)

--- a/sieval/core/models/gen_model.py
+++ b/sieval/core/models/gen_model.py
@@ -1,8 +1,30 @@
 """GenModel: text completions API backend."""
 
+from collections.abc import Mapping, Sequence
 from typing import override
 
 from .model import Model, ModelOutput, ModelUsage
+
+
+def _completion_top_logprobs(raw: object) -> list[dict[str, float]]:
+    if not isinstance(raw, Sequence) or isinstance(raw, str | bytes):
+        return []
+
+    top_logprobs = []
+    for item in raw:
+        if item is None:
+            top_logprobs.append({})
+            continue
+        if not isinstance(item, Mapping):
+            continue
+        top_logprobs.append(
+            {
+                token: float(logprob)
+                for token, logprob in item.items()
+                if isinstance(token, str) and isinstance(logprob, int | float)
+            }
+        )
+    return top_logprobs
 
 
 class GenModel(Model[str]):
@@ -133,6 +155,7 @@ class GenModel(Model[str]):
         usage: ModelUsage | None = None
         tokens: list[str] = []
         token_logprobs: list[float | None] = []
+        top_token_logprobs: list[dict[str, float]] = []
         saw_logprobs = False
 
         # Snapshot params for stable meta serialization
@@ -148,7 +171,7 @@ class GenModel(Model[str]):
         if stream_mode and "stream_options" not in request_params:
             request_params["stream_options"] = {"include_usage": True}
 
-        resp = await self._client.completions.create(  # type: ignore[no-matching-overload]
+        resp = await self._client.completions.create(  # ty: ignore[no-matching-overload]
             model=self._model,
             prompt=prompt,
             **request_params,
@@ -178,6 +201,11 @@ class GenModel(Model[str]):
                                     tokens.extend(logprobs_obj.tokens)
                                 if logprobs_obj.token_logprobs:
                                     token_logprobs.extend(logprobs_obj.token_logprobs)
+                                top_token_logprobs.extend(
+                                    _completion_top_logprobs(
+                                        getattr(logprobs_obj, "top_logprobs", None)
+                                    )
+                                )
 
                 chunk_usage = getattr(chunk, "usage", None)
                 if chunk_usage is not None:
@@ -204,6 +232,11 @@ class GenModel(Model[str]):
                             tokens.extend(logprobs_obj.tokens)
                         if logprobs_obj.token_logprobs:
                             token_logprobs.extend(logprobs_obj.token_logprobs)
+                        top_token_logprobs.extend(
+                            _completion_top_logprobs(
+                                getattr(logprobs_obj, "top_logprobs", None)
+                            )
+                        )
 
             raw_usage = resp.usage
             if raw_usage is not None:
@@ -225,6 +258,7 @@ class GenModel(Model[str]):
             finish_reasons=finish_reasons,
             logprobs_tokens=tokens,
             logprobs=token_logprobs,
+            top_logprobs=top_token_logprobs or None,
             usage=usage,
             request_params=request_params,
             response_model=response_model,

--- a/sieval/core/models/model.py
+++ b/sieval/core/models/model.py
@@ -68,6 +68,7 @@ class ModelOutput:
     reasoning_texts: list[str] | None = None
     logprobs_tokens: list[str] | None = None
     logprobs: list[float | None] | None = None
+    top_logprobs: list[dict[str, float]] | None = None
     usage: ModelUsage | None = None
     request_params: dict[str, JSONValue] | None = None
     # From API response — what the server actually used

--- a/sieval/datasets/__init__.pyi
+++ b/sieval/datasets/__init__.pyi
@@ -9,6 +9,10 @@ from .aime_2025 import (
     AIME2025Dataset,
     AIME2025DatasetSample,
 )
+from .cmmlu import (
+    CMMLUDataset,
+    CMMLUDatasetSample,
+)
 from .drop import (
     DROPDataset,
     DROPDatasetSample,
@@ -59,6 +63,8 @@ __all__ = [
     "AIME2024DatasetSample",
     "AIME2025Dataset",
     "AIME2025DatasetSample",
+    "CMMLUDataset",
+    "CMMLUDatasetSample",
     "DROPDataset",
     "DROPDatasetSample",
     "GPQADiamondDataset",

--- a/sieval/datasets/cmmlu.py
+++ b/sieval/datasets/cmmlu.py
@@ -1,0 +1,311 @@
+"""
+CMMLU dataset loader.
+
+AI-Generated Code - GPT-5.5 (OpenAI)
+"""
+
+import csv
+import io
+import zipfile
+from collections.abc import Mapping
+from pathlib import Path, PurePosixPath
+from typing import Any, TypedDict, override
+
+from datasets import Dataset as HFDataset
+from datasets import DatasetDict as HFDatasetDict
+
+from sieval.core.datasets import Category, Dataset, Level1Category, sieval_dataset
+from sieval.core.utils.hf import ensure_dataset_dict
+
+CMMLU_REVISION = "d6e7b716d8ac694f38969a6c0407437d1fded799"
+CMMLU_SOURCE_URL = f"https://github.com/haonan-li/CMMLU/archive/{CMMLU_REVISION}.zip"
+
+
+class CMMLUDatasetSample(TypedDict):
+    question: str
+    A: str
+    B: str
+    C: str
+    D: str
+    answer: str
+    subject: str
+
+
+@sieval_dataset(
+    name="cmmlu",
+    display_name="CMMLU",
+    description="CMMLU Chinese multi-domain exam benchmark with 67 subjects.",
+    source=f"url:{CMMLU_SOURCE_URL}",
+    categories=(Category(Level1Category.KNOWLEDGE, "Multi-domain"),),
+    tags=("chinese", "multiple-choice"),
+)
+class CMMLUDataset(Dataset[CMMLUDatasetSample]):
+    SUBJECTS = [
+        "agronomy",
+        "anatomy",
+        "ancient_chinese",
+        "arts",
+        "astronomy",
+        "business_ethics",
+        "chinese_civil_service_exam",
+        "chinese_driving_rule",
+        "chinese_food_culture",
+        "chinese_foreign_policy",
+        "chinese_history",
+        "chinese_literature",
+        "chinese_teacher_qualification",
+        "clinical_knowledge",
+        "college_actuarial_science",
+        "college_education",
+        "college_engineering_hydrology",
+        "college_law",
+        "college_mathematics",
+        "college_medical_statistics",
+        "college_medicine",
+        "computer_science",
+        "computer_security",
+        "conceptual_physics",
+        "construction_project_management",
+        "economics",
+        "education",
+        "electrical_engineering",
+        "elementary_chinese",
+        "elementary_commonsense",
+        "elementary_information_and_technology",
+        "elementary_mathematics",
+        "ethnology",
+        "food_science",
+        "genetics",
+        "global_facts",
+        "high_school_biology",
+        "high_school_chemistry",
+        "high_school_geography",
+        "high_school_mathematics",
+        "high_school_physics",
+        "high_school_politics",
+        "human_sexuality",
+        "international_law",
+        "journalism",
+        "jurisprudence",
+        "legal_and_moral_basis",
+        "logical",
+        "machine_learning",
+        "management",
+        "marketing",
+        "marxist_theory",
+        "modern_chinese",
+        "nutrition",
+        "philosophy",
+        "professional_accounting",
+        "professional_law",
+        "professional_medicine",
+        "professional_psychology",
+        "public_relations",
+        "security_study",
+        "sociology",
+        "sports_science",
+        "traditional_chinese_medicine",
+        "virology",
+        "world_history",
+        "world_religions",
+    ]
+
+    @override
+    def load(
+        self,
+        name_or_path: str,
+        subjects: list[str] | None = None,
+        **kwargs: Any,
+    ) -> HFDatasetDict:
+        _ = kwargs
+        subjects_to_load = subjects or self.SUBJECTS
+        path = Path(name_or_path)
+
+        if path.is_file() and path.suffix == ".zip":
+            return self._load_zip(path, subjects_to_load)
+
+        if path.is_dir():
+            zip_path = _find_zip(path)
+            if zip_path is not None:
+                return self._load_zip(zip_path, subjects_to_load)
+
+            csv_root = _find_csv_root(path)
+            if csv_root is not None:
+                return self._load_csv_root(csv_root, subjects_to_load)
+
+        raise FileNotFoundError(
+            "CMMLU data must be a GitHub archive zip or a directory containing "
+            "data/dev/*.csv and data/test/*.csv."
+        )
+
+    def _load_zip(
+        self,
+        zip_path: Path,
+        subjects_to_load: list[str],
+    ) -> HFDatasetDict:
+        samples: dict[str, list[CMMLUDatasetSample]] = {"dev": [], "test": []}
+        with zipfile.ZipFile(zip_path) as archive:
+            names = archive.namelist()
+            for split in ("dev", "test"):
+                for subject in subjects_to_load:
+                    member = _find_zip_csv_member(names, split, subject)
+                    if member is None:
+                        continue
+                    with archive.open(member) as raw_file:
+                        text_file = io.TextIOWrapper(
+                            raw_file,
+                            encoding="utf-8-sig",
+                            newline="",
+                        )
+                        samples[split].extend(
+                            self._process_csv_rows(text_file, subject)
+                        )
+        return _dataset_dict_from_samples(samples)
+
+    def _load_csv_root(
+        self,
+        data_root: Path,
+        subjects_to_load: list[str],
+    ) -> HFDatasetDict:
+        samples: dict[str, list[CMMLUDatasetSample]] = {"dev": [], "test": []}
+        for subject in subjects_to_load:
+            for split in ("dev", "test"):
+                csv_path = data_root / split / f"{subject}.csv"
+                if not csv_path.exists():
+                    continue
+                with csv_path.open(encoding="utf-8-sig", newline="") as csv_file:
+                    samples[split].extend(self._process_csv_rows(csv_file, subject))
+        return _dataset_dict_from_samples(samples)
+
+    def _process_csv_rows(
+        self,
+        csv_file: io.TextIOBase,
+        subject: str,
+    ) -> list[CMMLUDatasetSample]:
+        reader = csv.DictReader(csv_file)
+        return [self._process_sample(row, subject) for row in reader]
+
+    def _process_sample(
+        self,
+        sample: Mapping[str, object],
+        subject: str | None = None,
+    ) -> CMMLUDatasetSample:
+        if _has_structured_fields(sample):
+            return _process_structured_sample(sample, subject)
+
+        raw_string = _find_raw_csv_row(sample)
+        if raw_string:
+            row = next(csv.reader([raw_string]))
+            if len(row) >= 7:
+                return {
+                    "question": row[1].strip(),
+                    "A": row[2].strip(),
+                    "B": row[3].strip(),
+                    "C": row[4].strip(),
+                    "D": row[5].strip(),
+                    "answer": row[6].strip().upper(),
+                    "subject": subject or str(sample.get("subject", "")),
+                }
+
+        raise ValueError(
+            "Malformed CMMLU row for subject "
+            f"{subject or str(sample.get('subject', ''))!r}: expected structured "
+            "question/A-D/answer fields or a >=7-column CSV row, got keys "
+            f"{sorted(sample.keys())}."
+        )
+
+
+def _has_structured_fields(sample: Mapping[str, object]) -> bool:
+    return any(key in sample for key in ("question", "Question"))
+
+
+def _find_zip(root: Path) -> Path | None:
+    preferred = root / f"{CMMLU_REVISION}.zip"
+    if preferred.exists():
+        return preferred
+
+    zip_files = sorted(root.glob("*.zip"))
+    if len(zip_files) == 1:
+        return zip_files[0]
+
+    for zip_file in zip_files:
+        if zip_file.name == "cmmlu_v1_0_1.zip":
+            return zip_file
+    return None
+
+
+def _find_csv_root(root: Path) -> Path | None:
+    candidates = [root / "data", root]
+    candidates.extend(
+        child / "data" for child in sorted(root.iterdir()) if child.is_dir()
+    )
+    for candidate in candidates:
+        if (candidate / "dev").is_dir() and (candidate / "test").is_dir():
+            return candidate
+    return None
+
+
+def _find_zip_csv_member(
+    names: list[str],
+    split: str,
+    subject: str,
+) -> str | None:
+    suffixes = (
+        ("data", split, f"{subject}.csv"),
+        (split, f"{subject}.csv"),
+    )
+    for name in names:
+        parts = PurePosixPath(name).parts
+        if any(parts[-len(suffix) :] == suffix for suffix in suffixes):
+            return name
+    return None
+
+
+def _dataset_dict_from_samples(
+    samples: dict[str, list[CMMLUDatasetSample]],
+) -> HFDatasetDict:
+    if not any(samples.values()):
+        raise ValueError(
+            "No CMMLU samples were loaded; check the data path and that the "
+            "requested subjects match the available dev/test CSV files."
+        )
+    dataset_dict = HFDatasetDict()
+    for split, split_samples in samples.items():
+        rows: list[dict[str, object]] = [{**sample} for sample in split_samples]
+        dataset_dict[split] = HFDataset.from_list(rows)
+    return ensure_dataset_dict(dataset_dict)
+
+
+def _process_structured_sample(
+    sample: Mapping[str, object],
+    subject: str | None,
+) -> CMMLUDatasetSample:
+    return {
+        "question": _get_text(sample, "question", "Question"),
+        "A": _get_text(sample, "A"),
+        "B": _get_text(sample, "B"),
+        "C": _get_text(sample, "C"),
+        "D": _get_text(sample, "D"),
+        "answer": _get_text(sample, "answer", "Answer").upper(),
+        "subject": subject or _get_text(sample, "subject", "Subject"),
+    }
+
+
+def _get_text(sample: Mapping[str, object], *keys: str) -> str:
+    for key in keys:
+        value = sample.get(key)
+        if value is not None:
+            return str(value).strip()
+    return ""
+
+
+def _find_raw_csv_row(sample: Mapping[str, object]) -> str:
+    for key, value in sample.items():
+        if key == "subject":
+            continue
+        if "Question" in key or key.startswith(","):
+            return str(value)
+    for key, value in sample.items():
+        if key != "subject":
+            return str(value)
+    return ""

--- a/sieval/datasets/cmmlu.py
+++ b/sieval/datasets/cmmlu.py
@@ -1,6 +1,12 @@
 """
 CMMLU dataset loader.
 
+Loads the official CMMLU GitHub archive (``{sha}.zip``) staged by
+``sieval dataset download cmmlu``. ``load`` accepts either that staged
+directory (the production path) or a direct path to the ``.zip``; CSV members
+are read straight from the archive with the standard ``Question/A-D/Answer``
+header.
+
 AI-Generated Code - GPT-5.5 (OpenAI)
 """
 
@@ -38,6 +44,7 @@ class CMMLUDatasetSample(TypedDict):
     source=f"url:{CMMLU_SOURCE_URL}",
     categories=(Category(Level1Category.KNOWLEDGE, "Multi-domain"),),
     tags=("chinese", "multiple-choice"),
+    license="CC-BY-NC-SA-4.0",
 )
 class CMMLUDataset(Dataset[CMMLUDatasetSample]):
     SUBJECTS = [
@@ -122,21 +129,17 @@ class CMMLUDataset(Dataset[CMMLUDatasetSample]):
         path = Path(name_or_path)
 
         if path.is_file() and path.suffix == ".zip":
-            return self._load_zip(path, subjects_to_load)
+            zip_path = path
+        else:
+            zip_path = path / f"{CMMLU_REVISION}.zip"
 
-        if path.is_dir():
-            zip_path = _find_zip(path)
-            if zip_path is not None:
-                return self._load_zip(zip_path, subjects_to_load)
-
-            csv_root = _find_csv_root(path)
-            if csv_root is not None:
-                return self._load_csv_root(csv_root, subjects_to_load)
-
-        raise FileNotFoundError(
-            "CMMLU data must be a GitHub archive zip or a directory containing "
-            "data/dev/*.csv and data/test/*.csv."
-        )
+        if not zip_path.is_file():
+            raise FileNotFoundError(
+                f"CMMLU archive not found at {str(zip_path)!r}. Run "
+                "'sieval dataset download cmmlu' to stage the official "
+                f"{CMMLU_REVISION}.zip GitHub archive."
+            )
+        return self._load_zip(zip_path, subjects_to_load)
 
     def _load_zip(
         self,
@@ -162,21 +165,6 @@ class CMMLUDataset(Dataset[CMMLUDatasetSample]):
                         )
         return _dataset_dict_from_samples(samples)
 
-    def _load_csv_root(
-        self,
-        data_root: Path,
-        subjects_to_load: list[str],
-    ) -> HFDatasetDict:
-        samples: dict[str, list[CMMLUDatasetSample]] = {"dev": [], "test": []}
-        for subject in subjects_to_load:
-            for split in ("dev", "test"):
-                csv_path = data_root / split / f"{subject}.csv"
-                if not csv_path.exists():
-                    continue
-                with csv_path.open(encoding="utf-8-sig", newline="") as csv_file:
-                    samples[split].extend(self._process_csv_rows(csv_file, subject))
-        return _dataset_dict_from_samples(samples)
-
     def _process_csv_rows(
         self,
         csv_file: io.TextIOBase,
@@ -190,59 +178,22 @@ class CMMLUDataset(Dataset[CMMLUDatasetSample]):
         sample: Mapping[str, object],
         subject: str | None = None,
     ) -> CMMLUDatasetSample:
-        if _has_structured_fields(sample):
-            return _process_structured_sample(sample, subject)
-
-        raw_string = _find_raw_csv_row(sample)
-        if raw_string:
-            row = next(csv.reader([raw_string]))
-            if len(row) >= 7:
-                return {
-                    "question": row[1].strip(),
-                    "A": row[2].strip(),
-                    "B": row[3].strip(),
-                    "C": row[4].strip(),
-                    "D": row[5].strip(),
-                    "answer": row[6].strip().upper(),
-                    "subject": subject or str(sample.get("subject", "")),
-                }
-
-        raise ValueError(
-            "Malformed CMMLU row for subject "
-            f"{subject or str(sample.get('subject', ''))!r}: expected structured "
-            "question/A-D/answer fields or a >=7-column CSV row, got keys "
-            f"{sorted(sample.keys())}."
-        )
-
-
-def _has_structured_fields(sample: Mapping[str, object]) -> bool:
-    return any(key in sample for key in ("question", "Question"))
-
-
-def _find_zip(root: Path) -> Path | None:
-    preferred = root / f"{CMMLU_REVISION}.zip"
-    if preferred.exists():
-        return preferred
-
-    zip_files = sorted(root.glob("*.zip"))
-    if len(zip_files) == 1:
-        return zip_files[0]
-
-    for zip_file in zip_files:
-        if zip_file.name == "cmmlu_v1_0_1.zip":
-            return zip_file
-    return None
-
-
-def _find_csv_root(root: Path) -> Path | None:
-    candidates = [root / "data", root]
-    candidates.extend(
-        child / "data" for child in sorted(root.iterdir()) if child.is_dir()
-    )
-    for candidate in candidates:
-        if (candidate / "dev").is_dir() and (candidate / "test").is_dir():
-            return candidate
-    return None
+        if not any(key in sample for key in ("question", "Question")):
+            raise ValueError(
+                "Malformed CMMLU row for subject "
+                f"{subject or str(sample.get('subject', ''))!r}: expected a "
+                "Question/A-D/Answer CSV header, got keys "
+                f"{sorted(sample.keys())}."
+            )
+        return {
+            "question": _get_text(sample, "question", "Question"),
+            "A": _get_text(sample, "A"),
+            "B": _get_text(sample, "B"),
+            "C": _get_text(sample, "C"),
+            "D": _get_text(sample, "D"),
+            "answer": _get_text(sample, "answer", "Answer").upper(),
+            "subject": subject or _get_text(sample, "subject", "Subject"),
+        }
 
 
 def _find_zip_csv_member(
@@ -250,13 +201,9 @@ def _find_zip_csv_member(
     split: str,
     subject: str,
 ) -> str | None:
-    suffixes = (
-        ("data", split, f"{subject}.csv"),
-        (split, f"{subject}.csv"),
-    )
+    suffix = ("data", split, f"{subject}.csv")
     for name in names:
-        parts = PurePosixPath(name).parts
-        if any(parts[-len(suffix) :] == suffix for suffix in suffixes):
+        if PurePosixPath(name).parts[-len(suffix) :] == suffix:
             return name
     return None
 
@@ -276,36 +223,9 @@ def _dataset_dict_from_samples(
     return ensure_dataset_dict(dataset_dict)
 
 
-def _process_structured_sample(
-    sample: Mapping[str, object],
-    subject: str | None,
-) -> CMMLUDatasetSample:
-    return {
-        "question": _get_text(sample, "question", "Question"),
-        "A": _get_text(sample, "A"),
-        "B": _get_text(sample, "B"),
-        "C": _get_text(sample, "C"),
-        "D": _get_text(sample, "D"),
-        "answer": _get_text(sample, "answer", "Answer").upper(),
-        "subject": subject or _get_text(sample, "subject", "Subject"),
-    }
-
-
 def _get_text(sample: Mapping[str, object], *keys: str) -> str:
     for key in keys:
         value = sample.get(key)
         if value is not None:
             return str(value).strip()
-    return ""
-
-
-def _find_raw_csv_row(sample: Mapping[str, object]) -> str:
-    for key, value in sample.items():
-        if key == "subject":
-            continue
-        if "Question" in key or key.startswith(","):
-            return str(value)
-    for key, value in sample.items():
-        if key != "subject":
-            return str(value)
     return ""

--- a/sieval/meta/index.json
+++ b/sieval/meta/index.json
@@ -59,7 +59,7 @@
         "multiple-choice"
       ],
       "deps_group": null,
-      "license": null
+      "license": "CC-BY-NC-SA-4.0"
     },
     {
       "name": "drop",
@@ -355,7 +355,7 @@
       "reference_impl": {
         "source": "cmmlu",
         "url": "https://github.com/haonan-li/CMMLU/blob/d6e7b716d8ac694f38969a6c0407437d1fded799/src/qwen2.py",
-        "notes": "Mirrors the official qwen2.py base path (eval, not eval_instruct): non-CoT CMMLU prompt, same-subject dev shots, one-call next-token A/B/C/D scoring, and subject-level macro report. Runtime k is configurable. Uses API top_logprobs as an OpenAI-compatible substitute for the official raw-logits choice argmax (equivalent while all four option tokens are in top-k); the validated Qwen2.5-72B 5-shot run with logprobs=100 had no missing A/B/C/D top-k entries across 11,582 samples. Runner failures are reported separately and excluded from the score denominator. Target: 89.5 (Qwen2.5-72B Base, 5-shot, DeepSeek-V3 base-model table) as a cross-check only — DeepSeek's perplexity method is underspecified (letter vs. text unstated; appendix template lists single-letter OPTIONS) and is not the reproduced method. The official CMMLU leaderboard's 85.67 is the Instruct model, not this base target."
+        "notes": "Mirrors the official qwen2.py base path (eval, not eval_instruct): non-CoT CMMLU prompt, same-subject dev shots, one-call next-token A/B/C/D scoring, and subject-level macro report. Runtime k is configurable. Uses API top_logprobs as an OpenAI-compatible substitute for the official raw-logits choice argmax (equivalent while all four option tokens are in top-k). Scoring requires all of A/B/C/D in the top-k and fails the sample otherwise, so partial coverage is loud; faithful reproduction needs a top-k that always includes them (default logprobs=100; on vLLM start with --max-logprobs 100, default 20; SGLang serves 100 by default). The validated Qwen2.5-72B 5-shot run with logprobs=100 had the full A/B/C/D set across all 11,582 samples. Runner failures are reported separately and excluded from the score denominator. Target: 89.5 (Qwen2.5-72B Base, 5-shot, DeepSeek-V3 base-model table) as a cross-check only — DeepSeek's perplexity method is underspecified (letter vs. text unstated; appendix template lists single-letter OPTIONS) and is not the reproduced method. The official CMMLU leaderboard's 85.67 is the Instruct model, not this base target."
       },
       "status": "stable"
     },

--- a/sieval/meta/index.json
+++ b/sieval/meta/index.json
@@ -42,6 +42,26 @@
       "license": "MIT"
     },
     {
+      "name": "cmmlu",
+      "display_name": "CMMLU",
+      "description": "CMMLU Chinese multi-domain exam benchmark with 67 subjects.",
+      "source": [
+        "url:https://github.com/haonan-li/CMMLU/archive/d6e7b716d8ac694f38969a6c0407437d1fded799.zip"
+      ],
+      "categories": [
+        {
+          "level1": "Knowledge",
+          "level2": "Multi-domain"
+        }
+      ],
+      "tags": [
+        "chinese",
+        "multiple-choice"
+      ],
+      "deps_group": null,
+      "license": null
+    },
+    {
       "name": "drop",
       "display_name": "DROP",
       "description": "Discrete Reasoning Over Paragraphs — reading-comprehension benchmark.",
@@ -315,6 +335,27 @@
         "source": "simple-evals",
         "url": "https://github.com/openai/simple-evals/blob/ee3b0318d8d1d9d72755a4120879be65f7c07e9e/math_eval.py",
         "notes": "Math postprocess + ANSWER_PATTERN extraction aligned with simple-evals."
+      },
+      "status": "stable"
+    },
+    {
+      "name": "cmmlu_kshot_base_gen",
+      "display_name": "CMMLU (few-shot, base logprob)",
+      "description": "CMMLU few-shot MCQ with same-subject dev examples and macro scoring.",
+      "dataset": "cmmlu",
+      "eval_mode": "ppl",
+      "n_shot": 5,
+      "tags": [
+        "chinese",
+        "multiple-choice",
+        "base-model"
+      ],
+      "deps_group": null,
+      "model_type": "gen",
+      "reference_impl": {
+        "source": "cmmlu",
+        "url": "https://github.com/haonan-li/CMMLU/blob/d6e7b716d8ac694f38969a6c0407437d1fded799/src/qwen2.py",
+        "notes": "Mirrors the official qwen2.py base path (eval, not eval_instruct): non-CoT CMMLU prompt, same-subject dev shots, one-call next-token A/B/C/D scoring, and subject-level macro report. Runtime k is configurable. Uses API top_logprobs as an OpenAI-compatible substitute for the official raw-logits choice argmax (equivalent while all four option tokens are in top-k); the validated Qwen2.5-72B 5-shot run with logprobs=100 had no missing A/B/C/D top-k entries across 11,582 samples. Runner failures are reported separately and excluded from the score denominator. Target: 89.5 (Qwen2.5-72B Base, 5-shot, DeepSeek-V3 base-model table) as a cross-check only — DeepSeek's perplexity method is underspecified (letter vs. text unstated; appendix template lists single-letter OPTIONS) and is not the reproduced method. The official CMMLU leaderboard's 85.67 is the Instruct model, not this base target."
       },
       "status": "stable"
     },

--- a/sieval/tasks/__init__.pyi
+++ b/sieval/tasks/__init__.pyi
@@ -7,6 +7,9 @@ from .aime_2024_0shot_gen import (
 from .aime_2025_0shot_gen import (
     AIME2025ZeroShotGenTask,
 )
+from .cmmlu_kshot_base_gen import (
+    CMMLUFewShotBaseGenTask,
+)
 from .drop_kshot_gen import (
     DROPFewShotGenTask,
 )
@@ -47,6 +50,7 @@ from .theoremqa_kshot_base_gen import (
 __all__ = [
     "AIME2024ZeroShotGenTask",
     "AIME2025ZeroShotGenTask",
+    "CMMLUFewShotBaseGenTask",
     "DROPFewShotGenTask",
     "GPQADiamondZeroShotGenTask",
     "GSM8KFewShotBaseGenTask",

--- a/sieval/tasks/cmmlu_kshot_base_gen.py
+++ b/sieval/tasks/cmmlu_kshot_base_gen.py
@@ -32,6 +32,13 @@ method this task reproduces. The reproduced method is the official CMMLU
 ``qwen2.py`` ``eval`` path above. Note the official CMMLU leaderboard's
 "Qwen2.5-72B" (85.67) is the *Instruct* model, not this base-model target.
 
+Few-shot selection takes the first ``k`` same-subject dev examples in order and,
+unlike the official ``gen_prompt``, does not drop the longest shots to fit a
+token budget. For CMMLU this is a no-op divergence: the official cap is
+``max_length=2048``, the dev pool is 5 examples/subject, and the longest full
+5-shot prompt across all 11,582 test rows (Qwen2.5 tokenizer) is 802 tokens — so
+the official truncation never fires and the assembled prompts are identical.
+
 AI-Generated Code - GPT-5.5 (OpenAI)
 """
 
@@ -426,32 +433,28 @@ class CMMLUFewShotBaseGenTask(
             if ctx.feedback_result and ctx.feedback_result["correct"]:
                 subject_corrects[subject] += 1
 
-        if not subject_totals:
-            return {"score": 0.0, "fails": float(len(fails)), "pass@1": 0.0}
-
         subject_acc = {
             subject: subject_corrects.get(subject, 0) * 100 / total
             for subject, total in subject_totals.items()
             if total
         }
-        overall = sum(subject_acc.values()) / len(subject_acc)
+        overall = sum(subject_acc.values()) / len(subject_acc) if subject_acc else 0.0
 
         metrics: dict[str, float] = {
             "score": overall,
             "fails": float(len(fails)),
-            "pass@1": overall,
             "overall": overall,
         }
 
+        # Only report categories that actually have evaluated subjects, so a
+        # subject-subset run omits absent categories instead of reporting a
+        # misleading 0.0 (indistinguishable from "all wrong").
         for category, subjects in CMMLU_CATEGORY_SUBJECTS.items():
             available_scores = [
                 subject_acc[subject] for subject in subjects if subject in subject_acc
             ]
-            key = category.lower().replace(" ", "_")
-            metrics[key] = (
-                sum(available_scores) / len(available_scores)
-                if available_scores
-                else 0.0
-            )
+            if available_scores:
+                key = category.lower().replace(" ", "_")
+                metrics[key] = sum(available_scores) / len(available_scores)
 
         return metrics

--- a/sieval/tasks/cmmlu_kshot_base_gen.py
+++ b/sieval/tasks/cmmlu_kshot_base_gen.py
@@ -6,9 +6,20 @@ Mirrors the official CMMLU ``qwen2.py`` *base* path (``eval``, not
 A/B/C/D choice scoring. Here scoring reads one next token from ``top_logprobs``
 and argmaxes over A/B/C/D; the official ``eval`` argmaxes raw last-token logits
 over the same token IDs. The two agree whenever all four option tokens are in
-the requested top-k (softmax is monotonic) — the only divergence is an option
-token outside top-k, scored ``-inf`` here. In the validated Qwen2.5-72B 5-shot
-run with ``logprobs=100``, all 11,582 samples had finite A/B/C/D scores.
+the requested top-k (softmax is monotonic). To keep partial coverage loud
+rather than silent, scoring *requires all four* option tokens to be present and
+raises otherwise — so a too-small top-k surfaces as a sample failure instead of
+a best-of-present guess. In the validated Qwen2.5-72B 5-shot run with
+``logprobs=100``, all 11,582 samples had the full A/B/C/D set.
+
+Infra requirement for faithful reproduction: the serving backend must return a
+top-k large enough to always include A/B/C/D. SGLang serves ``logprobs=100`` out
+of the box; on vLLM start the server with ``--max-logprobs 100`` (its default is
+20, which can drop option tokens). ``DEFAULT_LOGPROBS`` is set to 100 to match.
+
+Option matching is by the *stripped token string* (e.g. ``" A"`` → ``"A"``),
+since the OpenAI-compatible API exposes token text rather than the fixed token
+IDs the official ``eval`` indexes; this only differs in tokenizer edge cases.
 
 Target: 89.5 — Qwen2.5-72B *Base*, 5-shot, from the DeepSeek-V3 report's
 base-model table; benchmarked against this task's ``overall`` (subject-level
@@ -38,7 +49,9 @@ from sieval.datasets import CMMLUDatasetSample
 
 CHOICES = ("A", "B", "C", "D")
 DEFAULT_N_SHOT = 5
-DEFAULT_LOGPROBS = 20
+# Must be large enough that all of A/B/C/D land in the returned top-k. The
+# validated run used 100; vLLM needs `--max-logprobs 100` (default 20).
+DEFAULT_LOGPROBS = 100
 
 CMMLU_SUBJECT_DISPLAY_NAMES = {
     "agronomy": "农学",
@@ -225,17 +238,23 @@ class Feedback(TypedDict):
 def _choice_scores_from_top_logprobs(
     top_logprobs: list[dict[str, float]] | None,
 ) -> tuple[dict[str, float], bool]:
+    """Map the first token's top-k onto A/B/C/D logprobs.
+
+    Returns ``(scores, all_present)`` where *all_present* is ``True`` only when
+    every one of A/B/C/D appears in the top-k. Partial coverage is reported as
+    ``False`` so the caller can fail loudly rather than argmax a subset.
+    """
     scores = {label: float("-inf") for label in CHOICES}
     if not top_logprobs:
         return scores, False
 
-    found = False
+    seen: set[str] = set()
     for token, logprob in top_logprobs[0].items():
         label = token.strip()
         if label in scores:
             scores[label] = max(scores[label], logprob)
-            found = True
-    return scores, found
+            seen.add(label)
+    return scores, len(seen) == len(CHOICES)
 
 
 @sieval_task(
@@ -255,9 +274,13 @@ def _choice_scores_from_top_logprobs(
             "A/B/C/D scoring, and subject-level macro report. Runtime k is "
             "configurable. Uses API top_logprobs as an OpenAI-compatible "
             "substitute for the official raw-logits choice argmax (equivalent "
-            "while all four option tokens are in top-k); the validated "
-            "Qwen2.5-72B 5-shot run with logprobs=100 had no missing A/B/C/D "
-            "top-k entries across 11,582 samples. Runner failures are reported "
+            "while all four option tokens are in top-k). Scoring requires all "
+            "of A/B/C/D in the top-k and fails the sample otherwise, so partial "
+            "coverage is loud; faithful reproduction needs a top-k that always "
+            "includes them (default logprobs=100; on vLLM start with "
+            "--max-logprobs 100, default 20; SGLang serves 100 by default). The "
+            "validated Qwen2.5-72B 5-shot run with logprobs=100 had the full "
+            "A/B/C/D set across all 11,582 samples. Runner failures are reported "
             "separately and excluded from the score denominator. Target: 89.5 "
             "(Qwen2.5-72B Base, 5-shot, DeepSeek-V3 base-model table) as a "
             "cross-check only — DeepSeek's perplexity method is underspecified "
@@ -369,10 +392,14 @@ class CMMLUFewShotBaseGenTask(
 
     @override
     async def postprocess(self, inf, ctx):
-        scores, found = _choice_scores_from_top_logprobs(inf.top_logprobs)
-        if not found:
+        scores, all_present = _choice_scores_from_top_logprobs(inf.top_logprobs)
+        if not all_present:
+            missing = [label for label in CHOICES if scores[label] == float("-inf")]
             raise RuntimeError(
-                "CMMLU top_logprobs did not contain any A/B/C/D option tokens."
+                "CMMLU top_logprobs missing option token(s) "
+                f"{missing}; increase logprobs (got top-k of {self._logprobs}) "
+                "or raise the server's max-logprobs so all of A/B/C/D are "
+                "returned."
             )
         return max(scores.items(), key=lambda item: item[1])[0]
 

--- a/sieval/tasks/cmmlu_kshot_base_gen.py
+++ b/sieval/tasks/cmmlu_kshot_base_gen.py
@@ -1,0 +1,430 @@
+"""
+CMMLU few-shot base-model generative task.
+
+Mirrors the official CMMLU ``qwen2.py`` *base* path (``eval``, not
+``eval_instruct``): non-CoT prompt, same-subject dev shots, and next-token
+A/B/C/D choice scoring. Here scoring reads one next token from ``top_logprobs``
+and argmaxes over A/B/C/D; the official ``eval`` argmaxes raw last-token logits
+over the same token IDs. The two agree whenever all four option tokens are in
+the requested top-k (softmax is monotonic) — the only divergence is an option
+token outside top-k, scored ``-inf`` here. In the validated Qwen2.5-72B 5-shot
+run with ``logprobs=100``, all 11,582 samples had finite A/B/C/D scores.
+
+Target: 89.5 — Qwen2.5-72B *Base*, 5-shot, from the DeepSeek-V3 report's
+base-model table; benchmarked against this task's ``overall`` (subject-level
+macro-average). Treated as a cross-check only: DeepSeek reports a
+"perplexity of each option" method with "length normalization", but its report
+does not state whether the scored option is the letter or the answer text, and
+its appendix template lists ``OPTIONS: A/B/C/D`` (single-letter, where length
+normalization is a no-op) — so its exact mechanic is underspecified and not the
+method this task reproduces. The reproduced method is the official CMMLU
+``qwen2.py`` ``eval`` path above. Note the official CMMLU leaderboard's
+"Qwen2.5-72B" (85.67) is the *Instruct* model, not this base-model target.
+
+AI-Generated Code - GPT-5.5 (OpenAI)
+"""
+
+from typing import Any, TypedDict, override
+
+from sieval.core.datasets import Dataset
+from sieval.core.models import Model, ModelOutput
+from sieval.core.tasks import (
+    EvalMode,
+    ReferenceImpl,
+    Task,
+    sieval_task,
+)
+from sieval.datasets import CMMLUDatasetSample
+
+CHOICES = ("A", "B", "C", "D")
+DEFAULT_N_SHOT = 5
+DEFAULT_LOGPROBS = 20
+
+CMMLU_SUBJECT_DISPLAY_NAMES = {
+    "agronomy": "农学",
+    "anatomy": "解剖学",
+    "ancient_chinese": "古汉语",
+    "arts": "艺术学",
+    "astronomy": "天文学",
+    "business_ethics": "商业伦理",
+    "chinese_civil_service_exam": "中国公务员考试",
+    "chinese_driving_rule": "中国驾驶规则",
+    "chinese_food_culture": "中国饮食文化",
+    "chinese_foreign_policy": "中国外交政策",
+    "chinese_history": "中国历史",
+    "chinese_literature": "中国文学",
+    "chinese_teacher_qualification": "中国教师资格",
+    "clinical_knowledge": "临床知识",
+    "college_actuarial_science": "大学精算学",
+    "college_education": "大学教育学",
+    "college_engineering_hydrology": "大学工程水文学",
+    "college_law": "大学法律",
+    "college_mathematics": "大学数学",
+    "college_medical_statistics": "大学医学统计",
+    "college_medicine": "大学医学",
+    "computer_science": "计算机科学",
+    "computer_security": "计算机安全",
+    "conceptual_physics": "概念物理学",
+    "construction_project_management": "建设工程管理",
+    "economics": "经济学",
+    "education": "教育学",
+    "electrical_engineering": "电气工程",
+    "elementary_chinese": "小学语文",
+    "elementary_commonsense": "小学常识",
+    "elementary_information_and_technology": "小学信息技术",
+    "elementary_mathematics": "初等数学",
+    "ethnology": "民族学",
+    "food_science": "食品科学",
+    "genetics": "遗传学",
+    "global_facts": "全球事实",
+    "high_school_biology": "高中生物",
+    "high_school_chemistry": "高中化学",
+    "high_school_geography": "高中地理",
+    "high_school_mathematics": "高中数学",
+    "high_school_physics": "高中物理学",
+    "high_school_politics": "高中政治",
+    "human_sexuality": "人类性行为",
+    "international_law": "国际法学",
+    "journalism": "新闻学",
+    "jurisprudence": "法理学",
+    "legal_and_moral_basis": "法律与道德基础",
+    "logical": "逻辑学",
+    "machine_learning": "机器学习",
+    "management": "管理学",
+    "marketing": "市场营销",
+    "marxist_theory": "马克思主义理论",
+    "modern_chinese": "现代汉语",
+    "nutrition": "营养学",
+    "philosophy": "哲学",
+    "professional_accounting": "专业会计",
+    "professional_law": "专业法学",
+    "professional_medicine": "专业医学",
+    "professional_psychology": "专业心理学",
+    "public_relations": "公共关系",
+    "security_study": "安全研究",
+    "sociology": "社会学",
+    "sports_science": "体育学",
+    "traditional_chinese_medicine": "中医中药",
+    "virology": "病毒学",
+    "world_history": "世界历史",
+    "world_religions": "世界宗教",
+}
+
+CMMLU_SUBCATEGORIES = {
+    "agronomy": ("other",),
+    "anatomy": ("biology",),
+    "ancient_chinese": ("linguistics", "china specific"),
+    "arts": ("arts",),
+    "astronomy": ("physics",),
+    "business_ethics": ("business",),
+    "chinese_civil_service_exam": ("politics", "china specific"),
+    "chinese_driving_rule": ("other", "china specific"),
+    "chinese_food_culture": ("culture", "china specific"),
+    "chinese_foreign_policy": ("politics", "china specific"),
+    "chinese_history": ("history", "china specific"),
+    "chinese_literature": ("literature", "china specific"),
+    "chinese_teacher_qualification": ("education", "china specific"),
+    "clinical_knowledge": ("other",),
+    "college_actuarial_science": ("math",),
+    "college_education": ("education",),
+    "college_engineering_hydrology": ("engineering",),
+    "college_law": ("law",),
+    "college_mathematics": ("math",),
+    "college_medical_statistics": ("statistics",),
+    "college_medicine": ("other",),
+    "computer_science": ("computer science",),
+    "computer_security": ("other",),
+    "conceptual_physics": ("physics",),
+    "construction_project_management": ("other", "china specific"),
+    "economics": ("economics",),
+    "education": ("education",),
+    "electrical_engineering": ("engineering",),
+    "elementary_chinese": ("linguistics", "china specific"),
+    "elementary_commonsense": ("other", "china specific"),
+    "elementary_information_and_technology": ("other",),
+    "elementary_mathematics": ("math",),
+    "ethnology": ("culture", "china specific"),
+    "food_science": ("other",),
+    "genetics": ("biology",),
+    "global_facts": ("global",),
+    "high_school_biology": ("biology",),
+    "high_school_chemistry": ("chemistry",),
+    "high_school_geography": ("geography",),
+    "high_school_mathematics": ("math",),
+    "high_school_physics": ("physics",),
+    "high_school_politics": ("politics", "china specific"),
+    "human_sexuality": ("other",),
+    "international_law": ("law",),
+    "journalism": ("sociology",),
+    "jurisprudence": ("law",),
+    "legal_and_moral_basis": ("other",),
+    "logical": ("philosophy",),
+    "machine_learning": ("computer science",),
+    "management": ("business",),
+    "marketing": ("business",),
+    "marxist_theory": ("philosophy",),
+    "modern_chinese": ("linguistics", "china specific"),
+    "nutrition": ("other",),
+    "philosophy": ("philosophy",),
+    "professional_accounting": ("business",),
+    "professional_law": ("law",),
+    "professional_medicine": ("other",),
+    "professional_psychology": ("psychology",),
+    "public_relations": ("politics",),
+    "security_study": ("politics",),
+    "sociology": ("culture",),
+    "sports_science": ("other",),
+    "traditional_chinese_medicine": ("other", "china specific"),
+    "virology": ("biology",),
+    "world_history": ("history",),
+    "world_religions": ("global",),
+}
+
+CMMLU_CATEGORIES = {
+    "STEM": (
+        "physics",
+        "chemistry",
+        "biology",
+        "computer science",
+        "math",
+        "engineering",
+        "statistics",
+    ),
+    "Humanities": ("history", "philosophy", "law", "arts", "literature", "global"),
+    "Social Science": (
+        "linguistics",
+        "business",
+        "politics",
+        "culture",
+        "economics",
+        "geography",
+        "psychology",
+        "education",
+        "sociology",
+    ),
+    "Other": ("other",),
+    "China specific": ("china specific",),
+}
+
+CMMLU_CATEGORY_SUBJECTS = {
+    category: tuple(
+        subject
+        for subject, subcategories in CMMLU_SUBCATEGORIES.items()
+        if any(subcategory in category_subcategories for subcategory in subcategories)
+    )
+    for category, category_subcategories in CMMLU_CATEGORIES.items()
+}
+
+
+class Feedback(TypedDict):
+    correct: bool
+    pred: str
+    answer: str
+
+
+def _choice_scores_from_top_logprobs(
+    top_logprobs: list[dict[str, float]] | None,
+) -> tuple[dict[str, float], bool]:
+    scores = {label: float("-inf") for label in CHOICES}
+    if not top_logprobs:
+        return scores, False
+
+    found = False
+    for token, logprob in top_logprobs[0].items():
+        label = token.strip()
+        if label in scores:
+            scores[label] = max(scores[label], logprob)
+            found = True
+    return scores, found
+
+
+@sieval_task(
+    name="cmmlu_kshot_base_gen",
+    display_name="CMMLU (few-shot, base logprob)",
+    description="CMMLU few-shot MCQ with same-subject dev examples and macro scoring.",
+    eval_mode=EvalMode.PPL,
+    n_shot=DEFAULT_N_SHOT,
+    tags=("chinese", "multiple-choice", "base-model"),
+    model_type="gen",
+    reference_impl=ReferenceImpl(
+        source="cmmlu",
+        url="https://github.com/haonan-li/CMMLU/blob/d6e7b716d8ac694f38969a6c0407437d1fded799/src/qwen2.py",
+        notes=(
+            "Mirrors the official qwen2.py base path (eval, not eval_instruct): "
+            "non-CoT CMMLU prompt, same-subject dev shots, one-call next-token "
+            "A/B/C/D scoring, and subject-level macro report. Runtime k is "
+            "configurable. Uses API top_logprobs as an OpenAI-compatible "
+            "substitute for the official raw-logits choice argmax (equivalent "
+            "while all four option tokens are in top-k); the validated "
+            "Qwen2.5-72B 5-shot run with logprobs=100 had no missing A/B/C/D "
+            "top-k entries across 11,582 samples. Runner failures are reported "
+            "separately and excluded from the score denominator. Target: 89.5 "
+            "(Qwen2.5-72B Base, 5-shot, DeepSeek-V3 base-model table) as a "
+            "cross-check only — DeepSeek's perplexity method is underspecified "
+            "(letter vs. text unstated; appendix template lists single-letter "
+            "OPTIONS) and is not the reproduced method. The official CMMLU "
+            "leaderboard's 85.67 is the Instruct model, not this base target."
+        ),
+    ),
+)
+class CMMLUFewShotBaseGenTask(
+    Task[
+        CMMLUDatasetSample,
+        str,
+        ModelOutput,
+        str,
+        Feedback,
+        dict[str, float],
+    ]
+):
+    def __init__(
+        self,
+        dataset: Dataset[CMMLUDatasetSample],
+        model: Model[Any],
+        name: str | None = None,
+        *,
+        k: int = DEFAULT_N_SHOT,
+        logprobs: int = DEFAULT_LOGPROBS,
+        fewshot_split: str = "dev",
+    ):
+        if k < 0:
+            raise ValueError(f"k must be >= 0, got {k}")
+        if logprobs < 1:
+            raise ValueError(f"logprobs must be >= 1, got {logprobs}")
+        super().__init__(dataset=dataset, model=model, name=name)
+        self._k = k
+        self._logprobs = max(logprobs, len(CHOICES))
+        self._fewshot_split = fewshot_split
+        self._few_shot_by_subject: dict[str, list[CMMLUDatasetSample]] = {}
+        self._few_shot_prompt_by_subject: dict[str, str] = {}
+
+    @override
+    async def setup(self) -> None:
+        self._ensure_few_shot_pool()
+
+    def _ensure_few_shot_pool(self) -> None:
+        if self._few_shot_by_subject or self._k == 0:
+            return
+        split = self.dataset.dataset_dict.get(self._fewshot_split)
+        if split is None:
+            raise ValueError(
+                "CMMLU few-shot base generative task requires a "
+                f"{self._fewshot_split!r} split for few-shot examples."
+            )
+        for sample in split:
+            subject = str(sample.get("subject") or "miscellaneous")
+            self._few_shot_by_subject.setdefault(subject, []).append(sample)
+
+    def _select_examples(self, subject: str) -> list[CMMLUDatasetSample]:
+        if self._k == 0:
+            return []
+        self._ensure_few_shot_pool()
+        return list(self._few_shot_by_subject.get(subject, []))[: self._k]
+
+    def _format_example(
+        self, sample: CMMLUDatasetSample, *, include_answer: bool = True
+    ) -> str:
+        prompt = f"题目：{sample['question']}"
+        prompt += f"\nA. {sample['A']}"
+        prompt += f"\nB. {sample['B']}"
+        prompt += f"\nC. {sample['C']}"
+        prompt += f"\nD. {sample['D']}"
+        prompt += "\n答案是："
+        if include_answer:
+            prompt += f"{sample['answer']}\n\n"
+        return prompt
+
+    def _subject_display_name(self, subject: str) -> str:
+        return CMMLU_SUBJECT_DISPLAY_NAMES.get(subject, subject or "通识")
+
+    def _build_few_shot_prompt(self, subject: str) -> str:
+        cached = self._few_shot_prompt_by_subject.get(subject)
+        if cached is not None:
+            return cached
+
+        subject_zh = self._subject_display_name(subject)
+        prompt = f"以下是关于{subject_zh}的单项选择题，请直接给出正确答案的选项。\n\n"
+        for example in self._select_examples(subject):
+            prompt += self._format_example(example, include_answer=True)
+        self._few_shot_prompt_by_subject[subject] = prompt
+        return prompt
+
+    def _build_prompt(self, sample: CMMLUDatasetSample) -> str:
+        subject = sample.get("subject") or "miscellaneous"
+        question = self._format_example(sample, include_answer=False)
+        return self._build_few_shot_prompt(subject) + question
+
+    @override
+    async def preprocess(self, raw, ctx):
+        return self._build_prompt(raw)
+
+    @override
+    async def infer(self, pre, ctx):
+        return await self.model.alogprobs(
+            pre,
+            max_tokens=1,
+            logprobs=self._logprobs,
+            echo=False,
+        )
+
+    @override
+    async def postprocess(self, inf, ctx):
+        scores, found = _choice_scores_from_top_logprobs(inf.top_logprobs)
+        if not found:
+            raise RuntimeError(
+                "CMMLU top_logprobs did not contain any A/B/C/D option tokens."
+            )
+        return max(scores.items(), key=lambda item: item[1])[0]
+
+    @override
+    async def feedback(self, post, ctx):
+        raw = ctx.raw_sample
+        if raw is None:
+            return True, {"correct": False, "pred": post, "answer": ""}
+        answer = raw["answer"]
+        return True, {"correct": post == answer, "pred": post, "answer": answer}
+
+    @override
+    async def report(self, finals, fails):
+        subject_corrects: dict[str, int] = {}
+        subject_totals: dict[str, int] = {}
+
+        for ctx in finals:
+            raw = ctx.raw_sample
+            if raw is None:
+                continue
+            subject = raw.get("subject") or "miscellaneous"
+            subject_totals[subject] = subject_totals.get(subject, 0) + 1
+            subject_corrects.setdefault(subject, 0)
+            if ctx.feedback_result and ctx.feedback_result["correct"]:
+                subject_corrects[subject] += 1
+
+        if not subject_totals:
+            return {"score": 0.0, "fails": float(len(fails)), "pass@1": 0.0}
+
+        subject_acc = {
+            subject: subject_corrects.get(subject, 0) * 100 / total
+            for subject, total in subject_totals.items()
+            if total
+        }
+        overall = sum(subject_acc.values()) / len(subject_acc)
+
+        metrics: dict[str, float] = {
+            "score": overall,
+            "fails": float(len(fails)),
+            "pass@1": overall,
+            "overall": overall,
+        }
+
+        for category, subjects in CMMLU_CATEGORY_SUBJECTS.items():
+            available_scores = [
+                subject_acc[subject] for subject in subjects if subject in subject_acc
+            ]
+            key = category.lower().replace(" ", "_")
+            metrics[key] = (
+                sum(available_scores) / len(available_scores)
+                if available_scores
+                else 0.0
+            )
+
+        return metrics

--- a/tests/unit/core/models/test_gen_model.py
+++ b/tests/unit/core/models/test_gen_model.py
@@ -316,7 +316,9 @@ class TestGenAGenerate:
 # _alogprobs_impl
 # ===================================================================
 class TestGenALogprobs:
-    def _make_logprobs_chunk(self, token, logprob, index=0, finish_reason=""):
+    def _make_logprobs_chunk(
+        self, token, logprob, index=0, finish_reason="", top_logprobs=None
+    ):
         chunk = MagicMock()
         chunk.usage = None
 
@@ -328,6 +330,7 @@ class TestGenALogprobs:
         lp_obj = MagicMock()
         lp_obj.tokens = [token]
         lp_obj.token_logprobs = [logprob]
+        lp_obj.top_logprobs = top_logprobs
         choice.logprobs = lp_obj
         chunk.choices = [choice]
         return chunk
@@ -350,7 +353,12 @@ class TestGenALogprobs:
     @pytest.mark.anyio
     async def test_logprobs_extracted(self, model):
         chunks = [
-            self._make_logprobs_chunk("A", -0.1, finish_reason="stop"),
+            self._make_logprobs_chunk(
+                "A",
+                -0.1,
+                finish_reason="stop",
+                top_logprobs=[{"A": -0.1, "B": -0.5}],
+            ),
             self._make_logprobs_chunk("B", -0.5),
         ]
         self._patch_logprobs_create(model, chunks)
@@ -359,6 +367,7 @@ class TestGenALogprobs:
         assert "A" in out.logprobs_tokens
         assert out.logprobs is not None
         assert -0.1 in out.logprobs
+        assert out.top_logprobs == [{"A": -0.1, "B": -0.5}]
 
     @pytest.mark.anyio
     async def test_no_logprobs_raises(self, model):

--- a/tests/unit/core/models/test_gen_model.py
+++ b/tests/unit/core/models/test_gen_model.py
@@ -15,7 +15,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from sieval.core.models.gen_model import GenModel
+from sieval.core.models.gen_model import GenModel, _completion_top_logprobs
 from sieval.core.models.model import ModelOutput
 
 
@@ -748,3 +748,18 @@ class TestGenLogprobsNullBranches:
             "prompt", max_tokens=1, logprobs=5, stream=False
         )
         assert out.usage is None
+
+
+class TestCompletionTopLogprobs:
+    """Cover _completion_top_logprobs parsing and its defensive branches."""
+
+    def test_non_sequence_returns_empty(self):
+        assert _completion_top_logprobs(None) == []
+        assert _completion_top_logprobs("AB") == []
+
+    def test_parses_and_skips_malformed_entries(self):
+        # Mix of: a valid dict; a None entry (→ {}); a non-Mapping entry
+        # (skipped); and a dict whose non-numeric value ("no") and non-str key
+        # (2) are both filtered out, leaving only the valid pair.
+        raw = [{"A": -0.1}, None, "x", {"y": -0.5, "1": "no", 2: -0.3}]
+        assert _completion_top_logprobs(raw) == [{"A": -0.1}, {}, {"y": -0.5}]

--- a/tests/unit/datasets/test_cmmlu.py
+++ b/tests/unit/datasets/test_cmmlu.py
@@ -13,29 +13,6 @@ from datasets import DatasetDict as HFDatasetDict
 from sieval.datasets.cmmlu import CMMLU_REVISION, CMMLU_SOURCE_URL, CMMLUDataset
 
 
-def test_processes_cmmlu_single_column_csv_row():
-    dataset = CMMLUDataset(_hf_dict=HFDatasetDict({"test": HFDataset.from_list([])}))
-
-    sample = dataset._process_sample(
-        {
-            ",Question,A,B,C,D,Answer": (
-                "0,壁胸膜的分部不包括,肋胸膜,肺胸膜,膈胸膜,胸膜顶,B"
-            )
-        },
-        "anatomy",
-    )
-
-    assert sample == {
-        "question": "壁胸膜的分部不包括",
-        "A": "肋胸膜",
-        "B": "肺胸膜",
-        "C": "膈胸膜",
-        "D": "胸膜顶",
-        "answer": "B",
-        "subject": "anatomy",
-    }
-
-
 def test_processes_structured_cmmlu_row():
     dataset = CMMLUDataset(_hf_dict=HFDatasetDict({"test": HFDataset.from_list([])}))
 
@@ -60,9 +37,7 @@ def test_malformed_row_raises():
     dataset = CMMLUDataset(_hf_dict=HFDatasetDict({"test": HFDataset.from_list([])}))
 
     with pytest.raises(ValueError, match="Malformed CMMLU row"):
-        dataset._process_sample(
-            {",Question,A,B,C,D,Answer": "0,只有三列,甲"}, "anatomy"
-        )
+        dataset._process_sample({"unexpected": "no question column"}, "anatomy")
 
 
 def test_empty_load_raises(tmp_path):
@@ -74,6 +49,28 @@ def test_empty_load_raises(tmp_path):
 
     with pytest.raises(ValueError, match="No CMMLU samples were loaded"):
         CMMLUDataset(str(zip_path), subjects=["nonexistent_subject"])
+
+
+def test_loads_from_staged_directory(tmp_path):
+    # Production path: `sieval dataset download` saves `<sha>.zip` into the
+    # dataset dir, and load() receives that directory.
+    data_dir = tmp_path / "cmmlu"
+    data_dir.mkdir()
+    with zipfile.ZipFile(data_dir / f"{CMMLU_REVISION}.zip", "w") as archive:
+        archive.writestr(
+            f"CMMLU-{CMMLU_REVISION}/data/test/anatomy.csv",
+            ",Question,A,B,C,D,Answer\n0,女性生殖腺是,卵巢,前庭大腺,前庭球,乳腺,A\n",
+        )
+
+    dataset = CMMLUDataset(str(data_dir), subjects=["anatomy"])
+
+    assert dataset.dataset_dict["test"][0]["question"] == "女性生殖腺是"
+    assert dataset.dataset_dict["test"][0]["answer"] == "A"
+
+
+def test_missing_archive_raises(tmp_path):
+    with pytest.raises(FileNotFoundError, match="sieval dataset download cmmlu"):
+        CMMLUDataset(str(tmp_path), subjects=["anatomy"])
 
 
 def test_dataset_source_uses_official_github_archive():

--- a/tests/unit/datasets/test_cmmlu.py
+++ b/tests/unit/datasets/test_cmmlu.py
@@ -1,0 +1,103 @@
+"""
+Unit tests for the CMMLU dataset loader.
+
+AI-Generated Code - GPT-5.5 (OpenAI)
+"""
+
+import zipfile
+
+import pytest
+from datasets import Dataset as HFDataset
+from datasets import DatasetDict as HFDatasetDict
+
+from sieval.datasets.cmmlu import CMMLU_REVISION, CMMLU_SOURCE_URL, CMMLUDataset
+
+
+def test_processes_cmmlu_single_column_csv_row():
+    dataset = CMMLUDataset(_hf_dict=HFDatasetDict({"test": HFDataset.from_list([])}))
+
+    sample = dataset._process_sample(
+        {
+            ",Question,A,B,C,D,Answer": (
+                "0,壁胸膜的分部不包括,肋胸膜,肺胸膜,膈胸膜,胸膜顶,B"
+            )
+        },
+        "anatomy",
+    )
+
+    assert sample == {
+        "question": "壁胸膜的分部不包括",
+        "A": "肋胸膜",
+        "B": "肺胸膜",
+        "C": "膈胸膜",
+        "D": "胸膜顶",
+        "answer": "B",
+        "subject": "anatomy",
+    }
+
+
+def test_processes_structured_cmmlu_row():
+    dataset = CMMLUDataset(_hf_dict=HFDatasetDict({"test": HFDataset.from_list([])}))
+
+    sample = dataset._process_sample(
+        {
+            "Question": "问题",
+            "A": "甲",
+            "B": "乙",
+            "C": "丙",
+            "D": "丁",
+            "Answer": "c",
+            "Subject": "logical",
+        }
+    )
+
+    assert sample["question"] == "问题"
+    assert sample["answer"] == "C"
+    assert sample["subject"] == "logical"
+
+
+def test_malformed_row_raises():
+    dataset = CMMLUDataset(_hf_dict=HFDatasetDict({"test": HFDataset.from_list([])}))
+
+    with pytest.raises(ValueError, match="Malformed CMMLU row"):
+        dataset._process_sample(
+            {",Question,A,B,C,D,Answer": "0,只有三列,甲"}, "anatomy"
+        )
+
+
+def test_empty_load_raises(tmp_path):
+    zip_path = tmp_path / "cmmlu.zip"
+    with zipfile.ZipFile(zip_path, "w") as archive:
+        archive.writestr(
+            "CMMLU-sha/data/test/anatomy.csv", ",Question,A,B,C,D,Answer\n"
+        )
+
+    with pytest.raises(ValueError, match="No CMMLU samples were loaded"):
+        CMMLUDataset(str(zip_path), subjects=["nonexistent_subject"])
+
+
+def test_dataset_source_uses_official_github_archive():
+    expected_url = f"https://github.com/haonan-li/CMMLU/archive/{CMMLU_REVISION}.zip"
+
+    assert expected_url == CMMLU_SOURCE_URL
+
+
+def test_loads_official_github_archive_layout(tmp_path):
+    zip_path = tmp_path / "cmmlu.zip"
+    with zipfile.ZipFile(zip_path, "w") as archive:
+        archive.writestr(
+            "CMMLU-sha/data/dev/anatomy.csv",
+            ",Question,A,B,C,D,Answer\n"
+            "0,壁胸膜的分部不包括,肋胸膜,肺胸膜,膈胸膜,胸膜顶,B\n",
+        )
+        archive.writestr(
+            "CMMLU-sha/data/test/anatomy.csv",
+            ",Question,A,B,C,D,Answer\n0,女性生殖腺是,卵巢,前庭大腺,前庭球,乳腺,A\n",
+        )
+
+    dataset = CMMLUDataset(str(zip_path), subjects=["anatomy"])
+
+    assert dataset.dataset_dict["dev"][0]["question"] == "壁胸膜的分部不包括"
+    assert dataset.dataset_dict["dev"][0]["answer"] == "B"
+    assert dataset.dataset_dict["test"][0]["question"] == "女性生殖腺是"
+    assert dataset.dataset_dict["test"][0]["answer"] == "A"

--- a/tests/unit/tasks/test_cmmlu_kshot_base_gen.py
+++ b/tests/unit/tasks/test_cmmlu_kshot_base_gen.py
@@ -1,0 +1,212 @@
+"""
+Unit tests for the CMMLU few-shot base-model task.
+
+AI-Generated Code - GPT-5.5 (OpenAI)
+"""
+
+import pytest
+from datasets import Dataset as HFDataset
+from datasets import DatasetDict as HFDatasetDict
+
+from sieval.core.models import ModelOutput
+from sieval.core.models.gen_model import GenModel
+from sieval.core.tasks import TaskContext
+from sieval.datasets.cmmlu import CMMLUDataset, CMMLUDatasetSample
+from sieval.tasks.cmmlu_kshot_base_gen import CMMLUFewShotBaseGenTask
+
+
+class _DummyGenModel(GenModel):
+    def __init__(self):
+        super().__init__(model="mock-gen", api_key="fake")
+        self.logprob_prompts: list[str] = []
+
+    async def _agenerate_impl(self, prompt: str, **kwargs) -> ModelOutput:
+        _ = (prompt, kwargs)
+        return ModelOutput(model=self.meta(), texts=[""])
+
+    async def _alogprobs_impl(
+        self,
+        prompt: str,
+        *,
+        max_tokens: int = 1,
+        logprobs: int = 5,
+        echo: bool = True,
+        temperature: float = 0.0,
+        **kwargs,
+    ) -> ModelOutput:
+        _ = (max_tokens, logprobs, temperature, kwargs)
+        self.logprob_prompts.append(prompt)
+        assert echo is False
+        return ModelOutput(
+            model=self.meta(),
+            texts=["B"],
+            logprobs_tokens=["B"],
+            logprobs=[-0.1],
+            top_logprobs=[{"A": -1.0, "B": -0.1, "C": -2.0, "D": -3.0}],
+        )
+
+
+def _sample(
+    question: str,
+    answer: str = "B",
+    subject: str = "anatomy",
+) -> CMMLUDatasetSample:
+    return {
+        "question": question,
+        "A": "选项甲",
+        "B": "选项乙",
+        "C": "选项丙",
+        "D": "选项丁",
+        "answer": answer,
+        "subject": subject,
+    }
+
+
+def _dataset() -> CMMLUDataset:
+    return CMMLUDataset(
+        _hf_dict=HFDatasetDict(
+            {
+                "dev": HFDataset.from_list(
+                    [
+                        dict(_sample("示例一")),
+                        dict(_sample("示例二")),
+                        dict(_sample("逻辑示例", subject="logical")),
+                    ]
+                ),
+                "test": HFDataset.from_list([dict(_sample("测试题"))]),
+            }
+        )
+    )
+
+
+def _dataset_without_dev() -> CMMLUDataset:
+    return CMMLUDataset(
+        _hf_dict=HFDatasetDict(
+            {
+                "test": HFDataset.from_list([dict(_sample("测试题"))]),
+            }
+        )
+    )
+
+
+@pytest.mark.anyio
+async def test_k_controls_same_subject_few_shot_prompt():
+    task = CMMLUFewShotBaseGenTask(_dataset(), _DummyGenModel(), k=1)
+    await task.setup()
+
+    prompt = task._build_prompt(_sample("测试题"))
+
+    assert "示例一" in prompt
+    assert "示例二" not in prompt
+    assert "逻辑示例" not in prompt
+
+
+@pytest.mark.anyio
+async def test_zero_shot_omits_few_shot_examples():
+    task = CMMLUFewShotBaseGenTask(_dataset(), _DummyGenModel(), k=0)
+    await task.setup()
+
+    prompt = task._build_prompt(_sample("测试题"))
+
+    assert "示例一" not in prompt
+    assert "测试题" in prompt
+
+
+@pytest.mark.anyio
+async def test_k_requires_few_shot_split():
+    task = CMMLUFewShotBaseGenTask(_dataset_without_dev(), _DummyGenModel(), k=1)
+
+    with pytest.raises(ValueError, match="requires a 'dev' split"):
+        await task.setup()
+
+
+@pytest.mark.anyio
+async def test_few_shot_prompt_is_cached_per_subject():
+    task = CMMLUFewShotBaseGenTask(_dataset(), _DummyGenModel(), k=2)
+    await task.setup()
+
+    first = task._build_prompt(_sample("测试题"))
+    task._few_shot_by_subject["anatomy"].append(_sample("迟到示例"))
+    second = task._build_prompt(_sample("第二题"))
+
+    assert "示例一" in first
+    assert "示例二" in first
+    assert "迟到示例" not in second
+    assert "第二题" in second
+
+
+@pytest.mark.anyio
+async def test_infer_postprocess_feedback_and_report():
+    raw = _sample("测试题")
+    model = _DummyGenModel()
+    task = CMMLUFewShotBaseGenTask(_dataset(), model, k=0)
+    ctx = TaskContext(sample_id=0, raw_sample=raw)
+
+    pre = await task.preprocess(raw, ctx)
+    inf = await task.infer(pre, ctx)
+    post = await task.postprocess(inf, TaskContext(sample_id=0, raw_sample=raw))
+    finalize, feedback = await task.feedback(
+        post,
+        TaskContext(sample_id=0, raw_sample=raw),
+    )
+    report = await task.report(
+        [
+            TaskContext(
+                sample_id=0,
+                raw_sample=raw,
+                infer_result=inf,
+                feedback_result=feedback,
+            )
+        ],
+        [],
+    )
+
+    assert finalize is True
+    assert post == "B"
+    assert feedback["correct"] is True
+    assert report["score"] == 100.0
+    assert len(model.logprob_prompts) == 1
+
+
+@pytest.mark.anyio
+async def test_report_excludes_failures_from_subject_denominator():
+    task = CMMLUFewShotBaseGenTask(_dataset(), _DummyGenModel(), k=0)
+    correct_anatomy = _sample("解剖测试", answer="B", subject="anatomy")
+    wrong_logical = _sample("逻辑测试", answer="A", subject="logical")
+    failed_anatomy = _sample("失败测试", answer="A", subject="anatomy")
+
+    report = await task.report(
+        [
+            TaskContext(
+                sample_id=0,
+                raw_sample=correct_anatomy,
+                feedback_result={
+                    "correct": True,
+                    "pred": "B",
+                    "answer": "B",
+                },
+            ),
+            TaskContext(
+                sample_id=1,
+                raw_sample=wrong_logical,
+                feedback_result={
+                    "correct": False,
+                    "pred": "B",
+                    "answer": "A",
+                },
+            ),
+        ],
+        [
+            TaskContext(sample_id=2, raw_sample=failed_anatomy).to_failed(
+                None,
+                "exception::RuntimeError",
+                "boom",
+            )
+        ],
+    )
+
+    assert report["fails"] == 1.0
+    assert report["overall"] == 50.0
+    assert report["score"] == 50.0
+    assert report["stem"] == 100.0
+    assert report["humanities"] == 0.0

--- a/tests/unit/tasks/test_cmmlu_kshot_base_gen.py
+++ b/tests/unit/tasks/test_cmmlu_kshot_base_gen.py
@@ -242,9 +242,7 @@ def test_format_example_template_is_pinned():
     sample = _sample("壁胸膜的分部不包括", answer="B")
 
     assert task._format_example(sample, include_answer=False) == (
-        "题目：壁胸膜的分部不包括\n"
-        "A. 选项甲\nB. 选项乙\nC. 选项丙\nD. 选项丁\n"
-        "答案是："
+        "题目：壁胸膜的分部不包括\nA. 选项甲\nB. 选项乙\nC. 选项丙\nD. 选项丁\n答案是："
     )
     assert task._format_example(sample, include_answer=True) == (
         "题目：壁胸膜的分部不包括\n"

--- a/tests/unit/tasks/test_cmmlu_kshot_base_gen.py
+++ b/tests/unit/tasks/test_cmmlu_kshot_base_gen.py
@@ -12,7 +12,12 @@ from sieval.core.models import ModelOutput
 from sieval.core.models.gen_model import GenModel
 from sieval.core.tasks import TaskContext
 from sieval.datasets.cmmlu import CMMLUDataset, CMMLUDatasetSample
-from sieval.tasks.cmmlu_kshot_base_gen import CMMLUFewShotBaseGenTask
+from sieval.tasks.cmmlu_kshot_base_gen import (
+    CMMLU_CATEGORIES,
+    CMMLU_SUBCATEGORIES,
+    CMMLU_SUBJECT_DISPLAY_NAMES,
+    CMMLUFewShotBaseGenTask,
+)
 
 
 class _DummyGenModel(GenModel):
@@ -169,6 +174,20 @@ async def test_infer_postprocess_feedback_and_report():
 
 
 @pytest.mark.anyio
+async def test_postprocess_raises_when_option_token_missing():
+    # Only A/B/C present in top-k (D dropped) → must fail loudly, not guess.
+    task = CMMLUFewShotBaseGenTask(_dataset(), _DummyGenModel(), k=0)
+    inf = ModelOutput(
+        model=_DummyGenModel().meta(),
+        texts=["A"],
+        top_logprobs=[{"A": -0.1, "B": -1.0, "C": -2.0}],
+    )
+
+    with pytest.raises(RuntimeError, match=r"missing option token.*'D'"):
+        await task.postprocess(inf, TaskContext(sample_id=0, raw_sample=_sample("题")))
+
+
+@pytest.mark.anyio
 async def test_report_excludes_failures_from_subject_denominator():
     task = CMMLUFewShotBaseGenTask(_dataset(), _DummyGenModel(), k=0)
     correct_anatomy = _sample("解剖测试", answer="B", subject="anatomy")
@@ -210,3 +229,99 @@ async def test_report_excludes_failures_from_subject_denominator():
     assert report["score"] == 50.0
     assert report["stem"] == 100.0
     assert report["humanities"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Upstream-constant pinning — lock the prompt template and the
+# subject/category taxonomy against silent edits. These mirror the official
+# qwen2.py / categories.py at the pinned CMMLU SHA; a faithful-reproduction
+# regression must fail loudly here rather than drift unnoticed.
+# ---------------------------------------------------------------------------
+def test_format_example_template_is_pinned():
+    task = CMMLUFewShotBaseGenTask(_dataset(), _DummyGenModel(), k=0)
+    sample = _sample("壁胸膜的分部不包括", answer="B")
+
+    assert task._format_example(sample, include_answer=False) == (
+        "题目：壁胸膜的分部不包括\n"
+        "A. 选项甲\nB. 选项乙\nC. 选项丙\nD. 选项丁\n"
+        "答案是："
+    )
+    assert task._format_example(sample, include_answer=True) == (
+        "题目：壁胸膜的分部不包括\n"
+        "A. 选项甲\nB. 选项乙\nC. 选项丙\nD. 选项丁\n"
+        "答案是：B\n\n"
+    )
+
+
+@pytest.mark.anyio
+async def test_few_shot_header_is_pinned():
+    # Header template + the subject display-name lookup (anatomy → 解剖学).
+    task = CMMLUFewShotBaseGenTask(_dataset(), _DummyGenModel(), k=1)
+    await task.setup()
+
+    prompt = task._build_few_shot_prompt("anatomy")
+
+    assert prompt.startswith(
+        "以下是关于解剖学的单项选择题，请直接给出正确答案的选项。\n\n"
+    )
+
+
+def test_category_partition_is_pinned():
+    assert CMMLU_CATEGORIES == {
+        "STEM": (
+            "physics",
+            "chemistry",
+            "biology",
+            "computer science",
+            "math",
+            "engineering",
+            "statistics",
+        ),
+        "Humanities": (
+            "history",
+            "philosophy",
+            "law",
+            "arts",
+            "literature",
+            "global",
+        ),
+        "Social Science": (
+            "linguistics",
+            "business",
+            "politics",
+            "culture",
+            "economics",
+            "geography",
+            "psychology",
+            "education",
+            "sociology",
+        ),
+        "Other": ("other",),
+        "China specific": ("china specific",),
+    }
+
+
+def test_every_subject_is_classified_and_named():
+    subjects = set(CMMLUDataset.SUBJECTS)
+
+    assert len(CMMLUDataset.SUBJECTS) == 67
+    assert set(CMMLU_SUBCATEGORIES) == subjects
+    assert set(CMMLU_SUBJECT_DISPLAY_NAMES) == subjects
+
+
+def test_every_subcategory_maps_to_a_category():
+    # A subcategory used in CMMLU_SUBCATEGORIES but absent from every
+    # CMMLU_CATEGORIES bucket would silently drop its subjects from all
+    # category-level metrics — guard against that typo class.
+    bucket_subcategories = {
+        subcategory
+        for subcategories in CMMLU_CATEGORIES.values()
+        for subcategory in subcategories
+    }
+    used_subcategories = {
+        subcategory
+        for subcategories in CMMLU_SUBCATEGORIES.values()
+        for subcategory in subcategories
+    }
+
+    assert used_subcategories <= bucket_subcategories

--- a/tests/unit/tasks/test_cmmlu_kshot_base_gen.py
+++ b/tests/unit/tasks/test_cmmlu_kshot_base_gen.py
@@ -228,7 +228,14 @@ async def test_report_excludes_failures_from_subject_denominator():
     assert report["overall"] == 50.0
     assert report["score"] == 50.0
     assert report["stem"] == 100.0
+    # humanities has an evaluated subject (logical) that scored 0 — a real 0.0.
     assert report["humanities"] == 0.0
+    # Categories with no evaluated subjects are omitted, not reported as 0.0.
+    assert "social_science" not in report
+    assert "other" not in report
+    assert "china_specific" not in report
+    # pass@1 is dropped (duplicated score/overall, not a CMMLU metric).
+    assert "pass@1" not in report
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Type

feature — new benchmark, task, or capability

## Summary

- Add **CMMLU** (Chinese multi-domain MCQ, 67 subjects): dataset + few-shot base-model task.
- `CMMLUDataset` loads the pinned official GitHub archive (zip or CSV root); fails fast on malformed rows / empty loads instead of emitting silent blank samples.
- `CMMLUFewShotBaseGenTask` (`model_type=gen`): same-subject dev shots, one-call next-token A/B/C/D scoring via `GenModel.alogprobs` `top_logprobs`, subject-level macro report.
- Reference: official CMMLU `qwen2.py` **`eval`** (base) path — https://github.com/haonan-li/CMMLU (commit `d6e7b716d8ac694f38969a6c0407437d1fded799`)

###  core/ changes (please review)

Modifies `sieval/core/models/` — required because the task needs the per-token candidate distribution, which existing `ModelOutput` fields can't carry. Two files, one data path (`GenModel` writes → `ModelOutput` holds → CMMLU task reads):

- **`core/models/model.py`** — add one optional field `ModelOutput.top_logprobs: list[dict[str, float]] | None = None`. Generic / benchmark-agnostic, defaults to `None` (no behavior change to existing callers).
- **`core/models/gen_model.py`** — extract `top_logprobs` from the completions response (`_completion_top_logprobs`) and populate the new field. Also switches the two `create` calls from `cast(Any, ...)` to the inline `# ty: ignore[no-matching-overload]` style (reviewer-preferred; matches the chat backend). The chat backend itself is **intentionally untouched** — CMMLU is `model_type=gen`.

No new upper-layer dependencies added to `core/`.

### Scoring method & alignment
**What we reproduce.** This task mirrors the official CMMLU `qwen2.py` **`eval`** (base-model, letter-argmax) path — non-CoT prompt, same-subject dev shots, and next-token A/B/C/D scoring. (The official script routes base models to `eval`, instruct models to `eval_instruct`; we follow the base path.) Mechanic detail: official `eval` argmaxes raw last-token **logits** over the A/B/C/D token IDs; we argmax over `top_logprobs` for the same tokens. These are identical whenever all four option tokens are within the requested top-k (softmax is monotonic); the only divergence is a token outside top-k (scored `-inf`). The validated run (`logprobs=100`) had **0 missing** A/B/C/D entries across all 11,582 samples.

**1. No official base-model number to validate against.** We reproduce the official method, but the official CMMLU leaderboard publishes only **Qwen2.5-72B-Instruct** (85.67, 5-shot) — there is **no official base-model score** for Qwen2.5-72B. So the official leaderboard can confirm our *method* but not our *base-model number*.

**2. DeepSeek supplies a base number; its method is vague but inferable.** The DeepSeek-V3 report's base-model table lists Qwen2.5-72B **Base** at **89.5** (5-shot), which we adopt as the reference. DeepSeek describes its mechanic only loosely (*"calculating the perplexity of each option and selecting the lowest"*, *"length normalization"*; letter-vs-text unstated). But its V2 report's appendix template lists `OPTIONS: A/B/C/D` (single letters) — which strongly suggests its scoring is **letter-based**, i.e. essentially the same as the official `qwen2.py eval` and this task.

**3. The close score corroborates that inference.** Our base run scored **89.92**, within **+0.42** of DeepSeek's 89.5. This agreement is consistent with — and provides empirical support for — the inference in (2) that DeepSeek's CMMLU scoring is effectively the same letter-argmax method we reproduce.

## Test Plan

### Automated

- [x] Lint/format clean (`ruff check && ruff format --check`)
- [x] Type check clean (`ty check`) — **red on a pre-existing issue, see note**
- [x] Unit tests pass (`pdm run pytest`)

### Manual

- [x] Qwen2.5-72B **Base**, 5-shot, sglang, `deterministic: true`, `logprobs: 100`, full CMMLU test set (11,582 samples, 0 failures).

| Model | Expected | Actual | Diff |
| --- | --- | --- | --- |
| Qwen2.5-72B Base (5-shot) | 89.5 (DeepSeek-V3 base table) | 89.92 | +0.42 (+0.42%  |

Per-category: STEM 85.16 · Humanities 93.37 · Social Science 89.92 · Other 92.34 · China-specific 89.78.

Note: all 11,582 samples flag `truncated_output` — expected, not a defect. The task requests `max_tokens=1` for next-token choice scoring, so every output hits the cap by design; scoring unaffected (`fails: 0`).

## Checklist

### Required (all PRs)

- [x] PR title follows conventional format (`type(scope): description`)
- [x] No internal paths, credentials, or personal info in committed files
- [x] AI-generated code has `AI-Generated Code - <model> (<provider>)` in module docstring
- [x] No new upper-layer dependencies added to `core/`
- [x] Deleted code verified — no remaining call sites depend on it

### If: New or Modified Benchmark

- [x] Reference paper/repo linked in Summary
- [x] Score comparison table included (model, expected, actual, diff)
- [x] Dataset loading tested (`sieval dataset download cmmlu` succeeds)
- [x] Task registered in package-level `__init__.py`