### PR TITLE
feat(models): add SglangGenModel for echoed-input logprobs via sglang /generate

### DIFF
--- a/sieval/cli/leaderboard/session.py
+++ b/sieval/cli/leaderboard/session.py
@@ -24,7 +24,7 @@ from loguru import logger
 
 from sieval.cli.leaderboard.card import AlignmentCard, load_card
 from sieval.core.datasets import Dataset
-from sieval.core.models import ChatModel, GenModel, Model
+from sieval.core.models import ChatModel, GenModel, Model, SglangGenModel
 from sieval.core.runners import MultiTaskRunner, TaskRunnerConfig
 from sieval.core.tasks.context import TaskAction
 from sieval.core.types import JSONValue
@@ -62,6 +62,7 @@ class _InferMetaDict(TypedDict, total=False):
 class ModelConfigDict(TypedDict, total=False):
     name: str  # For base models
     type: Literal["chat", "gen"]  # "chat" or "gen" (default: "chat")
+    engine: Literal["vllm", "sglang"]  # gen backend (default: "vllm")
     base: str  # For derived models
     args: dict[str, Any]
     api_key: str
@@ -978,7 +979,16 @@ class EvalSession:
             model_type = self._infer_model_type(name, explicit_type)
 
             if model_type == "gen":
-                self.models[name] = GenModel(model=model_name, **args)
+                engine = cfg.get("engine", "vllm")
+                if engine == "sglang":
+                    self.models[name] = SglangGenModel(model=model_name, **args)
+                elif engine == "vllm":
+                    self.models[name] = GenModel(model=model_name, **args)
+                else:
+                    raise ValueError(
+                        f"Model '{name}' has invalid engine '{engine}'. "
+                        "Expected 'vllm' or 'sglang'"
+                    )
             elif model_type == "chat":
                 self.models[name] = ChatModel(model=model_name, **args)
             else:

--- a/sieval/cli/leaderboard/session.py
+++ b/sieval/cli/leaderboard/session.py
@@ -978,6 +978,13 @@ class EvalSession:
             explicit_type = cfg.get("type")
             model_type = self._infer_model_type(name, explicit_type)
 
+            # `engine` selects the gen backend; it is meaningless for chat.
+            if "engine" in cfg and model_type != "gen":
+                raise ValueError(
+                    f"Model '{name}': 'engine' is only valid for type: gen, "
+                    f"but this model is '{model_type}'."
+                )
+
             if model_type == "gen":
                 engine = cfg.get("engine", "vllm")
                 if engine == "sglang":
@@ -1030,6 +1037,12 @@ class EvalSession:
                     raise ValueError(
                         f"Derived model '{name}' cannot override api_key/api_base from "
                         f"base model '{base_name}'. Create a new base model instead."
+                    )
+
+                if "engine" in cfg:
+                    raise ValueError(
+                        f"Derived model '{name}' cannot set 'engine'; it is inherited "
+                        f"from base model '{base_name}'. Set it on the base instead."
                     )
 
                 # Extract concurrency_limit separately for with_args

--- a/sieval/cli/leaderboard/session.py
+++ b/sieval/cli/leaderboard/session.py
@@ -1050,23 +1050,35 @@ class EvalSession:
 
                 # Check if type conversion is needed
                 target_type = cfg.get("type")
-                if target_type:
-                    # Convert to target type
-                    if target_type == "gen":
-                        new_model = base_model.as_type(GenModel)
-                    elif target_type == "chat":
-                        new_model = base_model.as_type(ChatModel)
+                if target_type == "gen":
+                    # An sglang-backed base is already "gen"; as_type(GenModel)
+                    # would swap it to the OpenAI /v1/completions path (which
+                    # rejects echo+logprobs), silently defeating engine: sglang.
+                    # Preserve it. A plain GenModel base is unaffected.
+                    if isinstance(base_model, SglangGenModel):
+                        new_model = base_model
                     else:
-                        raise ValueError(
-                            f"Model '{name}' has invalid type '{target_type}'. "
-                            "Expected 'chat' or 'gen'"
-                        )
+                        new_model = base_model.as_type(GenModel)
                     logger.info(
                         "Created derived model '{}' from '{}' "
                         "with type conversion to '{}'",
                         name,
                         base_name,
                         target_type,
+                    )
+                elif target_type == "chat":
+                    new_model = base_model.as_type(ChatModel)
+                    logger.info(
+                        "Created derived model '{}' from '{}' "
+                        "with type conversion to '{}'",
+                        name,
+                        base_name,
+                        target_type,
+                    )
+                elif target_type:
+                    raise ValueError(
+                        f"Model '{name}' has invalid type '{target_type}'. "
+                        "Expected 'chat' or 'gen'"
                     )
                 else:
                     # No type conversion, just derive

--- a/sieval/cli/validation.py
+++ b/sieval/cli/validation.py
@@ -153,6 +153,25 @@ def _validate_models(cfg: dict, result: ValidationResult) -> None:
                 f"Model '{name}': type must be 'chat' or 'gen', got '{model_type}'"
             )
 
+        # `engine` selects the gen backend (mirrors _setup_models' guards; the
+        # engine-on-non-gen check there uses the *inferred* type, so here we
+        # can only flag the statically-decidable explicit `type: chat` case).
+        if "engine" in mcfg:
+            engine = mcfg.get("engine")
+            if has_base:
+                result.errors.append(
+                    f"Model '{name}': derived models cannot set 'engine'; it is "
+                    "inherited from the base model. Set it on the base instead."
+                )
+            elif engine not in ("vllm", "sglang"):
+                result.errors.append(
+                    f"Model '{name}': engine must be 'vllm' or 'sglang', got {engine!r}"
+                )
+            elif model_type == "chat":
+                result.errors.append(
+                    f"Model '{name}': 'engine' is only valid for type: gen, not 'chat'"
+                )
+
         if has_base:
             base_ref = mcfg["base"]
             if not isinstance(base_ref, str) or not base_ref:

--- a/sieval/core/models/__init__.py
+++ b/sieval/core/models/__init__.py
@@ -1,6 +1,7 @@
 from .chat_model import ChatModel
 from .gen_model import GenModel
 from .model import Model, ModelCallMeta, ModelMeta, ModelOutput, ModelUsage
