### PR TITLE
fix(tasks): pass gold first to math_verify.verify (#18)

### DIFF
--- a/sieval/tasks/aime_2024_0shot_gen.py
+++ b/sieval/tasks/aime_2024_0shot_gen.py
@@ -86,7 +86,8 @@ class AIME2024ZeroShotGenTask(
             try:
                 parsed_pred = parse(pred_with_env)
                 parsed_ref = parse(ref_with_env)
-                correct = verify(parsed_pred, parsed_ref)
+                # math_verify.verify expects the gold answer as the first arg.
+                correct = verify(parsed_ref, parsed_pred)
             except Exception as e:
                 logger.warning("Feedback failed for sample {}: {}", ctx.sample_id, e)
                 correct = False

--- a/sieval/tasks/aime_2025_0shot_gen.py
+++ b/sieval/tasks/aime_2025_0shot_gen.py
@@ -86,7 +86,8 @@ class AIME2025ZeroShotGenTask(
             try:
                 parsed_pred = parse(pred_with_env)
                 parsed_ref = parse(ref_with_env)
-                correct = verify(parsed_pred, parsed_ref)
+                # math_verify.verify expects the gold answer as the first arg.
+                correct = verify(parsed_ref, parsed_pred)
             except Exception as e:
                 logger.warning("Feedback failed for sample {}: {}", ctx.sample_id, e)
                 correct = False

--- a/sieval/tasks/math_500_0shot_gen.py
+++ b/sieval/tasks/math_500_0shot_gen.py
@@ -84,7 +84,8 @@ class MATH500ZeroShotGenTask(
             try:
                 parsed_pred = parse(pred_with_env)
                 parsed_ref = parse(ref_with_env)
-                correct = verify(parsed_pred, parsed_ref)
+                # math_verify.verify expects the gold answer as the first arg.
+                correct = verify(parsed_ref, parsed_pred)
             except Exception as e:
                 logger.warning("Feedback failed for sample {}: {}", ctx.sample_id, e)
                 correct = False


### PR DESCRIPTION
## Type

- fix — bug fix or alignment correction

## Summary

`math_verify.verify` is **non-symmetric** — the gold answer must be the first argument (assignment simplification + interval conversion depend on it). Three existing generative math tasks called it reversed (`verify(pred, gold)`):

- `aime_2024_0shot_gen.py`
- `aime_2025_0shot_gen.py`
- `math_500_0shot_gen.py`

This aligns all three to `verify(gold, pred)` — the order the MathArena tasks (#16) already use — plus a one-line comment at each site.

Impact is low in practice (integer / simple-scalar golds, comparison effectively symmetric), but the order is incorrect per the library contract and can cause false negatives on assignment- or interval-shaped answers.

## Related Issues

Closes #18

## Test Plan

### Automated

- [x] Lint/format clean (ruff — pre-commit hooks passed)
- [x] Type check clean (ty — pre-commit hooks passed)
- [x] Unit tests pass (`pytest tests/unit/tasks/test_{aime_2024,aime_2025,math_500}_0shot_gen.py` — 3 passed)

### Manual

- [x] No score-affecting change for the existing integer-gold runs (comparison is symmetric there); fix is contract-correctness for non-scalar golds.

## Checklist

### Required (all PRs)

- [x] PR title follows conventional format (`type(scope): description`)
- [x] No internal paths, credentials, or personal info in committed files
- [x] AI-generated code has `AI-Generated Code - <model> (<provider>)` in module docstring (unchanged existing files)
- [x] No new upper-layer dependencies added to `core/`
- [x] Deleted code verified — no remaining call sites depend on it