### PR TITLE
feat(openbookqa): add dataset and k-shot generative tasks

### DIFF
--- a/sieval/community/openbookqa.py
+++ b/sieval/community/openbookqa.py
@@ -1,0 +1,101 @@
+"""OpenBookQA prompt template and answer extraction, adapted from OpenCompass.
+
+Vendored from open-compass/opencompass @ 5767b748:
+  - configs/datasets/obqa/obqa_gen_9069e4.py — prompt template (``main`` variant)
+  - utils/text_postprocessors.py — ``first_option_postprocess``
+
+``first_option_postprocess`` is reproduced verbatim, including upstream's
+missing-comma quirk between the ``故选`` and ``只有选项`` patterns (the two
+adjacent f-strings implicitly concatenate into one pattern). The only
+mechanical change is the ``r`` string prefix to silence the W605 invalid-escape
+warning; the compiled regexes are byte-for-byte identical to upstream.
+
+AI-Generated Code - Opus 4.8 (Anthropic)
+"""
+
+import re
+
+# `main` variant of _template in obqa_gen_9069e4.py. The `additional`/fact1
+# variant ("Given the fact: {fact1}\n...") is intentionally not vendored.
+OBQA_PROMPT_TEMPLATE = (
+    "Question: {question_stem}\nA. {A}\nB. {B}\nC. {C}\nD. {D}\nAnswer:"
+)
+
+OBQA_OPTIONS = "ABCD"
+
+
+def first_option_postprocess(text: str, options: str, cushion=True) -> str:
+    """Find first valid option for text."""
+
+    patterns = [
+        rf'答案是?\s*([{options}])',
+        rf'答案是?\s*：\s*([{options}])',
+        rf'答案是?\s*:\s*([{options}])',
+        rf'答案选项应?该?是\s*([{options}])',
+        rf'答案选项应?该?为\s*([{options}])',
+        rf'答案应该?是\s*([{options}])',
+        rf'答案应该?选\s*([{options}])',
+        rf'答案选项为?\s*：\s*([{options}])',
+        rf'答案选项为?\s+\(?\*?\*?([{options}])\*?\*?\)?',
+        rf'答案选项是?\s*:\s*([{options}])',
+        rf'答案为\s*([{options}])',
+        rf'答案选\s*([{options}])',
+        rf'选择?\s*([{options}])',
+        rf'故选?\s*([{options}])'
+        rf'只有选?项?\s?([{options}])\s?是?对',
+        rf'只有选?项?\s?([{options}])\s?是?错',
+        rf'只有选?项?\s?([{options}])\s?不?正确',
+        rf'只有选?项?\s?([{options}])\s?错误',
+        rf'说法不?对选?项?的?是\s?([{options}])',
+        rf'说法不?正确选?项?的?是\s?([{options}])',
+        rf'说法错误选?项?的?是\s?([{options}])',
+        rf'([{options}])\s?是正确的',
+        rf'([{options}])\s?是正确答案',
+        rf'选项\s?([{options}])\s?正确',
+        rf'所以答\s?([{options}])',
+        rf'所以\s?([{options}][.。$]?$)',
+        rf'所有\s?([{options}][.。$]?$)',
+        rf'[\s，：:,]([{options}])[。，,\.]?$',
+        rf'[\s，,：:][故即]([{options}])[。\.]?$',
+        rf'[\s，,：:]因此([{options}])[。\.]?$',
+        rf'[是为。]\s?([{options}])[。\.]?$',
+        rf'因此\s?([{options}])[。\.]?$',
+        rf'显然\s?([{options}])[。\.]?$',
+        r'答案是\s?(\S+)(?:。|$)',
+        r'答案应该是\s?(\S+)(?:。|$)',
+        r'答案为\s?(\S+)(?:。|$)',
+        rf'(?i)ANSWER\s*:\s*([{options}])',
+        rf'[Tt]he answer is:?\s+\(?([{options}])\)?',
+        rf'[Tt]he answer is:?\s+\(?\*?\*?([{options}])\*?\*?\)?',
+        rf'[Tt]he answer is option:?\s+\(?([{options}])\)?',
+        rf'[Tt]he correct answer is:?\s+\(?([{options}])\)?',
+        rf'[Tt]he correct answer is option:?\s+\(?([{options}])\)?',
+        rf'[Tt]he correct answer is:?.*?boxed{{([{options}])}}',
+        rf'[Tt]he correct option is:?.*?boxed{{([{options}])}}',
+        rf'[Tt]he correct answer option is:?.*?boxed{{([{options}])}}',
+        rf'[Tt]he answer to the question is:?\s+\(?([{options}])\)?',
+        rf'^选项\s?([{options}])',
+        rf'^([{options}])\s?选?项',
+        rf'(\s|^)[{options}][\s。，,：:\.$]',
+        r'1.\s?(.*?)$',
+        rf'1.\s?([{options}])[.。$]?$',
+    ]
+    cushion_patterns = [
+        rf'([{options}]):',
+        rf'([{options}])',
+    ]
+
+    if cushion:
+        patterns.extend(cushion_patterns)
+    for pattern in patterns:
+        text = text.strip()
+        match = re.search(pattern, text, re.DOTALL)
+        if match:
+            if match.group(1) is not None and match.group(1) != '':
+                outputs = match.group(1)
+            else:
+                outputs = match.group(0)
+            for i in options:
+                if i in outputs:
+                    return i
+    return ''