+from .sglang_gen_model import SglangGenModel
 
 __all__ = [
     "ChatModel",
@@ -10,4 +11,5 @@ __all__ = [
     "ModelMeta",
     "ModelOutput",
     "ModelUsage",
+    "SglangGenModel",
 ]

--- a/sieval/core/models/model.py
+++ b/sieval/core/models/model.py
@@ -66,6 +66,11 @@ class ModelOutput:
     texts: list[str]
     finish_reasons: list[str] | None = None
     reasoning_texts: list[str] | None = None
+    # Token texts follow the OpenAI / literal-whitespace convention (leading
+    # spaces preserved, e.g. " A"). Backends that emit other markers (e.g.
+    # sglang byte-level "ĠA") normalize to this contract before populating it,
+    # so consumers can match on literal whitespace rather than per-tokenizer
+    # markers.
     logprobs_tokens: list[str] | None = None
     logprobs: list[float | None] | None = None
     top_logprobs: list[dict[str, float]] | None = None

--- a/sieval/core/models/sglang_gen_model.py
+++ b/sieval/core/models/sglang_gen_model.py
@@ -1,0 +1,135 @@
+"""SglangGenModel: echoed-input logprobs via sglang native /generate.
+
+sglang's OpenAI ``/v1/completions`` endpoint rejects ``echo=True`` together
+with ``logprobs``, so PPL-style tasks (ARC, MMLU-Base, HellaSwag) that read
+the logprob of an answer token appended to the prompt cannot use it. This
+variant overrides only logprob extraction to call the native ``/generate``
+endpoint (``return_logprob=True`` + ``logprob_start_len=0``), which returns
+per-token logprobs over the full echoed input sequence.
+
+AI-Generated Code - Claude Opus 4.8 (Anthropic)
+"""
+
+from typing import override
+
+from sieval.core.types import JSONValue
+
+from .gen_model import GenModel
+from .model import ModelOutput, ModelUsage
+
+
+def _normalize_token_text(text: str) -> str:
+    """Map GPT-2 byte-level BPE markers back to literal whitespace.
+
+    sglang detokenizes when ``return_text_in_logprobs=True``, but some
+    tokenizers (e.g. Qwen) surface the raw byte-level markers ``Ġ`` (space)
+    and ``Ċ`` (newline). ``extract_option_logprob`` matches ``" A"`` /
+    ``A``, so an un-normalized ``"ĠA"`` would silently never match and the
+    prediction would degrade. Normalize here so downstream scoring is fed
+    the same token text the OpenAI path would produce.
+    """
+    return text.replace("Ġ", " ").replace("Ċ", "\n")
+
+
+class SglangGenModel(GenModel):
+    """GenModel variant reading echoed-input logprobs via sglang /generate.
+
+    Only ``_alogprobs_impl`` is overridden; ``_agenerate_impl`` keeps using
+    the OpenAI ``/v1/completions`` endpoint (plain generation works there).
+
+    AI-Generated Code - Claude Opus 4.8 (Anthropic)
+    """
+
+    def _generate_url(self) -> str:
+        """Derive the native ``/generate`` URL from the OpenAI ``/v1`` base."""
+        base = (self._api_base or "").rstrip("/").removesuffix("/v1").rstrip("/")
+        return f"{base}/generate"
+
+    @staticmethod
+    def _parse_logprobs(meta: dict, echo: bool) -> tuple[list[str], list[float | None]]:
+        """Flatten sglang ``*_token_logprobs`` into token-text + logprob lists.
+
+        Each entry is ``[logprob, token_id, token_text]`` (first input
+        logprob is ``None``). With ``echo`` the input segment precedes the
+        output segment so echoed candidate tokens land at the sequence end.
+        """
+        entries: list[list] = []
+        if echo:
+            entries.extend(meta.get("input_token_logprobs") or [])
+        entries.extend(meta.get("output_token_logprobs") or [])
+
+        tokens: list[str] = []
+        token_logprobs: list[float | None] = []
+        for logprob, _token_id, token_text in entries:
+            tokens.append(_normalize_token_text(token_text))
+            token_logprobs.append(logprob)
+        return tokens, token_logprobs
+
+    @staticmethod
+    def _parse_usage(meta: dict) -> ModelUsage | None:
+        """Build ``ModelUsage`` from sglang ``meta_info`` token counts."""
+        input_tokens = meta.get("prompt_tokens")
+        output_tokens = meta.get("completion_tokens")
+        if input_tokens is None or output_tokens is None:
+            return None
+        return {
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "total_tokens": input_tokens + output_tokens,
+        }
+
+    @override
+    async def _alogprobs_impl(
+        self,
+        prompt: str,
+        *,
+        max_tokens: int = 1,
+        logprobs: int = 5,
+        echo: bool = True,
+        temperature: float = 0.0,
+        **kwargs,
+    ) -> ModelOutput:
+        num_choices_raw = {**self._kwargs, **kwargs}.get("n", 1)
+        if isinstance(num_choices_raw, bool) or not isinstance(num_choices_raw, int):
+            raise TypeError(
+                "n must be an int, got "
+                f"{type(num_choices_raw).__name__}: {num_choices_raw!r}"
+            )
+        if num_choices_raw != 1:
+            raise ValueError(
+                f"alogprobs only supports n=1; received n={num_choices_raw}"
+            )
+
+        body: dict[str, JSONValue] = {
+            "text": prompt,
+            "sampling_params": {
+                "temperature": temperature,
+                # sglang rejects max_new_tokens=0; the generated tokens are
+                # ignored for scoring.
+                "max_new_tokens": max(max_tokens, 1),
+            },
+            "return_logprob": True,
+            # 0 → all echoed input token logprobs; -1 → output only.
+            "logprob_start_len": 0 if echo else -1,
+            "top_logprobs_num": logprobs,
+            "return_text_in_logprobs": True,
+        }
+
+        resp = await self._client._client.post(self._generate_url(), json=body)
+        resp.raise_for_status()
+        data = resp.json()
+        meta = data["meta_info"]
+
+        tokens, token_logprobs = self._parse_logprobs(meta, echo)
+        if not token_logprobs:
+            raise RuntimeError("sglang /generate returned no logprobs.")
+
+        return ModelOutput(
+            model=self.meta(),
+            texts=[data.get("text", "")],
+            logprobs_tokens=tokens,
+            logprobs=token_logprobs,
+            usage=self._parse_usage(meta),
+            request_params=body,
+            response_model=self._model,
+        )

--- a/sieval/core/models/sglang_gen_model.py
+++ b/sieval/core/models/sglang_gen_model.py
@@ -1,21 +1,42 @@
-"""SglangGenModel: echoed-input logprobs via sglang native /generate.
+"""SglangGenModel: native sglang ``/generate`` backend for text + logprobs.
 
 sglang's OpenAI ``/v1/completions`` endpoint rejects ``echo=True`` together
-with ``logprobs``, so PPL-style tasks (ARC, MMLU-Base, HellaSwag) that read
-the logprob of an answer token appended to the prompt cannot use it. This
-variant overrides only logprob extraction to call the native ``/generate``
-endpoint (``return_logprob=True`` + ``logprob_start_len=0``), which returns
-per-token logprobs over the full echoed input sequence.
+with ``logprobs``, so PPL-style scoring (ARC/HellaSwag read the logprob of an
+answer token appended to the prompt; CMMLU/MMLU-Base read the first output
+token's top-k) cannot go through it. This model speaks sglang's native
+``/generate`` protocol for BOTH generation and logprob extraction, so a single
+object talks one wire protocol end-to-end.
+
+It extends ``Model[str]`` rather than ``GenModel`` deliberately: the only thing
+``GenModel`` would contribute is its OpenAI-completions ``_agenerate_impl``,
+which is a different protocol than the ``/generate`` logprob path — incidental
+reuse, not coupling. The genuinely shared infrastructure (OpenAI async client,
+limiters, ``with_args``/``meta``, the public ``agenerate``/``alogprobs``
+wrappers) lives in ``Model`` and is inherited directly.
 
 AI-Generated Code - Claude Opus 4.8 (Anthropic)
 """
 
-from typing import override
+from typing import Any, override
 
 from sieval.core.types import JSONValue
 
-from .gen_model import GenModel
-from .model import ModelOutput, ModelUsage
+from .model import Model, ModelOutput, ModelUsage
+
+# OpenAI-style generation kwarg -> sglang sampling_params key. Only these are
+# forwarded to /generate; unrecognized kwargs (e.g. seed, stream, echo) are
+# dropped rather than risk sglang rejecting an unknown sampling param.
+_SAMPLING_PARAM_MAP: dict[str, str] = {
+    "max_tokens": "max_new_tokens",
+    "temperature": "temperature",
+    "top_p": "top_p",
+    "top_k": "top_k",
+    "min_p": "min_p",
+    "stop": "stop",
+    "frequency_penalty": "frequency_penalty",
+    "presence_penalty": "presence_penalty",
+    "repetition_penalty": "repetition_penalty",
+}
 
 
 def _normalize_token_text(text: str) -> str:
@@ -24,18 +45,16 @@ def _normalize_token_text(text: str) -> str:
     sglang detokenizes when ``return_text_in_logprobs=True``, but some
     tokenizers (e.g. Qwen) surface the raw byte-level markers ``Ġ`` (space)
     and ``Ċ`` (newline). ``extract_option_logprob`` matches ``" A"`` /
-    ``A``, so an un-normalized ``"ĠA"`` would silently never match and the
-    prediction would degrade. Normalize here so downstream scoring is fed
-    the same token text the OpenAI path would produce.
+    ``A`` and CMMLU keys its top-k on the token text, so an un-normalized
+    ``"ĠA"`` would silently never match and the prediction would degrade.
+    Normalize here so downstream scoring is fed the same token text the
+    OpenAI path would produce.
     """
     return text.replace("Ġ", " ").replace("Ċ", "\n")
 
 
-class SglangGenModel(GenModel):
-    """GenModel variant reading echoed-input logprobs via sglang /generate.
-
-    Only ``_alogprobs_impl`` is overridden; ``_agenerate_impl`` keeps using
-    the OpenAI ``/v1/completions`` endpoint (plain generation works there).
+class SglangGenModel(Model[str]):
+    """Model backend reading text and logprobs from sglang native ``/generate``.
 
     AI-Generated Code - Claude Opus 4.8 (Anthropic)
     """
@@ -44,6 +63,48 @@ class SglangGenModel(GenModel):
         """Derive the native ``/generate`` URL from the OpenAI ``/v1`` base."""
         base = (self._api_base or "").rstrip("/").removesuffix("/v1").rstrip("/")
         return f"{base}/generate"
+
+    async def _post(self, body: dict[str, JSONValue]) -> Any:
+        """POST ``body`` to ``/generate`` via the OpenAI client.
+
+        Using the public ``self._client.post`` (not the private httpx handle)
+        keeps the configured auth and ``max_retries`` behaviour; an absolute
+        URL is required because the client would otherwise append the path to
+        the ``/v1`` base. Returns the parsed JSON (a dict, or a list when
+        ``sampling_params.n > 1``).
+        """
+        return await self._client.post(self._generate_url(), cast_to=object, body=body)
+
+    @staticmethod
+    def _validate_n(final_kwargs: dict[str, Any]) -> int:
+        """Validate and return ``n`` (mirrors GenModel's guard)."""
+        n = final_kwargs.get("n", 1)
+        if isinstance(n, bool) or not isinstance(n, int):
+            raise TypeError(f"n must be an int, got {type(n).__name__}: {n!r}")
+        if n < 1:
+            raise ValueError(f"n must be >= 1, got {n}")
+        return n
+
+    @classmethod
+    def _sampling_params(
+        cls, final_kwargs: dict[str, Any], *, temperature: float | None = None
+    ) -> dict[str, JSONValue]:
+        """Translate recognized OpenAI-style kwargs into sglang sampling_params."""
+        params: dict[str, JSONValue] = {}
+        for src, dst in _SAMPLING_PARAM_MAP.items():
+            if src in final_kwargs and final_kwargs[src] is not None:
+                params[dst] = final_kwargs[src]
+        if temperature is not None:
+            params["temperature"] = temperature
+        return params
+
+    @staticmethod
+    def _finish_reason(meta: dict) -> str:
+        """Extract a flat finish-reason string from sglang ``meta_info``."""
+        fr = meta.get("finish_reason")
+        if isinstance(fr, dict):
+            return str(fr.get("type", ""))
+        return str(fr) if fr else ""
 
     @staticmethod
     def _parse_logprobs(meta: dict, echo: bool) -> tuple[list[str], list[float | None]]:
@@ -66,6 +127,36 @@ class SglangGenModel(GenModel):
         return tokens, token_logprobs
 
     @staticmethod
+    def _parse_top_logprobs(meta: dict, echo: bool) -> list[dict[str, float]] | None:
+        """Flatten sglang ``*_top_logprobs`` into ``[{token: logprob}, ...]``.
+
+        Aligns index-for-index with the token list from ``_parse_logprobs``
+        (input segment first when ``echo``). A ``None``/empty per-token entry
+        (e.g. the first input token) becomes ``{}``. Returns ``None`` when the
+        server sent no top-k at all, matching ``ModelOutput.top_logprobs``'s
+        optional shape. CMMLU keys A/B/C/D off ``top_logprobs[0]``.
+        """
+        entries: list[Any] = []
+        if echo:
+            entries.extend(meta.get("input_top_logprobs") or [])
+        entries.extend(meta.get("output_top_logprobs") or [])
+        if not entries:
+            return None
+
+        result: list[dict[str, float]] = []
+        for per_token in entries:
+            if not per_token:
+                result.append({})
+                continue
+            result.append(
+                {
+                    _normalize_token_text(token_text): logprob
+                    for logprob, _token_id, token_text in per_token
+                }
+            )
+        return result
+
+    @staticmethod
     def _parse_usage(meta: dict) -> ModelUsage | None:
         """Build ``ModelUsage`` from sglang ``meta_info`` token counts."""
         input_tokens = meta.get("prompt_tokens")
@@ -79,6 +170,49 @@ class SglangGenModel(GenModel):
         }
 
     @override
+    async def _agenerate_impl(self, prompt: str, **kwargs) -> ModelOutput:
+        if not isinstance(prompt, str):
+            raise TypeError("SglangGenModel requires a string prompt.")
+
+        final_kwargs = {**self._kwargs, **kwargs}
+        num_choices = self._validate_n(final_kwargs)
+
+        sampling = self._sampling_params(final_kwargs)
+        if num_choices > 1:
+            sampling["n"] = num_choices
+
+        body: dict[str, JSONValue] = {"text": prompt, "sampling_params": sampling}
+        raw = await self._post(body)
+
+        # n>1 yields a list of per-sample dicts; n==1 a single dict.
+        results = raw if isinstance(raw, list) else [raw]
+        texts = [r.get("text", "") for r in results]
+        metas = [r["meta_info"] for r in results]
+        finish_reasons = [self._finish_reason(m) for m in metas]
+
+        # Prompt tokens are shared across samples; completions sum.
+        input_tokens = metas[0].get("prompt_tokens")
+        output_tokens = sum(m.get("completion_tokens") or 0 for m in metas)
+        usage: ModelUsage | None = (
+            {
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+                "total_tokens": input_tokens + output_tokens,
+            }
+            if input_tokens is not None
+            else None
+        )
+
+        return ModelOutput(
+            model=self.meta(),
+            texts=texts,
+            finish_reasons=finish_reasons,
+            usage=usage,
+            request_params=body,
+            response_model=self._model,
+        )
+
+    @override
     async def _alogprobs_impl(
         self,
         prompt: str,
@@ -89,25 +223,19 @@ class SglangGenModel(GenModel):
         temperature: float = 0.0,
         **kwargs,
     ) -> ModelOutput:
-        num_choices_raw = {**self._kwargs, **kwargs}.get("n", 1)
-        if isinstance(num_choices_raw, bool) or not isinstance(num_choices_raw, int):
-            raise TypeError(
-                "n must be an int, got "
-                f"{type(num_choices_raw).__name__}: {num_choices_raw!r}"
-            )
-        if num_choices_raw != 1:
-            raise ValueError(
-                f"alogprobs only supports n=1; received n={num_choices_raw}"
-            )
+        final_kwargs = {**self._kwargs, **kwargs}
+        num_choices = self._validate_n(final_kwargs)
+        if num_choices > 1:
+            raise ValueError(f"alogprobs only supports n=1; received n={num_choices}")
+
+        sampling = self._sampling_params(final_kwargs, temperature=temperature)
+        # sglang rejects max_new_tokens=0; the generated token is ignored for
+        # scoring but at least one is required.
+        sampling["max_new_tokens"] = max(max_tokens, 1)
 
         body: dict[str, JSONValue] = {
             "text": prompt,
-            "sampling_params": {
-                "temperature": temperature,
-                # sglang rejects max_new_tokens=0; the generated tokens are
-                # ignored for scoring.
-                "max_new_tokens": max(max_tokens, 1),
-            },
+            "sampling_params": sampling,
             "return_logprob": True,
             # 0 → all echoed input token logprobs; -1 → output only.
             "logprob_start_len": 0 if echo else -1,
@@ -115,20 +243,21 @@ class SglangGenModel(GenModel):
             "return_text_in_logprobs": True,
         }
 
-        resp = await self._client._client.post(self._generate_url(), json=body)
-        resp.raise_for_status()
-        data = resp.json()
+        data = await self._post(body)
         meta = data["meta_info"]
 
         tokens, token_logprobs = self._parse_logprobs(meta, echo)
-        if not token_logprobs:
+        top_logprobs = self._parse_top_logprobs(meta, echo)
+        if not token_logprobs and not top_logprobs:
             raise RuntimeError("sglang /generate returned no logprobs.")
 
         return ModelOutput(
             model=self.meta(),
             texts=[data.get("text", "")],
+            finish_reasons=[self._finish_reason(meta)],
             logprobs_tokens=tokens,
             logprobs=token_logprobs,
+            top_logprobs=top_logprobs,
             usage=self._parse_usage(meta),
             request_params=body,
             response_model=self._model,

--- a/sieval/core/models/sglang_gen_model.py
+++ b/sieval/core/models/sglang_gen_model.py
@@ -17,7 +17,7 @@ wrappers) lives in ``Model`` and is inherited directly.
 AI-Generated Code - Claude Opus 4.8 (Anthropic)
 """
 
-from typing import Any, override
+from typing import cast, override
 
 from sieval.core.types import JSONValue
 
@@ -49,6 +49,10 @@ def _normalize_token_text(text: str) -> str:
     ``"ĠA"`` would silently never match and the prediction would degrade.
     Normalize here so downstream scoring is fed the same token text the
     OpenAI path would produce.
+
+    Limitation: only GPT-2 byte-level markers are handled. SentencePiece
+    (``▁``, U+2581) and other tokenizer conventions pass through unchanged —
+    add them here if a tokenizer that uses them needs the same contract.
     """
     return text.replace("Ġ", " ").replace("Ċ", "\n")
 
@@ -64,19 +68,24 @@ class SglangGenModel(Model[str]):
         base = (self._api_base or "").rstrip("/").removesuffix("/v1").rstrip("/")
         return f"{base}/generate"
 
-    async def _post(self, body: dict[str, JSONValue]) -> Any:
+    async def _post(self, body: dict[str, JSONValue]) -> dict | list:
         """POST ``body`` to ``/generate`` via the OpenAI client.
 
-        Using the public ``self._client.post`` (not the private httpx handle)
-        keeps the configured auth and ``max_retries`` behaviour; an absolute
-        URL is required because the client would otherwise append the path to
-        the ``/v1`` base. Returns the parsed JSON (a dict, or a list when
+        Reuses the OpenAI SDK's low-level ``self._client.post`` to speak the
+        native ``/generate`` protocol: this keeps the configured auth and
+        ``max_retries``, and an absolute URL is required because the client
+        would otherwise append the path to the ``/v1`` base. It couples us to
+        an SDK-internal surface — the client/protocol decoupling is tracked in
+        RFC #25. Returns the parsed JSON (a dict, or a list when
         ``sampling_params.n > 1``).
         """
-        return await self._client.post(self._generate_url(), cast_to=object, body=body)
+        return cast(
+            "dict | list",
+            await self._client.post(self._generate_url(), cast_to=object, body=body),
+        )
 
     @staticmethod
-    def _validate_n(final_kwargs: dict[str, Any]) -> int:
+    def _validate_n(final_kwargs: dict) -> int:
         """Validate and return ``n`` (mirrors GenModel's guard)."""
         n = final_kwargs.get("n", 1)
         if isinstance(n, bool) or not isinstance(n, int):
@@ -87,7 +96,7 @@ class SglangGenModel(Model[str]):
 
     @classmethod
     def _sampling_params(
-        cls, final_kwargs: dict[str, Any], *, temperature: float | None = None
+        cls, final_kwargs: dict, *, temperature: float | None = None
     ) -> dict[str, JSONValue]:
         """Translate recognized OpenAI-style kwargs into sglang sampling_params."""
         params: dict[str, JSONValue] = {}
@@ -136,7 +145,7 @@ class SglangGenModel(Model[str]):
         server sent no top-k at all, matching ``ModelOutput.top_logprobs``'s
         optional shape. CMMLU keys A/B/C/D off ``top_logprobs[0]``.
         """
-        entries: list[Any] = []
+        entries: list = []
         if echo:
             entries.extend(meta.get("input_top_logprobs") or [])
         entries.extend(meta.get("output_top_logprobs") or [])
@@ -244,7 +253,32 @@ class SglangGenModel(Model[str]):
         }
 
         data = await self._post(body)
+        if not isinstance(data, dict):
+            raise RuntimeError(
+                f"sglang /generate returned {type(data).__name__}, expected an object."
+            )
         meta = data["meta_info"]
+
+        # sglang's radix prefix cache does not recompute logprobs for cached
+        # positions: on a cache hit it truncates input_token_logprobs to
+        # (prompt_tokens - cached_tokens). echo-based scoring reads the full
+        # echoed input sequence, so a truncated set would score silently wrong
+        # (vLLM errors in this case; sglang stays silent). Fail loud instead.
+        if echo:
+            input_lps = meta.get("input_token_logprobs") or []
+            prompt_tokens = meta.get("prompt_tokens")
+            cached_tokens = meta.get("cached_tokens") or 0
+            if cached_tokens or (
+                prompt_tokens is not None and len(input_lps) != prompt_tokens
+            ):
+                raise RuntimeError(
+                    "sglang returned partial echoed-input logprobs "
+                    f"({len(input_lps)} of {prompt_tokens} prompt tokens, "
+                    f"cached_tokens={cached_tokens}): its radix prefix cache does "
+                    "not recompute logprobs for cached positions, so echo-based "
+                    "scoring would be silently wrong. Launch sglang with "
+                    "--disable-radix-cache."
+                )
 
         tokens, token_logprobs = self._parse_logprobs(meta, echo)
         top_logprobs = self._parse_top_logprobs(meta, echo)

--- a/sieval/core/models/sglang_gen_model.py
+++ b/sieval/core/models/sglang_gen_model.py
@@ -51,7 +51,7 @@ def _request_params(body: dict[str, JSONValue]) -> dict[str, JSONValue]:
     return {k: v for k, v in body.items() if k != "text"}
 
 
-def _normalize_token_text(text: str) -> str:
+def _normalize_token_text(text: str | None) -> str:
     """Map GPT-2 byte-level BPE markers back to literal whitespace.
 
     sglang detokenizes when ``return_text_in_logprobs=True``, but some
@@ -62,10 +62,22 @@ def _normalize_token_text(text: str) -> str:
     Normalize here so downstream scoring is fed the same token text the
     OpenAI path would produce.
 
+    ``text`` is ``None`` when the server did not detokenize the logprobs
+    (a server launched with ``--skip-tokenizer-init`` ignores
+    ``return_text_in_logprobs``). Letter/option scoring cannot work without
+    token text, so fail loud with an actionable message rather than crash on
+    ``None.replace`` or silently degrade every token to ``""``.
+
     Limitation: only GPT-2 byte-level markers are handled. SentencePiece
     (``▁``, U+2581) and other tokenizer conventions pass through unchanged —
     add them here if a tokenizer that uses them needs the same contract.
     """
+    if text is None:
+        raise RuntimeError(
+            "sglang returned a logprob entry with no token text; option/letter "
+            "scoring needs detokenized text. Do not launch sglang with "
+            "--skip-tokenizer-init (it ignores return_text_in_logprobs)."
+        )
     return text.replace("Ġ", " ").replace("Ċ", "\n")
 
 
@@ -156,6 +168,11 @@ class SglangGenModel(Model[str]):
         (e.g. the first input token) becomes ``{}``. Returns ``None`` when the
         server sent no top-k at all, matching ``ModelOutput.top_logprobs``'s
         optional shape. CMMLU keys A/B/C/D off ``top_logprobs[0]``.
+
+        Distinct token ids can normalize to identical text (e.g. a byte-level
+        ``"ĠA"`` and a literal ``" A"`` both → ``" A"``). Coalescing them by
+        keeping the highest logprob prevents a low-probability duplicate from
+        clobbering the real one, matching CMMLU's max-over-strip semantics.
         """
         entries: list = []
         if echo:
@@ -169,12 +186,12 @@ class SglangGenModel(Model[str]):
             if not per_token:
                 result.append({})
                 continue
-            result.append(
-                {
-                    _normalize_token_text(token_text): logprob
-                    for logprob, _token_id, token_text in per_token
-                }
-            )
+            merged: dict[str, float] = {}
+            for logprob, _token_id, token_text in per_token:
+                key = _normalize_token_text(token_text)
+                if key not in merged or logprob > merged[key]:
+                    merged[key] = logprob
+            result.append(merged)
         return result
 
     @staticmethod

--- a/sieval/core/models/sglang_gen_model.py
+++ b/sieval/core/models/sglang_gen_model.py
@@ -39,6 +39,18 @@ _SAMPLING_PARAM_MAP: dict[str, str] = {
 }
 
 
+def _request_params(body: dict[str, JSONValue]) -> dict[str, JSONValue]:
+    """Return the persisted request params: the /generate body minus the prompt.
+
+    ``body["text"]`` is the full prompt, already recorded as the sample input —
+    copying it verbatim into every per-call record would duplicate it. This
+    shape is sglang-native (``sampling_params`` etc.) and intentionally differs
+    from the OpenAI-flavoured ``GenModel``/``ChatModel`` request_params; the
+    client/protocol decoupling that would unify them is tracked in RFC #25.
+    """
+    return {k: v for k, v in body.items() if k != "text"}
+
+
 def _normalize_token_text(text: str) -> str:
     """Map GPT-2 byte-level BPE markers back to literal whitespace.
 
@@ -195,6 +207,13 @@ class SglangGenModel(Model[str]):
 
         # n>1 yields a list of per-sample dicts; n==1 a single dict.
         results = raw if isinstance(raw, list) else [raw]
+        if not results or not all(
+            isinstance(r, dict) and "meta_info" in r for r in results
+        ):
+            raise RuntimeError(
+                "sglang /generate returned an unexpected response shape "
+                "(missing meta_info)."
+            )
         texts = [r.get("text", "") for r in results]
         metas = [r["meta_info"] for r in results]
         finish_reasons = [self._finish_reason(m) for m in metas]
@@ -217,7 +236,7 @@ class SglangGenModel(Model[str]):
             texts=texts,
             finish_reasons=finish_reasons,
             usage=usage,
-            request_params=body,
+            request_params=_request_params(body),
             response_model=self._model,
         )
 
@@ -263,14 +282,21 @@ class SglangGenModel(Model[str]):
         # positions: on a cache hit it truncates input_token_logprobs to
         # (prompt_tokens - cached_tokens). echo-based scoring reads the full
         # echoed input sequence, so a truncated set would score silently wrong
-        # (vLLM errors in this case; sglang stays silent). Fail loud instead.
+        # (vLLM errors in this case; sglang stays silent). Deliberate stance:
+        # ANY cache touch — or a response we can't verify against because it
+        # omitted prompt_tokens — is untrusted, so fail loud. echo-based scoring
+        # requires launching sglang with --disable-radix-cache.
         if echo:
             input_lps = meta.get("input_token_logprobs") or []
             prompt_tokens = meta.get("prompt_tokens")
             cached_tokens = meta.get("cached_tokens") or 0
-            if cached_tokens or (
-                prompt_tokens is not None and len(input_lps) != prompt_tokens
-            ):
+            if prompt_tokens is None:
+                raise RuntimeError(
+                    "sglang response omitted prompt_tokens, so echoed-input "
+                    "completeness cannot be verified; refusing to score silently. "
+                    "Launch sglang with --disable-radix-cache."
+                )
+            if cached_tokens or len(input_lps) != prompt_tokens:
                 raise RuntimeError(
                     "sglang returned partial echoed-input logprobs "
                     f"({len(input_lps)} of {prompt_tokens} prompt tokens, "
@@ -293,6 +319,6 @@ class SglangGenModel(Model[str]):
             logprobs=token_logprobs,
             top_logprobs=top_logprobs,
             usage=self._parse_usage(meta),
-            request_params=body,
+            request_params=_request_params(body),
             response_model=self._model,
         )

--- a/sieval/core/models/sglang_gen_model.py
+++ b/sieval/core/models/sglang_gen_model.py
@@ -198,6 +198,10 @@ class SglangGenModel(Model[str]):
         final_kwargs = {**self._kwargs, **kwargs}
         num_choices = self._validate_n(final_kwargs)
 
+        # Cross-engine parity note: with max_tokens unset no max_new_tokens is
+        # sent, so sglang applies its own default (128) while the vllm/OpenAI
+        # completions path applies the OpenAI default. Set max_tokens explicitly
+        # for identical output length when flipping engine: vllm <-> sglang.
         sampling = self._sampling_params(final_kwargs)
         if num_choices > 1:
             sampling["n"] = num_choices

--- a/sieval/core/tasks/task.py
+++ b/sieval/core/tasks/task.py
@@ -61,12 +61,12 @@ class Task[
 
     def _validate_model_type(self) -> None:
         """Raise ``TypeError`` if the model's kind does not match :attr:`model_type`."""
-        from sieval.core.models import ChatModel, GenModel
+        from sieval.core.models import ChatModel, GenModel, SglangGenModel
 
         expected_type = self.model_type
         if isinstance(self._model, ChatModel):
             actual_type = "chat"
-        elif isinstance(self._model, GenModel):
+        elif isinstance(self._model, (GenModel, SglangGenModel)):
             actual_type = "gen"
         else:
             raise TypeError(

--- a/tests/unit/cli/leaderboard/test_session.py
+++ b/tests/unit/cli/leaderboard/test_session.py
@@ -500,6 +500,54 @@ class TestInferModelType:
             runner._infer_model_type("m", None)
 
 
+class TestSetupModelsEngine:
+    """`engine` field dispatches a gen model to GenModel vs SglangGenModel."""
+
+    def _make_runner(self, models_cfg):
+        runner = object.__new__(EvalSession)
+        runner.config = {"models": models_cfg, "tasks": {}}
+        runner.models = {}
+        runner.deterministic = False
+        runner.model_override = None
+        return runner
+
+    def test_default_engine_is_gen_model(self):
+        from sieval.core.models import GenModel, SglangGenModel
+
+        runner = self._make_runner(
+            {"m": {"name": "x", "type": "gen", "api_key": "local"}}
+        )
+        runner._setup_models()
+        assert isinstance(runner.models["m"], GenModel)
+        assert not isinstance(runner.models["m"], SglangGenModel)
+
+    def test_sglang_engine_is_sglang_gen_model(self):
+        from sieval.core.models import SglangGenModel
+
+        runner = self._make_runner(
+            {"m": {"name": "x", "type": "gen", "engine": "sglang", "api_key": "local"}}
+        )
+        runner._setup_models()
+        assert isinstance(runner.models["m"], SglangGenModel)
+
+    def test_explicit_vllm_engine_is_gen_model(self):
+        from sieval.core.models import GenModel, SglangGenModel
+
+        runner = self._make_runner(
+            {"m": {"name": "x", "type": "gen", "engine": "vllm", "api_key": "local"}}
+        )
+        runner._setup_models()
+        assert isinstance(runner.models["m"], GenModel)
+        assert not isinstance(runner.models["m"], SglangGenModel)
+
+    def test_invalid_engine_raises(self):
+        runner = self._make_runner(
+            {"m": {"name": "x", "type": "gen", "engine": "bogus", "api_key": "local"}}
+        )
+        with pytest.raises(ValueError, match="invalid engine"):
+            runner._setup_models()
+
+
 # ===================================================================
 # Resolve task model / dataset helpers
 # ===================================================================

--- a/tests/unit/cli/leaderboard/test_session.py
+++ b/tests/unit/cli/leaderboard/test_session.py
@@ -547,6 +547,23 @@ class TestSetupModelsEngine:
         with pytest.raises(ValueError, match="invalid engine"):
             runner._setup_models()
 
+    def test_engine_on_chat_model_raises(self):
+        runner = self._make_runner(
+            {"m": {"name": "x", "type": "chat", "engine": "sglang", "api_key": "local"}}
+        )
+        with pytest.raises(ValueError, match="only valid for type: gen"):
+            runner._setup_models()
+
+    def test_engine_on_derived_model_raises(self):
+        runner = self._make_runner(
+            {
+                "base_m": {"name": "x", "type": "gen", "api_key": "local"},
+                "d": {"base": "base_m", "engine": "sglang"},
+            }
+        )
+        with pytest.raises(ValueError, match="cannot set 'engine'"):
+            runner._setup_models()
+
 
 # ===================================================================
 # Resolve task model / dataset helpers

--- a/tests/unit/cli/leaderboard/test_session.py
+++ b/tests/unit/cli/leaderboard/test_session.py
@@ -564,6 +564,25 @@ class TestSetupModelsEngine:
         with pytest.raises(ValueError, match="cannot set 'engine'"):
             runner._setup_models()
 
+    def test_derived_type_gen_preserves_sglang_base(self):
+        """`type: gen` on a derived model of an sglang base must NOT downgrade it
+        to GenModel (which would silently switch to /v1/completions)."""
+        from sieval.core.models import SglangGenModel
+
+        runner = self._make_runner(
+            {
+                "base_m": {
+                    "name": "x",
+                    "type": "gen",
+                    "engine": "sglang",
+                    "api_key": "local",
+                },
+                "d": {"base": "base_m", "type": "gen", "args": {"temperature": 0.5}},
+            }
+        )
+        runner._setup_models()
+        assert isinstance(runner.models["d"], SglangGenModel)
+
 
 # ===================================================================
 # Resolve task model / dataset helpers

--- a/tests/unit/cli/test_validation.py
+++ b/tests/unit/cli/test_validation.py
@@ -230,6 +230,57 @@ class TestValidateModels:
         assert not result.ok
         assert any("type" in e for e in result.errors)
 
+    def test_invalid_engine_value(self):
+        cfg = {
+            "models": {"m": {"name": "x", "type": "gen", "engine": "bogus"}},
+            "datasets": {},
+            "tasks": {},
+        }
+        result = validate_eval_config(cfg)
+        assert not result.ok
+        assert any("engine must be" in e for e in result.errors)
+
+    def test_engine_on_chat_model(self):
+        cfg = {
+            "models": {"m": {"name": "x", "type": "chat", "engine": "sglang"}},
+            "datasets": {},
+            "tasks": {},
+        }
+        result = validate_eval_config(cfg)
+        assert not result.ok
+        assert any("only valid for type: gen" in e for e in result.errors)
+
+    def test_engine_on_derived_model(self):
+        cfg = {
+            "models": {
+                "base": {"name": "x", "type": "gen", "engine": "sglang"},
+                "d": {"base": "base", "engine": "sglang"},
+            },
+            "datasets": {},
+            "tasks": {},
+        }
+        result = validate_eval_config(cfg)
+        assert not result.ok
+        assert any("cannot set 'engine'" in e for e in result.errors)
+
+    def test_valid_engine_sglang(self):
+        cfg = {
+            "models": {"m": {"name": "x", "type": "gen", "engine": "sglang"}},
+            "datasets": {},
+            "tasks": {},
+        }
+        result = validate_eval_config(cfg)
+        assert result.ok, result.errors
+
+    def test_valid_engine_vllm(self):
+        cfg = {
+            "models": {"m": {"name": "x", "type": "gen", "engine": "vllm"}},
+            "datasets": {},
+            "tasks": {},
+        }
+        result = validate_eval_config(cfg)
+        assert result.ok, result.errors
+
     def test_name_and_base_coexist(self):
         cfg = {
             "models": {"m": {"name": "gpt-4", "base": "other"}},

--- a/tests/unit/core/models/test_sglang_gen_model.py
+++ b/tests/unit/core/models/test_sglang_gen_model.py
@@ -1,17 +1,18 @@
 """
 Unit tests for sieval/core/models/sglang_gen_model.py.
 
-Covers: /generate URL derivation, request body, echo→logprob_start_len,
-input_token_logprobs parsing, token-text normalization, end-to-end
-extract_option_logprob / total_logprob consumption, array ordering, and the
-n>1 / empty-logprobs / max_tokens guards. The httpx POST is mocked — no real
-traffic.
+Covers native /generate generation (_agenerate_impl) and logprob extraction
+(_alogprobs_impl): URL derivation, request body, sampling-param translation,
+echo→logprob_start_len, input/output token-logprob + top-logprob parsing,
+token-text normalization, end-to-end extract_option_logprob / total_logprob /
+CMMLU-style top-k consumption, and the n / empty-response guards. The OpenAI
+client's public ``post`` is mocked — no real traffic.
 
 AI-Generated Code - Claude Opus 4.8 (Anthropic)
 """
 
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -30,23 +31,26 @@ def model():
     )
 
 
-def _patch_post(model: SglangGenModel, payload: dict):
-    """Mock the underlying httpx POST to return ``payload`` as JSON."""
-    resp = MagicMock()
-    resp.raise_for_status = MagicMock()
-    resp.json = MagicMock(return_value=payload)
-    mock_post = AsyncMock(return_value=resp)
-    target: Any = model._client._client
+def _patch_post(model: SglangGenModel, payload):
+    """Mock the OpenAI client's public ``post`` to return ``payload``."""
+    mock_post = AsyncMock(return_value=payload)
+    target: Any = model._client
     target.post = mock_post  # type: ignore[invalid-assignment]
     return mock_post
 
 
-def _meta(input_entries=None, output_entries=None, **extra):
+def _meta(
+    input_entries=None, output_entries=None, input_top=None, output_top=None, **extra
+):
     meta: dict[str, Any] = {}
     if input_entries is not None:
         meta["input_token_logprobs"] = input_entries
     if output_entries is not None:
         meta["output_token_logprobs"] = output_entries
+    if input_top is not None:
+        meta["input_top_logprobs"] = input_top
+    if output_top is not None:
+        meta["output_top_logprobs"] = output_top
     meta.update(extra)
     return meta
 
@@ -86,7 +90,83 @@ class TestNormalizeTokenText:
 
 
 # ===================================================================
-# Request body
+# _agenerate_impl (native /generate generation)
+# ===================================================================
+class TestAgenerate:
+    @pytest.mark.anyio
+    async def test_basic_generation(self, model):
+        post = _patch_post(
+            model,
+            {
+                "text": "hello world",
+                "meta_info": _meta(prompt_tokens=5, completion_tokens=2),
+            },
+        )
+        out = await model._agenerate_impl("hi")
+        assert isinstance(out, ModelOutput)
+        assert out.texts == ["hello world"]
+        assert out.usage == {"input_tokens": 5, "output_tokens": 2, "total_tokens": 7}
+        # posts to /generate with the text; no return_logprob for plain generation.
+        assert post.call_args[0][0] == "http://host:8000/generate"
+        body = post.call_args[1]["body"]
+        assert body["text"] == "hi"
+        assert "return_logprob" not in body
+
+    @pytest.mark.anyio
+    async def test_non_string_prompt_raises(self, model):
+        with pytest.raises(TypeError, match="requires a string"):
+            await model._agenerate_impl(["not", "a", "string"])
+
+    @pytest.mark.anyio
+    async def test_sampling_param_translation(self, model):
+        post = _patch_post(model, {"text": "x", "meta_info": _meta()})
+        await model._agenerate_impl(
+            "hi", max_tokens=64, temperature=0.7, top_p=0.9, seed=123
+        )
+        sp = post.call_args[1]["body"]["sampling_params"]
+        assert sp["max_new_tokens"] == 64
+        assert sp["temperature"] == 0.7
+        assert sp["top_p"] == 0.9
+        # unmapped kwargs (seed) are dropped, not forwarded to sglang.
+        assert "seed" not in sp
+
+    @pytest.mark.anyio
+    async def test_n_gt_1_list_response(self, model):
+        post = _patch_post(
+            model,
+            [
+                {"text": "a", "meta_info": _meta(prompt_tokens=4, completion_tokens=1)},
+                {"text": "b", "meta_info": _meta(prompt_tokens=4, completion_tokens=2)},
+            ],
+        )
+        out = await model._agenerate_impl("hi", n=2)
+        assert out.texts == ["a", "b"]
+        # prompt tokens counted once, completions summed
+        assert out.usage == {"input_tokens": 4, "output_tokens": 3, "total_tokens": 7}
+        assert post.call_args[1]["body"]["sampling_params"]["n"] == 2
+
+    @pytest.mark.anyio
+    async def test_finish_reason_extracted(self, model):
+        _patch_post(
+            model,
+            {"text": "x", "meta_info": _meta(finish_reason={"type": "length"})},
+        )
+        out = await model._agenerate_impl("hi")
+        assert out.finish_reasons == ["length"]
+
+    @pytest.mark.anyio
+    async def test_n_non_int_raises(self, model):
+        with pytest.raises(TypeError, match="n must be an int"):
+            await model._agenerate_impl("hi", n="2")
+
+    @pytest.mark.anyio
+    async def test_n_lt_1_raises(self, model):
+        with pytest.raises(ValueError, match="n must be >= 1"):
+            await model._agenerate_impl("hi", n=0)
+
+
+# ===================================================================
+# _alogprobs_impl request body
 # ===================================================================
 class TestRequestBody:
     @pytest.mark.anyio
@@ -95,13 +175,17 @@ class TestRequestBody:
             model, {"text": "", "meta_info": _meta(input_entries=[[-0.1, 1, " A"]])}
         )
         await model._alogprobs_impl("prompt", max_tokens=1, logprobs=5, echo=True)
-        body = post.call_args[1]["json"]
+        body = post.call_args[1]["body"]
         assert body["text"] == "prompt"
         assert body["return_logprob"] is True
         assert body["logprob_start_len"] == 0
         assert body["top_logprobs_num"] == 5
         assert body["return_text_in_logprobs"] is True
         assert body["sampling_params"]["max_new_tokens"] == 1
+        assert body["sampling_params"]["temperature"] == 0.0
+        # routed through the public client with an absolute URL.
+        assert post.call_args[0][0] == "http://host:8000/generate"
+        assert post.call_args[1]["cast_to"] is object
 
     @pytest.mark.anyio
     async def test_echo_false_sets_start_len_minus_one(self, model):
@@ -109,7 +193,7 @@ class TestRequestBody:
             model, {"text": "", "meta_info": _meta(output_entries=[[-0.1, 1, "x"]])}
         )
         await model._alogprobs_impl("prompt", echo=False)
-        assert post.call_args[1]["json"]["logprob_start_len"] == -1
+        assert post.call_args[1]["body"]["logprob_start_len"] == -1
 
     @pytest.mark.anyio
     async def test_max_tokens_floored_to_one(self, model):
@@ -117,19 +201,11 @@ class TestRequestBody:
             model, {"text": "", "meta_info": _meta(input_entries=[[-0.1, 1, " A"]])}
         )
         await model._alogprobs_impl("prompt", max_tokens=0)
-        assert post.call_args[1]["json"]["sampling_params"]["max_new_tokens"] == 1
-
-    @pytest.mark.anyio
-    async def test_url_targeted(self, model):
-        post = _patch_post(
-            model, {"text": "", "meta_info": _meta(input_entries=[[-0.1, 1, " A"]])}
-        )
-        await model._alogprobs_impl("prompt")
-        assert post.call_args[0][0] == "http://host:8000/generate"
+        assert post.call_args[1]["body"]["sampling_params"]["max_new_tokens"] == 1
 
 
 # ===================================================================
-# Parsing
+# Chosen-token logprob parsing
 # ===================================================================
 class TestParsing:
     @pytest.mark.anyio
@@ -139,7 +215,6 @@ class TestParsing:
         )
         _patch_post(model, {"text": "", "meta_info": meta})
         out = await model._alogprobs_impl("prompt")
-        assert isinstance(out, ModelOutput)
         assert out.logprobs_tokens == ["The", " cat", " A"]
         assert out.logprobs == [None, -0.5, -0.1]
 
@@ -152,7 +227,6 @@ class TestParsing:
 
     @pytest.mark.anyio
     async def test_array_ordering_input_then_output(self, model):
-        """echo=True keeps candidate tokens (output) after the input segment."""
         meta = _meta(
             input_entries=[[None, 1, "Q"], [-0.2, 2, " B"]],
             output_entries=[[-0.3, 3, " gen"]],
@@ -163,19 +237,20 @@ class TestParsing:
         assert out.logprobs == [None, -0.2, -0.3]
 
     @pytest.mark.anyio
+    async def test_finish_reason_on_logprobs(self, model):
+        meta = _meta(input_entries=[[-0.1, 1, " A"]], finish_reason={"type": "length"})
+        _patch_post(model, {"text": "", "meta_info": meta})
+        out = await model._alogprobs_impl("prompt")
+        assert out.finish_reasons == ["length"]
+
+    @pytest.mark.anyio
     async def test_usage_parsed(self, model):
         meta = _meta(
-            input_entries=[[-0.1, 1, " A"]],
-            prompt_tokens=7,
-            completion_tokens=1,
+            input_entries=[[-0.1, 1, " A"]], prompt_tokens=7, completion_tokens=1
         )
         _patch_post(model, {"text": "", "meta_info": meta})
         out = await model._alogprobs_impl("prompt")
-        assert out.usage == {
-            "input_tokens": 7,
-            "output_tokens": 1,
-            "total_tokens": 8,
-        }
+        assert out.usage == {"input_tokens": 7, "output_tokens": 1, "total_tokens": 8}
 
     @pytest.mark.anyio
     async def test_usage_none_when_counts_absent(self, model):
@@ -186,12 +261,94 @@ class TestParsing:
 
 
 # ===================================================================
-# End-to-end consumption by ppl utilities
+# Top-k logprob parsing (CMMLU / MMLU-Base consumption)
+# ===================================================================
+class TestTopLogprobs:
+    @pytest.mark.anyio
+    async def test_output_top_logprobs_echo_false(self, model):
+        """CMMLU shape: echo=False, first output token's top-k as {token: logprob}."""
+        meta = _meta(
+            output_entries=[[-0.7, 100, " A"]],
+            output_top=[[[-0.7, 100, " A"], [-1.2, 101, " B"], [-3.0, 102, " C"]]],
+        )
+        _patch_post(model, {"text": " A", "meta_info": meta})
+        out = await model._alogprobs_impl("prompt", echo=False)
+        assert out.top_logprobs == [{" A": -0.7, " B": -1.2, " C": -3.0}]
+
+    @pytest.mark.anyio
+    async def test_top_logprobs_normalized_keys(self, model):
+        meta = _meta(
+            output_entries=[[-0.7, 100, "ĠA"]],
+            output_top=[[[-0.7, 100, "ĠA"], [-1.2, 101, "ĠB"]]],
+        )
+        _patch_post(model, {"text": "", "meta_info": meta})
+        out = await model._alogprobs_impl("prompt", echo=False)
+        assert out.top_logprobs == [{" A": -0.7, " B": -1.2}]
+
+    @pytest.mark.anyio
+    async def test_top_logprobs_echo_aligns_input_first(self, model):
+        """echo=True: input top-k precede output; None/empty first entry → {}."""
+        meta = _meta(
+            input_entries=[[None, 1, "Q"], [-0.2, 2, " B"]],
+            output_entries=[[-0.3, 3, " g"]],
+            input_top=[None, [[-0.2, 2, " B"], [-0.9, 9, " C"]]],
+            output_top=[[[-0.3, 3, " g"]]],
+        )
+        _patch_post(model, {"text": " g", "meta_info": meta})
+        out = await model._alogprobs_impl("prompt", echo=True)
+        assert out.top_logprobs == [{}, {" B": -0.2, " C": -0.9}, {" g": -0.3}]
+
+    @pytest.mark.anyio
+    async def test_top_logprobs_none_when_absent(self, model):
+        meta = _meta(input_entries=[[-0.1, 1, " A"]])
+        _patch_post(model, {"text": "", "meta_info": meta})
+        out = await model._alogprobs_impl("prompt")
+        assert out.top_logprobs is None
+
+    @pytest.mark.anyio
+    async def test_cmmlu_style_scoring(self, model):
+        """Map first output token's top-k onto A/B/C/D (echo=False, CMMLU shape)."""
+        meta = _meta(
+            output_entries=[[-0.7, 100, " B"]],
+            output_top=[
+                [[-2.0, 1, " A"], [-0.7, 2, " B"], [-3.0, 3, " C"], [-2.5, 4, " D"]]
+            ],
+        )
+        _patch_post(model, {"text": " B", "meta_info": meta})
+        out = await model._alogprobs_impl("prompt", echo=False, logprobs=100)
+        scores = {tok.strip(): lp for tok, lp in (out.top_logprobs or [{}])[0].items()}
+        assert max(scores, key=lambda k: scores[k]) == "B"
+
+    @pytest.mark.anyio
+    async def test_distinct_tokens_stripping_to_same_letter_both_kept(self, model):
+        """Two tokens stripping to the same letter (' B' vs '\\tB') stay distinct.
+
+        Observed live on Qwen2.5-72B: the greedy ' B' (high logprob) and a
+        rare '\\tB' (very low) both strip to 'B'. They have different
+        normalized text, so they must remain SEPARATE dict entries — that is
+        what lets CMMLU's ``max``-over-strip recover the high logprob rather
+        than clobbering it with the low one.
+        """
+        meta = _meta(
+            output_entries=[[-0.007, 425, " B"]],
+            output_top=[[[-0.007, 425, " B"], [-11.94, 12791, "\tB"]]],
+        )
+        _patch_post(model, {"text": " B", "meta_info": meta})
+        out = await model._alogprobs_impl("prompt", echo=False, logprobs=100)
+        assert out.top_logprobs == [{" B": -0.007, "\tB": -11.94}]
+        # A max-over-strip consumer (CMMLU) recovers the high logprob.
+        best = max(
+            (lp for tok, lp in out.top_logprobs[0].items() if tok.strip() == "B")
+        )
+        assert best == -0.007
+
+
+# ===================================================================
+# End-to-end consumption by echo-based ppl utilities
 # ===================================================================
 class TestPplConsumption:
     @pytest.mark.anyio
     async def test_extract_option_logprob_finds_letter(self, model):
-        """A sequence ending in ' A' must yield the letter's logprob."""
         meta = _meta(
             input_entries=[
                 [None, 1, "Question:"],
@@ -201,18 +358,12 @@ class TestPplConsumption:
         )
         _patch_post(model, {"text": "", "meta_info": meta})
         out = await model._alogprobs_impl("Question: text A", echo=True)
-        lp = extract_option_logprob(out.logprobs_tokens, out.logprobs, "A")
-        assert lp == -0.7
+        assert extract_option_logprob(out.logprobs_tokens, out.logprobs, "A") == -0.7
 
     @pytest.mark.anyio
     async def test_total_logprob_sums_continuation(self, model):
-        """total_logprob skips the leading None and sums the rest."""
         meta = _meta(
-            input_entries=[
-                [None, 1, "Ctx"],
-                [-1.0, 2, " the"],
-                [-2.0, 3, " end"],
-            ],
+            input_entries=[[None, 1, "Ctx"], [-1.0, 2, " the"], [-2.0, 3, " end"]],
         )
         _patch_post(model, {"text": "", "meta_info": meta})
         out = await model._alogprobs_impl("Ctx the end", echo=True)
@@ -243,7 +394,8 @@ class TestGuards:
             await model._alogprobs_impl("prompt", n=True)
 
     @pytest.mark.anyio
-    async def test_empty_logprobs_raises(self, model):
+    async def test_empty_response_raises(self, model):
+        """No token logprobs AND no top logprobs → raise (retryable failure)."""
         _patch_post(model, {"text": "", "meta_info": _meta(input_entries=[])})
         with pytest.raises(RuntimeError, match="no logprobs"):
             await model._alogprobs_impl("prompt")

--- a/tests/unit/core/models/test_sglang_gen_model.py
+++ b/tests/unit/core/models/test_sglang_gen_model.py
@@ -1,0 +1,258 @@
+"""
+Unit tests for sieval/core/models/sglang_gen_model.py.
+
+Covers: /generate URL derivation, request body, echo→logprob_start_len,
+input_token_logprobs parsing, token-text normalization, end-to-end
+extract_option_logprob / total_logprob consumption, array ordering, and the
+n>1 / empty-logprobs / max_tokens guards. The httpx POST is mocked — no real
+traffic.
+
+AI-Generated Code - Claude Opus 4.8 (Anthropic)
+"""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from sieval.core.models.model import ModelOutput
+from sieval.core.models.sglang_gen_model import (
+    SglangGenModel,
+    _normalize_token_text,
+)
+from sieval.core.utils.ppl import extract_option_logprob, total_logprob
+
+
+@pytest.fixture
+def model():
+    return SglangGenModel(
+        model="test-sglang", api_base="http://host:8000/v1", api_key="local"
+    )
+
+
+def _patch_post(model: SglangGenModel, payload: dict):
+    """Mock the underlying httpx POST to return ``payload`` as JSON."""
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    resp.json = MagicMock(return_value=payload)
+    mock_post = AsyncMock(return_value=resp)
+    target: Any = model._client._client
+    target.post = mock_post  # type: ignore[invalid-assignment]
+    return mock_post
+
+
+def _meta(input_entries=None, output_entries=None, **extra):
+    meta: dict[str, Any] = {}
+    if input_entries is not None:
+        meta["input_token_logprobs"] = input_entries
+    if output_entries is not None:
+        meta["output_token_logprobs"] = output_entries
+    meta.update(extra)
+    return meta
+
+
+# ===================================================================
+# URL derivation
+# ===================================================================
+class TestGenerateUrl:
+    def test_strips_v1_suffix(self, model):
+        assert model._generate_url() == "http://host:8000/generate"
+
+    def test_trailing_slash_base(self):
+        m = SglangGenModel(model="x", api_base="http://host:8000/v1/", api_key="local")
+        assert m._generate_url() == "http://host:8000/generate"
+
+    def test_no_v1_suffix(self):
+        m = SglangGenModel(model="x", api_base="http://host:8000", api_key="local")
+        assert m._generate_url() == "http://host:8000/generate"
+
+    def test_none_base(self):
+        m = SglangGenModel(model="x", api_key="local")
+        assert m._generate_url() == "/generate"
+
+
+# ===================================================================
+# Token text normalization
+# ===================================================================
+class TestNormalizeTokenText:
+    def test_space_marker(self):
+        assert _normalize_token_text("ĠA") == " A"
+
+    def test_newline_marker(self):
+        assert _normalize_token_text("Ċ") == "\n"
+
+    def test_plain_unchanged(self):
+        assert _normalize_token_text(" A") == " A"
+
+
+# ===================================================================
+# Request body
+# ===================================================================
+class TestRequestBody:
+    @pytest.mark.anyio
+    async def test_echo_true_request_body(self, model):
+        post = _patch_post(
+            model, {"text": "", "meta_info": _meta(input_entries=[[-0.1, 1, " A"]])}
+        )
+        await model._alogprobs_impl("prompt", max_tokens=1, logprobs=5, echo=True)
+        body = post.call_args[1]["json"]
+        assert body["text"] == "prompt"
+        assert body["return_logprob"] is True
+        assert body["logprob_start_len"] == 0
+        assert body["top_logprobs_num"] == 5
+        assert body["return_text_in_logprobs"] is True
+        assert body["sampling_params"]["max_new_tokens"] == 1
+
+    @pytest.mark.anyio
+    async def test_echo_false_sets_start_len_minus_one(self, model):
+        post = _patch_post(
+            model, {"text": "", "meta_info": _meta(output_entries=[[-0.1, 1, "x"]])}
+        )
+        await model._alogprobs_impl("prompt", echo=False)
+        assert post.call_args[1]["json"]["logprob_start_len"] == -1
+
+    @pytest.mark.anyio
+    async def test_max_tokens_floored_to_one(self, model):
+        post = _patch_post(
+            model, {"text": "", "meta_info": _meta(input_entries=[[-0.1, 1, " A"]])}
+        )
+        await model._alogprobs_impl("prompt", max_tokens=0)
+        assert post.call_args[1]["json"]["sampling_params"]["max_new_tokens"] == 1
+
+    @pytest.mark.anyio
+    async def test_url_targeted(self, model):
+        post = _patch_post(
+            model, {"text": "", "meta_info": _meta(input_entries=[[-0.1, 1, " A"]])}
+        )
+        await model._alogprobs_impl("prompt")
+        assert post.call_args[0][0] == "http://host:8000/generate"
+
+
+# ===================================================================
+# Parsing
+# ===================================================================
+class TestParsing:
+    @pytest.mark.anyio
+    async def test_input_logprobs_to_tokens_and_logprobs(self, model):
+        meta = _meta(
+            input_entries=[[None, 1, "The"], [-0.5, 2, " cat"], [-0.1, 3, " A"]],
+        )
+        _patch_post(model, {"text": "", "meta_info": meta})
+        out = await model._alogprobs_impl("prompt")
+        assert isinstance(out, ModelOutput)
+        assert out.logprobs_tokens == ["The", " cat", " A"]
+        assert out.logprobs == [None, -0.5, -0.1]
+
+    @pytest.mark.anyio
+    async def test_token_text_normalized(self, model):
+        meta = _meta(input_entries=[[None, 1, "ĠThe"], [-0.1, 2, "ĠA"]])
+        _patch_post(model, {"text": "", "meta_info": meta})
+        out = await model._alogprobs_impl("prompt")
+        assert out.logprobs_tokens == [" The", " A"]
+
+    @pytest.mark.anyio
+    async def test_array_ordering_input_then_output(self, model):
+        """echo=True keeps candidate tokens (output) after the input segment."""
+        meta = _meta(
+            input_entries=[[None, 1, "Q"], [-0.2, 2, " B"]],
+            output_entries=[[-0.3, 3, " gen"]],
+        )
+        _patch_post(model, {"text": " gen", "meta_info": meta})
+        out = await model._alogprobs_impl("prompt", echo=True)
+        assert out.logprobs_tokens == ["Q", " B", " gen"]
+        assert out.logprobs == [None, -0.2, -0.3]
+
+    @pytest.mark.anyio
+    async def test_usage_parsed(self, model):
+        meta = _meta(
+            input_entries=[[-0.1, 1, " A"]],
+            prompt_tokens=7,
+            completion_tokens=1,
+        )
+        _patch_post(model, {"text": "", "meta_info": meta})
+        out = await model._alogprobs_impl("prompt")
+        assert out.usage == {
+            "input_tokens": 7,
+            "output_tokens": 1,
+            "total_tokens": 8,
+        }
+
+    @pytest.mark.anyio
+    async def test_usage_none_when_counts_absent(self, model):
+        meta = _meta(input_entries=[[-0.1, 1, " A"]])
+        _patch_post(model, {"text": "", "meta_info": meta})
+        out = await model._alogprobs_impl("prompt")
+        assert out.usage is None
+
+
+# ===================================================================
+# End-to-end consumption by ppl utilities
+# ===================================================================
+class TestPplConsumption:
+    @pytest.mark.anyio
+    async def test_extract_option_logprob_finds_letter(self, model):
+        """A sequence ending in ' A' must yield the letter's logprob."""
+        meta = _meta(
+            input_entries=[
+                [None, 1, "Question:"],
+                [-2.0, 2, " text"],
+                [-0.7, 3, " A"],
+            ],
+        )
+        _patch_post(model, {"text": "", "meta_info": meta})
+        out = await model._alogprobs_impl("Question: text A", echo=True)
+        lp = extract_option_logprob(out.logprobs_tokens, out.logprobs, "A")
+        assert lp == -0.7
+
+    @pytest.mark.anyio
+    async def test_total_logprob_sums_continuation(self, model):
+        """total_logprob skips the leading None and sums the rest."""
+        meta = _meta(
+            input_entries=[
+                [None, 1, "Ctx"],
+                [-1.0, 2, " the"],
+                [-2.0, 3, " end"],
+            ],
+        )
+        _patch_post(model, {"text": "", "meta_info": meta})
+        out = await model._alogprobs_impl("Ctx the end", echo=True)
+        total, count = total_logprob(out.logprobs_tokens, out.logprobs)
+        assert total == pytest.approx(-3.0)
+        assert count == 2
+
+
+# ===================================================================
+# Guards
+# ===================================================================
+class TestGuards:
+    @pytest.mark.anyio
+    async def test_n_gt_1_raises(self, model):
+        post = _patch_post(model, {"text": "", "meta_info": _meta()})
+        with pytest.raises(ValueError, match="only supports n=1"):
+            await model._alogprobs_impl("prompt", n=2)
+        post.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_n_non_int_raises(self, model):
+        with pytest.raises(TypeError, match="n must be an int"):
+            await model._alogprobs_impl("prompt", n="2")
+
+    @pytest.mark.anyio
+    async def test_n_bool_raises(self, model):
+        with pytest.raises(TypeError, match="n must be an int"):
+            await model._alogprobs_impl("prompt", n=True)
+
+    @pytest.mark.anyio
+    async def test_empty_logprobs_raises(self, model):
+        _patch_post(model, {"text": "", "meta_info": _meta(input_entries=[])})
+        with pytest.raises(RuntimeError, match="no logprobs"):
+            await model._alogprobs_impl("prompt")
+
+    @pytest.mark.anyio
+    async def test_meta_attached(self, model):
+        _patch_post(
+            model, {"text": "", "meta_info": _meta(input_entries=[[-0.1, 1, " A"]])}
+        )
+        out = await model._alogprobs_impl("prompt")
+        assert out.model["model"] == "test-sglang"
+        assert out.response_model == "test-sglang"

--- a/tests/unit/core/models/test_sglang_gen_model.py
+++ b/tests/unit/core/models/test_sglang_gen_model.py
@@ -245,12 +245,15 @@ class TestParsing:
 
     @pytest.mark.anyio
     async def test_usage_parsed(self, model):
+        # input count must equal prompt_tokens under echo (cold cache).
         meta = _meta(
-            input_entries=[[-0.1, 1, " A"]], prompt_tokens=7, completion_tokens=1
+            input_entries=[[None, 1, "Q"], [-0.1, 2, " A"]],
+            prompt_tokens=2,
+            completion_tokens=1,
         )
         _patch_post(model, {"text": "", "meta_info": meta})
         out = await model._alogprobs_impl("prompt")
-        assert out.usage == {"input_tokens": 7, "output_tokens": 1, "total_tokens": 8}
+        assert out.usage == {"input_tokens": 2, "output_tokens": 1, "total_tokens": 3}
 
     @pytest.mark.anyio
     async def test_usage_none_when_counts_absent(self, model):
@@ -408,3 +411,61 @@ class TestGuards:
         out = await model._alogprobs_impl("prompt")
         assert out.model["model"] == "test-sglang"
         assert out.response_model == "test-sglang"
+
+    @pytest.mark.anyio
+    async def test_non_dict_response_raises(self, model):
+        """A list response (only valid for n>1 generation) is rejected here."""
+        _patch_post(model, [{"text": "", "meta_info": _meta()}])
+        with pytest.raises(RuntimeError, match="expected an object"):
+            await model._alogprobs_impl("prompt")
+
+
+# ===================================================================
+# Radix-cache truncation guard (echo=True completeness)
+# ===================================================================
+class TestEchoCompletenessGuard:
+    """echo=True must fail loud when sglang's prefix cache truncates input logprobs."""
+
+    @pytest.mark.anyio
+    async def test_cached_tokens_nonzero_raises(self, model):
+        # Cache hit: input_token_logprobs truncated to the uncached tail.
+        meta = _meta(
+            input_entries=[[-0.1, 1, " star"]],
+            prompt_tokens=5,
+            cached_tokens=4,
+        )
+        _patch_post(model, {"text": "", "meta_info": meta})
+        with pytest.raises(RuntimeError, match="disable-radix-cache"):
+            await model._alogprobs_impl("prompt", echo=True)
+
+    @pytest.mark.anyio
+    async def test_count_mismatch_raises(self, model):
+        # cached_tokens field absent, but returned count < prompt_tokens.
+        meta = _meta(input_entries=[[-0.1, 1, " star"]], prompt_tokens=5)
+        _patch_post(model, {"text": "", "meta_info": meta})
+        with pytest.raises(RuntimeError, match="partial echoed-input"):
+            await model._alogprobs_impl("prompt", echo=True)
+
+    @pytest.mark.anyio
+    async def test_full_input_passes(self, model):
+        meta = _meta(
+            input_entries=[[None, 1, "a"], [-0.1, 2, " b"]],
+            prompt_tokens=2,
+            cached_tokens=0,
+        )
+        _patch_post(model, {"text": "", "meta_info": meta})
+        out = await model._alogprobs_impl("prompt", echo=True)
+        assert out.logprobs_tokens == ["a", " b"]
+
+    @pytest.mark.anyio
+    async def test_echo_false_ignores_cache(self, model):
+        """echo=False (CMMLU) reads output only — cache truncation is irrelevant."""
+        meta = _meta(
+            output_entries=[[-0.1, 1, " A"]],
+            output_top=[[[-0.1, 1, " A"]]],
+            prompt_tokens=5,
+            cached_tokens=4,
+        )
+        _patch_post(model, {"text": "", "meta_info": meta})
+        out = await model._alogprobs_impl("prompt", echo=False)
+        assert out.top_logprobs == [{" A": -0.1}]

--- a/tests/unit/core/models/test_sglang_gen_model.py
+++ b/tests/unit/core/models/test_sglang_gen_model.py
@@ -88,6 +88,12 @@ class TestNormalizeTokenText:
     def test_plain_unchanged(self):
         assert _normalize_token_text(" A") == " A"
 
+    def test_none_text_raises(self):
+        # Server without detokenization (--skip-tokenizer-init) returns no text;
+        # fail loud rather than crash on None.replace or degrade to "".
+        with pytest.raises(RuntimeError, match="no token text"):
+            _normalize_token_text(None)
+
 
 # ===================================================================
 # _agenerate_impl (native /generate generation)
@@ -398,6 +404,33 @@ class TestTopLogprobs:
             (lp for tok, lp in out.top_logprobs[0].items() if tok.strip() == "B")
         )
         assert best == -0.007
+
+    @pytest.mark.anyio
+    async def test_duplicate_normalized_tokens_keep_max(self, model):
+        """Two token ids normalizing to the SAME text keep the highest logprob.
+
+        A byte-level "ĠA" (high) and a literal " A" (low) both normalize to
+        " A"; the dict must not let the later, lower entry clobber the real
+        one — otherwise CMMLU would score the option at the wrong logprob.
+        """
+        meta = _meta(
+            output_entries=[[-0.05, 100, "ĠA"]],
+            output_top=[[[-0.05, 100, "ĠA"], [-9.9, 55, " A"]]],
+        )
+        _patch_post(model, {"text": " A", "meta_info": meta})
+        out = await model._alogprobs_impl("prompt", echo=False, logprobs=100)
+        assert out.top_logprobs == [{" A": -0.05}]
+
+    @pytest.mark.anyio
+    async def test_none_token_text_in_top_raises(self, model):
+        """A top-k entry with no token text (no detokenization) fails loud."""
+        meta = _meta(
+            output_entries=[[-0.1, 1, " A"]],
+            output_top=[[[-0.1, 1, None]]],
+        )
+        _patch_post(model, {"text": "", "meta_info": meta})
+        with pytest.raises(RuntimeError, match="no token text"):
+            await model._alogprobs_impl("prompt", echo=False)
 
 
 # ===================================================================

--- a/tests/unit/core/models/test_sglang_gen_model.py
+++ b/tests/unit/core/models/test_sglang_gen_model.py
@@ -164,6 +164,27 @@ class TestAgenerate:
         with pytest.raises(ValueError, match="n must be >= 1"):
             await model._agenerate_impl("hi", n=0)
 
+    @pytest.mark.anyio
+    async def test_invalid_response_missing_meta_info_raises(self, model):
+        """A response without meta_info fails loud instead of a bare KeyError."""
+        _patch_post(model, {"text": "hi"})  # no meta_info
+        with pytest.raises(RuntimeError, match="missing meta_info"):
+            await model._agenerate_impl("hi")
+
+    @pytest.mark.anyio
+    async def test_request_params_excludes_prompt(self, model):
+        post = _patch_post(
+            model,
+            {"text": "x", "meta_info": _meta(prompt_tokens=1, completion_tokens=1)},
+        )
+        out = await model._agenerate_impl("secret prompt", temperature=0.0)
+        # the raw prompt is sent on the wire...
+        assert post.call_args[1]["body"]["text"] == "secret prompt"
+        # ...but is NOT persisted into per-call request_params.
+        assert out.request_params is not None
+        assert "text" not in out.request_params
+        assert "sampling_params" in out.request_params
+
 
 # ===================================================================
 # _alogprobs_impl request body
@@ -172,7 +193,11 @@ class TestRequestBody:
     @pytest.mark.anyio
     async def test_echo_true_request_body(self, model):
         post = _patch_post(
-            model, {"text": "", "meta_info": _meta(input_entries=[[-0.1, 1, " A"]])}
+            model,
+            {
+                "text": "",
+                "meta_info": _meta(input_entries=[[-0.1, 1, " A"]], prompt_tokens=1),
+            },
         )
         await model._alogprobs_impl("prompt", max_tokens=1, logprobs=5, echo=True)
         body = post.call_args[1]["body"]
@@ -198,10 +223,28 @@ class TestRequestBody:
     @pytest.mark.anyio
     async def test_max_tokens_floored_to_one(self, model):
         post = _patch_post(
-            model, {"text": "", "meta_info": _meta(input_entries=[[-0.1, 1, " A"]])}
+            model,
+            {
+                "text": "",
+                "meta_info": _meta(input_entries=[[-0.1, 1, " A"]], prompt_tokens=1),
+            },
         )
         await model._alogprobs_impl("prompt", max_tokens=0)
         assert post.call_args[1]["body"]["sampling_params"]["max_new_tokens"] == 1
+
+    @pytest.mark.anyio
+    async def test_request_params_excludes_prompt(self, model):
+        _patch_post(
+            model,
+            {
+                "text": "",
+                "meta_info": _meta(input_entries=[[-0.1, 1, " A"]], prompt_tokens=1),
+            },
+        )
+        out = await model._alogprobs_impl("secret prompt", echo=True)
+        assert out.request_params is not None
+        assert "text" not in out.request_params
+        assert out.request_params["return_logprob"] is True
 
 
 # ===================================================================
@@ -212,6 +255,7 @@ class TestParsing:
     async def test_input_logprobs_to_tokens_and_logprobs(self, model):
         meta = _meta(
             input_entries=[[None, 1, "The"], [-0.5, 2, " cat"], [-0.1, 3, " A"]],
+            prompt_tokens=3,
         )
         _patch_post(model, {"text": "", "meta_info": meta})
         out = await model._alogprobs_impl("prompt")
@@ -220,7 +264,9 @@ class TestParsing:
 
     @pytest.mark.anyio
     async def test_token_text_normalized(self, model):
-        meta = _meta(input_entries=[[None, 1, "ĠThe"], [-0.1, 2, "ĠA"]])
+        meta = _meta(
+            input_entries=[[None, 1, "ĠThe"], [-0.1, 2, "ĠA"]], prompt_tokens=2
+        )
         _patch_post(model, {"text": "", "meta_info": meta})
         out = await model._alogprobs_impl("prompt")
         assert out.logprobs_tokens == [" The", " A"]
@@ -230,6 +276,7 @@ class TestParsing:
         meta = _meta(
             input_entries=[[None, 1, "Q"], [-0.2, 2, " B"]],
             output_entries=[[-0.3, 3, " gen"]],
+            prompt_tokens=2,
         )
         _patch_post(model, {"text": " gen", "meta_info": meta})
         out = await model._alogprobs_impl("prompt", echo=True)
@@ -238,7 +285,11 @@ class TestParsing:
 
     @pytest.mark.anyio
     async def test_finish_reason_on_logprobs(self, model):
-        meta = _meta(input_entries=[[-0.1, 1, " A"]], finish_reason={"type": "length"})
+        meta = _meta(
+            input_entries=[[-0.1, 1, " A"]],
+            prompt_tokens=1,
+            finish_reason={"type": "length"},
+        )
         _patch_post(model, {"text": "", "meta_info": meta})
         out = await model._alogprobs_impl("prompt")
         assert out.finish_reasons == ["length"]
@@ -257,9 +308,11 @@ class TestParsing:
 
     @pytest.mark.anyio
     async def test_usage_none_when_counts_absent(self, model):
-        meta = _meta(input_entries=[[-0.1, 1, " A"]])
+        # echo=False so the radix guard (which requires prompt_tokens) is skipped;
+        # this isolates _parse_usage returning None when counts are absent.
+        meta = _meta(output_entries=[[-0.1, 1, " A"]])
         _patch_post(model, {"text": "", "meta_info": meta})
-        out = await model._alogprobs_impl("prompt")
+        out = await model._alogprobs_impl("prompt", echo=False)
         assert out.usage is None
 
 
@@ -296,6 +349,7 @@ class TestTopLogprobs:
             output_entries=[[-0.3, 3, " g"]],
             input_top=[None, [[-0.2, 2, " B"], [-0.9, 9, " C"]]],
             output_top=[[[-0.3, 3, " g"]]],
+            prompt_tokens=2,
         )
         _patch_post(model, {"text": " g", "meta_info": meta})
         out = await model._alogprobs_impl("prompt", echo=True)