--- a/sieval/datasets/__init__.pyi
+++ b/sieval/datasets/__init__.pyi
@@ -69,6 +69,10 @@ from .mmlu_pro import (
     MMLUProDataset,
     MMLUProDatasetSample,
 )
+from .openbookqa import (
+    OpenBookQADataset,
+    OpenBookQADatasetSample,
+)
 from .t_eval import (
     TEvalBeforeCallingDataset,
     TEvalBeforeCallingDatasetSample,
@@ -113,6 +117,8 @@ __all__ = [
     "MMLUDatasetSample",
     "MMLUProDataset",
     "MMLUProDatasetSample",
+    "OpenBookQADataset",
+    "OpenBookQADatasetSample",
     "TEvalBeforeCallingDataset",
     "TEvalBeforeCallingDatasetSample",
     "TheoremQADataset",

--- a/sieval/datasets/openbookqa.py
+++ b/sieval/datasets/openbookqa.py
@@ -1,0 +1,61 @@
+"""OpenBookQA dataset loader.
+
+Source note: OpenCompass's ``obqa_gen_9069e4`` (the reference this benchmark's
+prompt + extractor are vendored from) runs against its own mirror
+``opencompass/openbookqa_test``; this loader points at the original
+``allenai/openbookqa`` (``main``) instead. The two resolve to the same
+500-example ``main`` test split — both position-map ``choices.text[0..3]`` → A–D
+and every record's ``choices.label`` is ordered ``[A, B, C, D]`` so ``answerKey``
+aligns (the ``" what?"``-style stem rewrite lives in OpenCompass's
+``OBQADatasetV2``, not the config targeted here).
+
+AI-Generated Code - Opus 4.8 (Anthropic)
+"""
+
+from typing import TypedDict, override
+
+from datasets import DatasetDict as HFDatasetDict
+from datasets import load_dataset
+
+from sieval.core.datasets import (
+    Category,
+    Dataset,
+    Level1Category,
+    sieval_dataset,
+)
+from sieval.core.utils.hf import apply_eval_split, ensure_dataset_dict
+
+OPENBOOKQA_REVISION = "388097ea7776314e93a529163e0fea805b8a6454"
+
+
+class OpenBookQADatasetSample(TypedDict):
+    id: str
+    question_stem: str
+    choices: dict[str, list[str]]
+    answerKey: str
+
+
+@sieval_dataset(
+    name="openbookqa",
+    display_name="OpenBookQA",
+    description="OpenBookQA elementary-science open-book multiple-choice QA.",
+    source=f"hf:allenai/openbookqa@{OPENBOOKQA_REVISION}",
+    categories=(Category(Level1Category.KNOWLEDGE, "STEM"),),
+    tags=("english", "science", "multiple-choice"),
+    license="Apache-2.0",
+)
+class OpenBookQADataset(Dataset[OpenBookQADatasetSample]):
+    @override
+    def load(
+        self,
+        name_or_path: str,
+        name: str = "main",
+        eval_split: str | None = None,
+        **kwargs,
+    ) -> HFDatasetDict:
+        # `name` is HF's subset selector (load_dataset's 2nd positional arg);
+        # pass it as a keyword so a config `args: {name: main}` can't collide
+        # with the positional and raise "multiple values for argument 'name'".
+        dataset = load_dataset(name_or_path, name=name, **kwargs)
+        dataset = ensure_dataset_dict(dataset)
+        return apply_eval_split(dataset, eval_split)

--- a/sieval/meta/index.json
+++ b/sieval/meta/index.json
@@ -378,6 +378,28 @@
       "checksums": {}
     },
     {
+      "name": "openbookqa",
+      "display_name": "OpenBookQA",
+      "description": "OpenBookQA elementary-science open-book multiple-choice QA.",
+      "source": [
+        "hf:allenai/openbookqa@388097ea7776314e93a529163e0fea805b8a6454"
+      ],
+      "categories": [
+        {
+          "level1": "Knowledge",
+          "level2": "STEM"
+        }
+      ],
+      "tags": [
+        "english",
+        "science",
+        "multiple-choice"
+      ],
+      "deps_group": null,
+      "license": "Apache-2.0",
+      "checksums": {}
+    },
+    {
       "name": "t_eval_before_calling",
       "display_name": "T-Eval Before-Calling",
       "description": "T-Eval tool-use benchmark — before-calling stage (plan/reason).",
@@ -816,6 +838,27 @@
         "source": "opencompass",
         "url": "https://github.com/open-compass/opencompass/blob/568572803ab108eb0e2ae73b770d965b7de078de/opencompass/configs/datasets/mmlu_pro/mmlu_pro_0shot_cot_gen_08c1de.py",
         "notes": "QUERY_TEMPLATE / CHOICES adapted from opencompass 0-shot CoT config."
+      },
+      "status": "stable"
+    },
+    {
+      "name": "openbookqa_kshot_gen",
+      "display_name": "OpenBookQA (k-shot, generative)",
+      "description": "OpenBookQA elementary-science MCQ, generative letter extraction.",
+      "dataset": "openbookqa",
+      "eval_mode": "gen",
+      "n_shot": 0,
+      "tags": [
+        "english",
+        "science",
+        "multiple-choice"
+      ],
+      "deps_group": null,
+      "model_type": "chat",
+      "reference_impl": {
+        "source": "opencompass",
+        "url": "https://github.com/open-compass/opencompass/blob/5767b74899806c0c37efdc5529ffea01e7340e48/opencompass/configs/datasets/obqa/obqa_gen_9069e4.py",
+        "notes": "Prompt template (main variant) and first_option_postprocess vendored from OpenCompass. At k=0 the prompt and extraction match the upstream 0-shot config; k>0 is a sieval extension (fixed first-k train rows)."
       },
       "status": "stable"
     },