@@ -303,7 +357,7 @@ class TestTopLogprobs:
 
     @pytest.mark.anyio
     async def test_top_logprobs_none_when_absent(self, model):
-        meta = _meta(input_entries=[[-0.1, 1, " A"]])
+        meta = _meta(input_entries=[[-0.1, 1, " A"]], prompt_tokens=1)
         _patch_post(model, {"text": "", "meta_info": meta})
         out = await model._alogprobs_impl("prompt")
         assert out.top_logprobs is None
@@ -358,6 +412,7 @@ class TestPplConsumption:
                 [-2.0, 2, " text"],
                 [-0.7, 3, " A"],
             ],
+            prompt_tokens=3,
         )
         _patch_post(model, {"text": "", "meta_info": meta})
         out = await model._alogprobs_impl("Question: text A", echo=True)
@@ -367,6 +422,7 @@ class TestPplConsumption:
     async def test_total_logprob_sums_continuation(self, model):
         meta = _meta(
             input_entries=[[None, 1, "Ctx"], [-1.0, 2, " the"], [-2.0, 3, " end"]],
+            prompt_tokens=3,
         )
         _patch_post(model, {"text": "", "meta_info": meta})
         out = await model._alogprobs_impl("Ctx the end", echo=True)
@@ -398,15 +454,25 @@ class TestGuards:
 
     @pytest.mark.anyio
     async def test_empty_response_raises(self, model):
-        """No token logprobs AND no top logprobs → raise (retryable failure)."""
-        _patch_post(model, {"text": "", "meta_info": _meta(input_entries=[])})
+        """No token logprobs AND no top logprobs → raise (retryable failure).
+
+        prompt_tokens=0 so the empty input matches (passes the radix guard) and
+        we reach the no-logprobs check.
+        """
+        _patch_post(
+            model, {"text": "", "meta_info": _meta(input_entries=[], prompt_tokens=0)}
+        )
         with pytest.raises(RuntimeError, match="no logprobs"):
             await model._alogprobs_impl("prompt")
 
     @pytest.mark.anyio
     async def test_meta_attached(self, model):
         _patch_post(
-            model, {"text": "", "meta_info": _meta(input_entries=[[-0.1, 1, " A"]])}
+            model,
+            {
+                "text": "",
+                "meta_info": _meta(input_entries=[[-0.1, 1, " A"]], prompt_tokens=1),
+            },
         )
         out = await model._alogprobs_impl("prompt")
         assert out.model["model"] == "test-sglang"
@@ -444,6 +510,15 @@ class TestEchoCompletenessGuard:
         meta = _meta(input_entries=[[-0.1, 1, " star"]], prompt_tokens=5)
         _patch_post(model, {"text": "", "meta_info": meta})
         with pytest.raises(RuntimeError, match="partial echoed-input"):