--- a/sieval/tasks/__init__.pyi
+++ b/sieval/tasks/__init__.pyi
@@ -58,6 +58,9 @@ from .mmlu_0shot_gen import (
 from .mmlu_pro_0shot_gen import (
     MMLUProZeroShotGenTask,
 )
+from .openbookqa_kshot_gen import (
+    OpenBookQAFewShotGenTask,
+)
 from .t_eval_before_calling_0shot_gen import (
     TEvalBeforeCallingZeroShotGenTask,
 )
@@ -85,6 +88,7 @@ __all__ = [
     "MBPPFewShotBaseGenTask",
     "MMLUProZeroShotGenTask",
     "MMLUZeroShotGenTask",
+    "OpenBookQAFewShotGenTask",
     "TEvalBeforeCallingZeroShotGenTask",
     "TheoremQAKShotBaseGenTask",
 ]

--- a/sieval/tasks/openbookqa_kshot_gen.py
+++ b/sieval/tasks/openbookqa_kshot_gen.py
@@ -1,0 +1,185 @@
+"""OpenBookQA k-shot generative task (instruct/chat models).
+
+Accuracy metric; the predicted option letter is extracted with OpenCompass's
+``first_option_postprocess(options="ABCD")``. That extractor and the prompt
+template are vendored from OpenCompass ``obqa_gen_9069e4`` (``main`` variant)
+in ``sieval.community.openbookqa``. This task targets implementation parity
+with that config (prompt + extraction), not a specific published accuracy.
+
+Deviations from the OpenCompass reference (``obqa_gen_9069e4``):
+  - OpenCompass uses ``ZeroRetriever`` (0-shot). At ``k=0`` the prompt and
+    extraction match upstream; ``k>0`` is a sieval extension with no upstream
+    counterpart — the few-shot block is the first ``k`` ``train`` rows (fixed
+    indices), each with its ``answerKey`` appended. By default they are packed
+    into one user turn (the lm-eval/OpenCompass default); when
+    ``fewshot_as_multiturn`` is set they are rendered as alternating
+    user/assistant turns instead (lm-eval's ``fewshot_as_multiturn``).
+    At ``k>0`` generation is bounded by a stop sequence (the next example's
+    ``Question:`` header) so a verbose run-on cannot emit a later high-priority
+    extractor match that overrides the real answer; ``k=0`` is left unbounded to
+    match the upstream 0-shot config.
+  - Only the ``main`` variant is implemented; the ``additional``/``fact1``
+    ("Given the fact: ...") prompt variant is not used.
+  - Choices map to A–D by position (``choices["text"][0..3]``), matching
+    OpenCompass ``OBQADataset``.
+
+Repro decoding: greedy ``temperature=0``, ``top_p=1``. ``obqa_gen_9069e4`` sets
+no ``max_out_len``, so ``max_gen_toks`` follows the model/run config rather than
+a task-pinned value.
+
+AI-Generated Code - Opus 4.8 (Anthropic)
+"""
+
+from typing import TypedDict, override
+
+from openai.types.chat import ChatCompletionMessageParam
+
+from sieval.community.openbookqa import (
+    OBQA_OPTIONS,
+    OBQA_PROMPT_TEMPLATE,
+    first_option_postprocess,
+)
+from sieval.core.models import ModelOutput
+from sieval.core.tasks import (
+    EvalMode,
+    ReferenceImpl,
+    Task,
+    sieval_task,
+)
+from sieval.datasets import OpenBookQADatasetSample
+
+DEFAULT_N_SHOT = 0
+FEWSHOT_SEP = "\n\n"
+# Coupled to the few-shot block: each packed example begins with "Question:".
+# Applied only at k>0 to bound verbose run-on (see infer); k=0 stays unbounded.
+STOP_SEQUENCES = ("\nQuestion:",)
+
+
+class Feedback(TypedDict):
+    correct: bool
+    pred: str
+    answer: str
+
+
+def _format_question(sample: OpenBookQADatasetSample) -> str:
+    texts = sample["choices"]["text"]
+    return OBQA_PROMPT_TEMPLATE.format(
+        question_stem=sample["question_stem"],
+        A=texts[0],
+        B=texts[1],
+        C=texts[2],
+        D=texts[3],
+    )
+
+
+@sieval_task(
+    name="openbookqa_kshot_gen",
+    display_name="OpenBookQA (k-shot, generative)",
+    description="OpenBookQA elementary-science MCQ, generative letter extraction.",
+    eval_mode=EvalMode.GEN,
+    n_shot=DEFAULT_N_SHOT,
+    tags=("english", "science", "multiple-choice"),
+    model_type="chat",
+    reference_impl=ReferenceImpl(
+        source="opencompass",
+        url="https://github.com/open-compass/opencompass/blob/5767b74899806c0c37efdc5529ffea01e7340e48/opencompass/configs/datasets/obqa/obqa_gen_9069e4.py",
+        notes=(
+            "Prompt template (main variant) and first_option_postprocess "
+            "vendored from OpenCompass. At k=0 the prompt and extraction match "
+            "the upstream 0-shot config; k>0 is a sieval extension (fixed "
+            "first-k train rows)."
+        ),
+    ),
+)
+class OpenBookQAFewShotGenTask(
+    Task[
+        OpenBookQADatasetSample,
+        list[ChatCompletionMessageParam],
+        ModelOutput,
+        str,
+        Feedback,
+        dict[str, float],
+    ]
+):
+    def __init__(
+        self,
+        dataset,
+        model,
+        name: str | None = None,
+        *,
+        k: int = DEFAULT_N_SHOT,
+        fewshot_split: str = "train",
+        fewshot_as_multiturn: bool = False,
+        stop: tuple[str, ...] = STOP_SEQUENCES,
+    ):
+        if k < 0:
+            raise ValueError(f"k must be >= 0, got {k}")
+        super().__init__(dataset=dataset, model=model, name=name)
+        self._k = k
+        self._fewshot_split = fewshot_split
+        self._fewshot_as_multiturn = fewshot_as_multiturn
+        self._stop = stop
+        self._fewshot_prefix: str = ""
+        self._fewshot_turns: list[ChatCompletionMessageParam] = []
+
+    @override
+    async def setup(self) -> None:
+        examples = self._retrieve_fewshot()
+        if self._fewshot_as_multiturn:
+            turns: list[ChatCompletionMessageParam] = []
+            for ex in examples:
+                turns.append({"role": "user", "content": _format_question(ex)})
+                turns.append({"role": "assistant", "content": ex["answerKey"]})
+            self._fewshot_turns = turns
+        else:
+            rendered = [f"{_format_question(ex)} {ex['answerKey']}" for ex in examples]
+            self._fewshot_prefix = (
+                FEWSHOT_SEP.join(rendered) + FEWSHOT_SEP if rendered else ""
+            )
+
+    @override
+    async def preprocess(self, raw, ctx):
+        query = _format_question(raw)
+        if self._fewshot_as_multiturn:
+            return [*self._fewshot_turns, {"role": "user", "content": query}]
+        return [{"role": "user", "content": self._fewshot_prefix + query}]
+
+    @override
+    async def infer(self, pre, ctx):
+        # At k>0 the packed few-shot block primes verbose models to run on and
+        # re-answer bundled examples; because the extractor scans the whole text
+        # by pattern priority (not first-by-position), a trailing match can then
+        # override the real leading answer. Bound generation at the next example
+        # boundary. k=0 stays unbounded to match the upstream 0-shot config.
+        if self._k > 0 and self._stop:
+            return await self.model.agenerate(pre, stop=list(self._stop))
+        return await self.model.agenerate(pre)
+
+    @override
+    async def postprocess(self, inf, ctx):
+        # n=1, only one choice
+        return first_option_postprocess(inf.texts[0], OBQA_OPTIONS)
+
+    @override
+    async def feedback(self, post, ctx):
+        answer = ctx.raw_sample["answerKey"]
+        return True, {"correct": post == answer, "pred": post, "answer": answer}
+
+    @override
+    async def report(self, finals, fails):
+        correct = sum(1 for ctx in finals if ctx.feedback_result["correct"])
+        accuracy = 100 * correct / len(finals) if finals else 0.0
+        # `score` is the headline; `accuracy` names the metric behind it
+        # (% of finalized samples whose extracted letter equals answerKey),
+        # mirroring how gsm8k/drop surface their metric alongside `score`.
+        return {"score": accuracy, "fails": len(fails), "accuracy": accuracy}
+
+    def _retrieve_fewshot(self) -> list[OpenBookQADatasetSample]:
+        if self._k <= 0:
+            return []
+        return self.dataset.retrieve_samples(
+            self._k,
+            split=self._fewshot_split,
+            mode="fixed",
+            indices=list(range(self._k)),
+        )

--- a/tests/unit/community/test_openbookqa.py
+++ b/tests/unit/community/test_openbookqa.py
@@ -1,0 +1,42 @@
+"""Tests for the OpenCompass-vendored OBQA prompt template and extractor.
+
+AI-Generated Code - Opus 4.8 (Anthropic)
+"""
+
+from sieval.community.openbookqa import (
+    OBQA_OPTIONS,
+    OBQA_PROMPT_TEMPLATE,
+    first_option_postprocess,
+)
+
+
+def test_prompt_template_matches_opencompass_main_variant():
+    # Pinned byte-for-byte against obqa_gen_9069e4.py _template[0]. Any drift
+    # here silently de-aligns us from the reference, so assert the exact string.
+    assert OBQA_PROMPT_TEMPLATE == (
+        "Question: {question_stem}\nA. {A}\nB. {B}\nC. {C}\nD. {D}\nAnswer:"
+    )
+    assert OBQA_OPTIONS == "ABCD"
+
+
+def test_extracts_english_answer_phrasings():
+    assert first_option_postprocess("The answer is B.", OBQA_OPTIONS) == "B"
+    assert first_option_postprocess("ANSWER: C", OBQA_OPTIONS) == "C"
+    assert (
+        first_option_postprocess("The correct answer is option (D).", OBQA_OPTIONS)
+        == "D"
+    )
+
+
+def test_cushion_fallback_returns_first_bare_option():
+    # No answer phrasing — cushion patterns pick the first option-letter present.
+    assert first_option_postprocess("A", OBQA_OPTIONS) == "A"
+
+
+def test_returns_empty_when_no_option_present():
+    assert first_option_postprocess("none of these apply", OBQA_OPTIONS) == ""
+
+
+def test_options_arg_restricts_alphabet():
+    # The letter must be drawn from `options`; "E" is not a valid OBQA option.
+    assert first_option_postprocess("The answer is E.", OBQA_OPTIONS) == ""

--- a/tests/unit/tasks/test_openbookqa_kshot_gen.py
+++ b/tests/unit/tasks/test_openbookqa_kshot_gen.py
@@ -1,0 +1,207 @@
+"""Unit tests for the OpenBookQA k-shot generative task.
+
+AI-Generated Code - Opus 4.8 (Anthropic)
+"""
+
+import pytest
+from datasets import Dataset as HFDataset
+from datasets import DatasetDict as HFDatasetDict
+
+from sieval.community.openbookqa import OBQA_PROMPT_TEMPLATE
+from sieval.core.models import ModelOutput
+from sieval.core.models.chat_model import ChatModel
+from sieval.core.tasks import TaskContext
+from sieval.datasets.openbookqa import OpenBookQADataset, OpenBookQADatasetSample
+from sieval.tasks.openbookqa_kshot_gen import (
+    STOP_SEQUENCES,
+    OpenBookQAFewShotGenTask,
+)
+
+
+class _CapturingChatModel(ChatModel):
+    def __init__(self):
+        super().__init__(model="mock-chat", api_key="fake")
+        self.last_kwargs: dict[str, object] = {}
+
+    async def _agenerate_impl(self, prompt, **kwargs) -> ModelOutput:
+        _ = prompt
+        self.last_kwargs = dict(kwargs)
+        return ModelOutput(model=self.meta(), texts=["The answer is A."])
+
+
+def _sample(stem: str, answer_key: str = "A") -> OpenBookQADatasetSample:
+    return {
+        "id": f"id-{stem}",
+        "question_stem": stem,
+        "choices": {"text": [f"{stem}-a", f"{stem}-b", f"{stem}-c", f"{stem}-d"]},
+        "answerKey": answer_key,
+    }
+
+
+def _dataset(train: list[OpenBookQADatasetSample]) -> OpenBookQADataset:
+    return OpenBookQADataset(
+        _hf_dict=HFDatasetDict(
+            {
+                "train": HFDataset.from_list([dict(s) for s in train]),
+                "test": HFDataset.from_list([dict(_sample("q-test"))]),
+            }
+        )
+    )
+
+
+def _expected_question(sample: OpenBookQADatasetSample) -> str:
+    texts = sample["choices"]["text"]
+    return OBQA_PROMPT_TEMPLATE.format(
+        question_stem=sample["question_stem"],
+        A=texts[0],
+        B=texts[1],
+        C=texts[2],
+        D=texts[3],
+    )
+
+
+@pytest.mark.anyio
+async def test_zero_shot_prompt_has_no_fewshot_prefix():
+    dataset = _dataset([_sample("q-train", "B")])
+    task = OpenBookQAFewShotGenTask(dataset, _CapturingChatModel(), k=0)
+    await task.setup()
+
+    raw = _sample("q-test")
+    pre = await task.preprocess(raw, TaskContext(sample_id=0, raw_sample=raw))
+
+    assert pre == [{"role": "user", "content": _expected_question(raw)}]
+
+
+@pytest.mark.anyio
+async def test_kshot_prefix_uses_fixed_first_k_train_rows_with_answer():
+    train = [_sample("q0", "A"), _sample("q1", "C"), _sample("q2", "D")]
+    dataset = _dataset(train)
+    task = OpenBookQAFewShotGenTask(dataset, _CapturingChatModel(), k=2)
+    await task.setup()
+
+    raw = _sample("q-test")
+    pre = await task.preprocess(raw, TaskContext(sample_id=0, raw_sample=raw))
+    content = pre[0]["content"]
+
+    # Fixed first 2 train rows, each with its answerKey appended, then the question.
+    expected_prefix = (
+        f"{_expected_question(train[0])} A\n\n{_expected_question(train[1])} C\n\n"
+    )
+    assert content == expected_prefix + _expected_question(raw)
+    # Third train row must not leak into a k=2 prompt.
+    assert "q2" not in content
+
+
+@pytest.mark.anyio
+async def test_multiturn_renders_alternating_user_assistant_turns():
+    train = [_sample("q0", "A"), _sample("q1", "C")]
+    dataset = _dataset(train)
+    task = OpenBookQAFewShotGenTask(
+        dataset, _CapturingChatModel(), k=2, fewshot_as_multiturn=True
+    )
+    await task.setup()
+
+    raw = _sample("q-test")
+    pre = await task.preprocess(raw, TaskContext(sample_id=0, raw_sample=raw))
+
+    # Each shot becomes a user(question) + assistant(answerKey) pair, then the
+    # final query as a trailing user turn — no single-turn packing.
+    assert pre == [
+        {"role": "user", "content": _expected_question(train[0])},
+        {"role": "assistant", "content": "A"},
+        {"role": "user", "content": _expected_question(train[1])},
+        {"role": "assistant", "content": "C"},
+        {"role": "user", "content": _expected_question(raw)},
+    ]
+
+
+@pytest.mark.anyio
+async def test_infer_does_not_forward_decoding_params():
+    dataset = _dataset([_sample("q0")])
+    model = _CapturingChatModel()
+    task = OpenBookQAFewShotGenTask(dataset, model, k=0)
+
+    raw = _sample("q-test")
+    await task.infer(
+        [{"role": "user", "content": "x"}],
+        TaskContext(sample_id=0, raw_sample=raw),
+    )
+
+    for forbidden in ("temperature", "top_p", "max_tokens", "n", "stop"):
+        assert forbidden not in model.last_kwargs
+
+
+def test_stop_sequences_pinned():
+    # Coupled to the few-shot block layout (examples begin with "Question:").
+    assert STOP_SEQUENCES == ("\nQuestion:",)
+
+
+@pytest.mark.anyio
+async def test_infer_bounds_generation_at_kshot_but_not_zero_shot():
+    dataset = _dataset([_sample("q0", "A"), _sample("q1", "C")])
+
+    # k>0: bound the run-on that would let a trailing match override the answer.
+    model_k = _CapturingChatModel()
+    task_k = OpenBookQAFewShotGenTask(dataset, model_k, k=2)
+    await task_k.infer(
+        [{"role": "user", "content": "x"}],
+        TaskContext(sample_id=0, raw_sample=_sample("q-test")),
+    )
+    assert model_k.last_kwargs.get("stop") == list(STOP_SEQUENCES)
+
+    # k=0: no stop — preserves upstream 0-shot parity.
+    model_0 = _CapturingChatModel()
+    task_0 = OpenBookQAFewShotGenTask(dataset, model_0, k=0)
+    await task_0.infer(
+        [{"role": "user", "content": "x"}],
+        TaskContext(sample_id=0, raw_sample=_sample("q-test")),
+    )
+    assert "stop" not in model_0.last_kwargs
+
+
+@pytest.mark.anyio
+async def test_feedback_and_report_accuracy_and_field_types():
+    dataset = _dataset([_sample("q0")])
+    task = OpenBookQAFewShotGenTask(dataset, _CapturingChatModel(), k=0)
+
+    correct_raw = _sample("q-test", "A")
+    wrong_raw = _sample("q-test", "B")
+    # postprocess extracts "A" from the mock "The answer is A." response.
+    post = await task.postprocess(
+        ModelOutput(model=task.model.meta(), texts=["The answer is A."]),
+        TaskContext(sample_id=0, raw_sample=correct_raw),
+    )
+    assert post == "A"
+
+    _, fb_correct = await task.feedback(
+        post, TaskContext(sample_id=0, raw_sample=correct_raw)
+    )
+    _, fb_wrong = await task.feedback(
+        post, TaskContext(sample_id=1, raw_sample=wrong_raw)
+    )
+    assert fb_correct["correct"] is True
+    assert fb_wrong["correct"] is False
+
+    finals = [
+        TaskContext(sample_id=0, raw_sample=correct_raw, feedback_result=fb_correct),
+        TaskContext(sample_id=1, raw_sample=wrong_raw, feedback_result=fb_wrong),
+    ]
+    report = await task.report(
+        finals,
+        [TaskContext(sample_id=2, raw_sample=_sample("q-fail"))],
+    )
+
+    # 1 correct out of 2 finalized samples; fails counted separately as int.
+    assert report["score"] == 50.0
+    # `accuracy` names the metric behind `score`; they must agree.
+    assert report["accuracy"] == 50.0
+    assert report["fails"] == 1
+    assert isinstance(report["fails"], int)
+    # MCQ tasks report accuracy only — no pass@1 (sibling consistency).
+    assert "pass@1" not in report
+
+
+def test_negative_k_rejected():
+    dataset = _dataset([_sample("q0")])
+    with pytest.raises(ValueError, match="k must be >= 0"):
+        OpenBookQAFewShotGenTask(dataset, _CapturingChatModel(), k=-1)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Type

- feature — new benchmark, task, or capability


## Summary
- Add OpenBookQA benchmark: dataset loader + chat/instruct k-shot generative task.
- `openbookqa_kshot_gen` (chat): prompt lists A–D, model generates, letter extracted; accuracy metric.
- Prompt template and `first_option_postprocess` vendored byte-for-byte from OpenCompass `obqa_gen_9069e4` (`main` variant).
- Loader mirrors `allenai/openbookqa` as-is (revision-pinned), keeps `choices` native; A–D mapping by position lives in the task.
- `k=0` matches the OpenCompass 0-shot reference; `k>0` is a sieval extension (fixed first-k train rows). Reference: https://github.com/open-compass/opencompass/blob/5767b74899806c0c37efdc5529ffea01e7340e48/opencompass/configs/datasets/obqa/obqa_gen_9069e4.py

## Test Plan

### Automated

- [x] Lint/format clean (`ruff check && ruff format --check`)
- [x] Type check clean (`ty check` or `mypy --strict`)
- [x] Unit tests pass (`pdm run pytest`) <!-- delete if benchmark-only PR -->

### Manual
| Model | Expected | Actual | Diff |
| --- | --- | --- | --- |
| Phi-4-mini-instruct (10-shot) | 79.2| 84.2 | +5.0 (+5.0%) |
| Qwen2.5-3B-Instruct (10-shot) | 79.3 | 82.6 | +3.3(3.3%) |

Note: the ReferenceImpl is OpenCompass `obqa_gen`, which publishes no OBQA score; the only published instruct comparison is the [Phi model card's number](https://huggingface.co/microsoft/Phi-4-mini-instruct), produced by a different (internal) harness, so the >3% gap is expected rather than a reproduction miss. `fails=0` in both runs.


## Checklist

### Required (all PRs)

- [x] PR title follows conventional format (`type(scope): description`)
- [x] No internal paths, credentials, or personal info in committed files
- [x] AI-generated code has `AI-Generated Code - <model> (<provider>)` in module docstring
- [x] No new upper-layer dependencies added to `core/`
- [x] Deleted code verified — no remaining call sites depend on it

### If: New or Modified Benchmark

- [x] Reference paper/repo linked in Summary
- [x] Score comparison table included (model, expected, actual, diff)
- [x] Dataset loading tested (`sieval dataset download <name>` succeeds)
- [x] Task registered in package-level `__init__.py`

### If: community/ Changes

- [x] Upstream diff documented (what differs and why)
- [x] License attribution preserved