+            await model._alogprobs_impl("prompt", echo=True)
+
+    @pytest.mark.anyio
+    async def test_missing_prompt_tokens_raises(self, model):
+        # Without prompt_tokens the count can't be verified → fail loud rather
+        # than let possibly-truncated logprobs through.
+        meta = _meta(input_entries=[[None, 1, "a"], [-0.1, 2, " b"]])
+        _patch_post(model, {"text": "", "meta_info": meta})
+        with pytest.raises(RuntimeError, match="omitted prompt_tokens"):
             await model._alogprobs_impl("prompt", echo=True)
 
     @pytest.mark.anyio

--- a/tests/unit/core/tasks/test_task.py
+++ b/tests/unit/core/tasks/test_task.py
@@ -15,6 +15,7 @@ from sieval.core.datasets import Dataset
 from sieval.core.models import ModelOutput
 from sieval.core.models.chat_model import ChatModel
 from sieval.core.models.gen_model import GenModel
+from sieval.core.models.sglang_gen_model import SglangGenModel
 from sieval.core.tasks.task import Task
 
 
@@ -50,6 +51,17 @@ class _MockChatModel(ChatModel):
 class _MockGenModel(GenModel):
     def __init__(self):
         super().__init__(model="mock-gen", api_key="fake")
+
+    async def _agenerate_impl(self, prompt, **kwargs) -> ModelOutput:
+        return ModelOutput(model=self.meta(), texts=["ok"])
+
+    async def _alogprobs_impl(self, prompt, **kwargs) -> ModelOutput:
+        raise NotImplementedError
+
+
+class _MockSglangGenModel(SglangGenModel):
+    def __init__(self):
+        super().__init__(model="mock-sglang", api_key="fake")
 
     async def _agenerate_impl(self, prompt, **kwargs) -> ModelOutput:
         return ModelOutput(model=self.meta(), texts=["ok"])
@@ -121,6 +133,10 @@ class TestValidateModelType:
 
     def test_gen_task_with_gen_model_ok(self):
         _GenOnlyTask(_SimpleDataset(), _MockGenModel())
+
+    def test_gen_task_with_sglang_gen_model_ok(self):
+        """SglangGenModel extends Model[str], not GenModel — still counts as 'gen'."""
+        _GenOnlyTask(_SimpleDataset(), _MockSglangGenModel())
 
     def test_chat_task_with_gen_model_raises(self):
         with pytest.raises(TypeError, match="chat"):


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Type

<!-- Choose ONE, delete the rest -->

- feature — new capability

## Summary
- Add `SglangGenModel(Model[str])` speaking sglang's native `/generate` protocol for both generation and logprob extraction. sglang's OpenAI `/v1/completions` rejects `echo=True + logprobs`, blocking echo-based PPL scoring (ARC/HellaSwag) and top-k scoring (CMMLU/MMLU-Base) on the sglang backend.
- Overrides both `_agenerate_impl` (native `/generate`) and `_alogprobs_impl` (echoed-input logprobs + first-token top-k). Extends `Model[str]` rather than `GenModel` — inheriting `GenModel` would only add its OpenAI-completions `_agenerate_impl`, a different wire protocol (incidental reuse, not coupling).
- Parses both `*_token_logprobs` (echo) and `*_top_logprobs` (top-k, CMMLU); normalizes GPT-2 byte-level token text (`Ġ`→space) — SentencePiece `▁` (U+2581) passes through unchanged (fails loud, not mis-scored).
- Radix-cache guard: fails loud when sglang's prefix cache truncates echoed input logprobs (advises `--disable-radix-cache`).
- Dispatch via new model-config field `engine: sglang`; rejected on chat and derived models. `Task._validate_model_type` recognizes it as a "gen" model.

## Test Plan

### Automated

- [x] Lint/format clean (`ruff check && ruff format --check`)
- [x] Type check clean (`ty check` or `mypy --strict`)
- [x] Unit tests pass (`pdm run pytest`) <!-- delete if benchmark-only PR -->

### Manual

- [x] Live vs Qwen2.5-72B (bf16, tp=2) sglang server: echo (ARC-style) and
      top-k (CMMLU-style) agree (`B`, -0.007); native generation OK.
- [x] Full `cmmlu_5shot_base_gen` with `engine: sglang`, 200 samples:
      score 87.2% (stem 83.9 / other 90.5), 0 fails.

## Checklist

### Required (all PRs)

- [x] PR title follows conventional format (`type(scope): description`)
- [x] No internal paths, credentials, or personal info in committed files
- [x] AI-generated code has `AI-Generated Code - <model> (<provider>)` in module docstring
- [x] No new upper-layer dependencies added to `core/`
- [x] Deleted code verified — no remaining call sites depend on it