### PR TITLE
feat(tasks): add HMMT Feb 2025 and IMO-AnswerBench benchmarks

### DIFF
--- a/sieval/community/imo_bench.py
+++ b/sieval/community/imo_bench.py
@@ -1,0 +1,50 @@
+# adapted from https://github.com/EnvCommons/IMO-Bench/blob/66b014f1b3799972ddfc32dbacea51b802586141/answer_verification.py
+"""IMO-Bench (Google DeepMind) AnswerBench answer verification.
+
+IMO-AnswerBench grades a short answer against the gold with ``math_verify`` and a
+normalized-string fallback when either side cannot be parsed (or ``verify()``
+raises). Vendored from the upstream ``answer_verification.py``.
+
+``math_verify`` is imported lazily inside the functions so importing a task
+module stays free of the optional ``[math]`` dependency (sieval import discipline);
+upstream imports it at module top.
+"""
+
+
+def parse_answer(answer: str) -> list:
+    """Parse a math answer with LaTeX handling; returns [] if it can't be parsed."""
+    from math_verify import parse
+
+    try:
+        parsed = parse(answer)
+        # Handle potential LaTeX by wrapping in $ for a proper LaTeX environment.
+        if not parsed:
+            parsed = parse(f"$ {answer} $")
+        return parsed
+    except Exception:
+        return []
+
+
+def verify_math_answer(gold: str, pred: str) -> bool:
+    """IMO-Bench equivalence: ``math_verify`` with a normalized-string fallback.
+
+    Falls back to ``gold.strip().lower() == pred.strip().lower()`` when either
+    side won't parse, or when ``verify()`` raises on a malformed/adversarial input.
+
+    Upstream's signature is ``verify_math_answer(answer_one, answer_two)`` and its
+    caller passes ``(model_answer, gold)``; sieval passes **gold first** because
+    ``math_verify.verify`` is documented non-symmetric (gold, target). The order is
+    immaterial for these short answers and keeps the call consistent with sieval's
+    other math tasks.
+    """
+    from math_verify import verify
+
+    parsed_gold = parse_answer(gold)
+    parsed_pred = parse_answer(pred)
+    # Fall back to normalized string comparison when math_verify can't parse.
+    if not parsed_gold or not parsed_pred:
+        return gold.strip().lower() == pred.strip().lower()
+    try:
+        return bool(verify(parsed_gold, parsed_pred))
+    except Exception:
+        return gold.strip().lower() == pred.strip().lower()

--- a/sieval/community/imo_bench.py
+++ b/sieval/community/imo_bench.py
@@ -10,6 +10,8 @@ module stays free of the optional ``[math]`` dependency (sieval import disciplin
 upstream imports it at module top.
 """
 
+import re
+
 
 def parse_answer(answer: str) -> list:
     """Parse a math answer with LaTeX handling; returns [] if it can't be parsed."""
@@ -48,3 +50,93 @@ def verify_math_answer(gold: str, pred: str) -> bool:
         return bool(verify(parsed_gold, parsed_pred))
     except Exception:
         return gold.strip().lower() == pred.strip().lower()
+
+
+# ---------------------------------------------------------------------------
+# sieval gen-mode wrapper (NOT upstream).
+#
+# Upstream AnswerBench is agentic: the agent submits a clean answer string via a
+# tool call, so verify_math_answer above sees exactly the gold's format. In a
+# non-agentic generative run the model writes its answer inside \boxed{}, often
+# verbosely — "P(x) = -1 \quad\text{or}\quad P(x) = x+1", "-2(m-1)", "$2^{u-2}$",
+# function-prefixed, $-wrapped, with \left/\right, or a multi-answer list.
+# math_verify.parse then mis-parses these and marks correct answers wrong.
+#
+# verify_answer_gen normalizes the boxed answer into the shape an agent would
+# submit and does a set-wise comparison for multi-answer golds, delegating every
+# atomic equivalence check to the vendored verify_math_answer. The fast path is
+# the verbatim upstream check, so this never grades *more strictly* than upstream.
+# ---------------------------------------------------------------------------
+
+_FN_PREFIX = re.compile(r"^\s*[A-Za-z]\s*\(\s*[A-Za-z0-9]\s*\)\s*=\s*")
+_SEP_WORDS = re.compile(r"\\text\s*\{\s*(?:and|or)\s*\}|\b(?:and|or)\b")
+_TEXT_ANNOT = re.compile(r"\\text\s*\{[^{}]*\}")
+_LATEX_NOISE = re.compile(r"\\left|\\right|\\displaystyle|\\!|\\,|\\;|\\:")
+
+
+def _normalize(s: str) -> str:
+    s = s.strip()
+    if s.startswith("$") and s.endswith("$"):
+        s = s[1:-1]
+    s = s.replace("$", "")
+    s = _SEP_WORDS.sub(",", s)  # "A or B" / "A and B" list separators -> comma
+    s = _TEXT_ANNOT.sub(" ", s)  # drop \text{...} prose annotations
+    s = _LATEX_NOISE.sub(" ", s)
+    s = re.sub(r"\\quad|\\qquad", " ", s)
+    s = re.sub(r"\s+", " ", s).strip().rstrip(".").strip()
+    return s
+
+
+def _split_top_level(s: str) -> list[str]:
+    """Split on top-level commas only; commas inside (), [], {} stay (tuples)."""
+    parts: list[str] = []
+    depth = 0
+    cur = ""
+    for ch in s:
+        if ch in "([{":
+            depth += 1
+            cur += ch
+        elif ch in ")]}":
+            depth = max(0, depth - 1)
+            cur += ch
+        elif ch == "," and depth == 0:
+            parts.append(cur)
+            cur = ""
+        else:
+            cur += ch
+    parts.append(cur)
+    return [p.strip() for p in parts if p.strip()]
+
+
+def _atom_equiv(a: str, b: str) -> bool:
+    # Identity-only (modulo whitespace, and modulo a leading "f(x)=" prefix).
+    # We deliberately do NOT call math_verify per split-item: math_verify.parse
+    # grabs a coincidental number out of expression/equation answers (e.g. "n=3k"
+    # -> 3), which produced false positives. Whole-answer math equivalence is still
+    # handled by the verify_math_answer fast path in verify_answer_gen.
+    if a.replace(" ", "") == b.replace(" ", ""):
+        return True
+    a2, b2 = _FN_PREFIX.sub("", a).strip(), _FN_PREFIX.sub("", b).strip()
+    return (a2, b2) != (a, b) and a2.replace(" ", "") == b2.replace(" ", "")
+
+
+def verify_answer_gen(gold: str, pred: str | None) -> bool:
+    """Grade a generative (boxed) answer against gold, IMO-Bench style.
+
+    Fast path is the verbatim official ``verify_math_answer``; only when that fails
+    do we normalize and set-match, so we never grade more strictly than upstream.
+    Kept intentionally conservative — prefer under- to over-counting; genuinely
+    free-form / prose answers (which need the upstream agentic clean submission or
+    an LLM judge) are left as-is.
+    """
+    if pred is None:
+        return False
+    if verify_math_answer(gold, pred):
+        return True
+    gold_items = _split_top_level(_normalize(gold))
+    pred_items = _split_top_level(_normalize(pred))
+    if not gold_items or not pred_items:
+        return _atom_equiv(_normalize(gold), _normalize(pred))
+    return all(any(_atom_equiv(x, y) for y in pred_items) for x in gold_items) and all(
+        any(_atom_equiv(y, x) for x in gold_items) for y in pred_items
+    )

--- a/sieval/community/imo_bench.py
+++ b/sieval/community/imo_bench.py
@@ -114,6 +114,13 @@ def _atom_equiv(a: str, b: str) -> bool:
     # grabs a coincidental number out of expression/equation answers (e.g. "n=3k"
     # -> 3), which produced false positives. Whole-answer math equivalence is still
     # handled by the verify_math_answer fast path in verify_answer_gen.
+    #
+    # An empty side (both reduced to "" by _normalize, e.g. "\\text{No}" vs
+    # "\\text{Yes}") is never a match — upstream verify_math_answer returns False
+    # there, and matching "" == "" would over-count. (Identical text answers are
+    # already caught by the verify_math_answer fast path before we normalize.)
+    if not a.strip() or not b.strip():
+        return False
     if a.replace(" ", "") == b.replace(" ", ""):
         return True
     a2, b2 = _FN_PREFIX.sub("", a).strip(), _FN_PREFIX.sub("", b).strip()

--- a/sieval/datasets/__init__.pyi
+++ b/sieval/datasets/__init__.pyi
@@ -45,6 +45,10 @@ from .ifeval import (
     IFEvalDataset,
     IFEvalDatasetSample,
 )
+from .imo_answer_bench import (
+    IMOAnswerBenchDataset,
+    IMOAnswerBenchDatasetSample,
+)
 from .livecodebench_code_generation import (
     LiveCodeBenchDataset,
     LiveCodeBenchDatasetSample,
@@ -93,6 +97,8 @@ __all__ = [
     "HumanEvalDatasetSample",
     "IFEvalDataset",
     "IFEvalDatasetSample",
+    "IMOAnswerBenchDataset",
+    "IMOAnswerBenchDatasetSample",
     "LiveCodeBenchDataset",
     "LiveCodeBenchDatasetSample",
     "MATH500Dataset",

--- a/sieval/datasets/__init__.pyi
+++ b/sieval/datasets/__init__.pyi
@@ -29,6 +29,10 @@ from .gsm8k import (
     GSM8KDataset,
     GSM8KDatasetSample,
 )
+from .hmmt_feb_2025 import (
+    HMMTFeb2025Dataset,
+    HMMTFeb2025DatasetSample,
+)
 from .hmmt_feb_2026 import (
     HMMTFeb2026Dataset,
     HMMTFeb2026DatasetSample,
@@ -81,6 +85,8 @@ __all__ = [
     "GPQADiamondDatasetSample",
     "GSM8KDataset",
     "GSM8KDatasetSample",
+    "HMMTFeb2025Dataset",
+    "HMMTFeb2025DatasetSample",
     "HMMTFeb2026Dataset",
     "HMMTFeb2026DatasetSample",
     "HumanEvalDataset",

--- a/sieval/datasets/hmmt_feb_2025.py
+++ b/sieval/datasets/hmmt_feb_2025.py
@@ -1,0 +1,67 @@
+"""HMMT February 2025 dataset loader (MathArena source).
+
+AI-Generated Code - Claude Opus 4.8 (Anthropic)
+"""
+
+import os
+from typing import TypedDict, override
+
+from datasets import DatasetDict as HFDatasetDict
+from datasets import Value, load_dataset
+
+from sieval.community.math import strip_string
+from sieval.core.datasets import (
+    Category,
+    Dataset,
+    Level1Category,
+    sieval_dataset,
+)
+from sieval.core.utils.hf import ensure_dataset
+
+# Pin the MathArena HF snapshot for reproducibility (see check_datasets / #8).
+HMMT_FEB_2025_REVISION = "6fdc4277120810ff75aa22d2d5489b91f7a262a1"
+
+
+class HMMTFeb2025DatasetSample(TypedDict):
+    question: str
+    answer: str
+
+
+@sieval_dataset(
+    name="hmmt_feb_2025",
+    display_name="HMMT Feb 2025",
+    description="Harvard-MIT Mathematics Tournament, February 2025, 30 problems.",
+    source=f"hf:MathArena/hmmt_feb_2025@{HMMT_FEB_2025_REVISION}",
+    categories=(Category(Level1Category.MATHEMATICS, "CompetitionMath"),),
+    tags=("english", "open-ended"),
+    license="CC-BY-NC-SA-4.0",
+)
+class HMMTFeb2025Dataset(Dataset[HMMTFeb2025DatasetSample]):
+    def _strip_sample(
+        self, sample: HMMTFeb2025DatasetSample
+    ) -> HMMTFeb2025DatasetSample:
+        # Normalize the answer only; leave the problem text verbatim. strip_string
+        # is an answer normalizer and mangles full problem LaTeX if applied to the
+        # question. Matches the aime_2024 / hmmt_feb_2026 loaders.
+        sample["answer"] = strip_string(sample["answer"])
+        return sample
+
+    @override
+    def load(self, name_or_path: str, **kwargs) -> HFDatasetDict:
+        # MathArena exposes a single `default` config under the `train` split with
+        # columns problem_idx / problem / answer / problem_type. Rename `problem`
+        # -> `question` to match the shared math sample schema.
+        dataset = ensure_dataset(load_dataset(name_or_path, split="train", **kwargs))
+        dataset = dataset.rename_column("problem", "question")
+        # HMMT answers are already strings (symbolic + some plain integers); the
+        # cast is a harmless no-op that keeps both math loaders uniform and the
+        # `answer: str` contract explicit.
+        dataset = dataset.cast_column("answer", Value("string"))
+        dataset = dataset.map(self._strip_sample, num_proc=os.cpu_count())
+        # the test split is the same as the train split
+        return HFDatasetDict(
+            {
+                "train": dataset,
+                "test": dataset,
+            }
+        )

--- a/sieval/datasets/imo_answer_bench.py
+++ b/sieval/datasets/imo_answer_bench.py
@@ -1,0 +1,57 @@
+"""IMO-AnswerBench dataset loader (Google DeepMind IMO-Bench suite).
+
+AI-Generated Code - Claude Opus 4.8 (Anthropic)
+"""
+
+from typing import TypedDict, override
+
+from datasets import DatasetDict as HFDatasetDict
+from datasets import Value, load_dataset
+
+from sieval.core.datasets import (
+    Category,
+    Dataset,
+    Level1Category,
+    sieval_dataset,
+)
+from sieval.core.utils.hf import ensure_dataset
+
+# Pin the HF snapshot for reproducibility (see check_datasets / #8).
+IMO_ANSWER_BENCH_REVISION = "0258becbd00fc07d34862bc8539e61c8742f0d14"
+
+
+class IMOAnswerBenchDatasetSample(TypedDict):
+    question: str
+    answer: str
+
+
+@sieval_dataset(
+    name="imo_answer_bench",
+    display_name="IMO-AnswerBench",
+    description=(
+        "IMO-Bench AnswerBench (Google DeepMind) — 400 short-answer olympiad problems."
+    ),
+    source=f"hf:Hwilner/imo-answerbench@{IMO_ANSWER_BENCH_REVISION}",
+    categories=(Category(Level1Category.MATHEMATICS, "CompetitionMath"),),
+    tags=("english", "open-ended"),
+    license="CC-BY-4.0",
+)
+class IMOAnswerBenchDataset(Dataset[IMOAnswerBenchDatasetSample]):
+    @override
+    def load(self, name_or_path: str, **kwargs) -> HFDatasetDict:
+        # Columns: "Problem ID" / "Problem" / "Short Answer" / "Category" /
+        # "Subcategory" / "Source". Map Problem -> question, Short Answer -> answer
+        # to match the shared math sample schema; other columns are kept as-is.
+        dataset = ensure_dataset(load_dataset(name_or_path, split="train", **kwargs))
+        dataset = dataset.rename_column("Problem", "question")
+        dataset = dataset.rename_column("Short Answer", "answer")
+        # Golds are short answers (integers, LaTeX expressions, small answer sets);
+        # kept verbatim — IMO-Bench grades via math-verify, not string normalization.
+        dataset = dataset.cast_column("answer", Value("string"))
+        # the test split is the same as the train split
+        return HFDatasetDict(
+            {
+                "train": dataset,
+                "test": dataset,
+            }
+        )

--- a/sieval/meta/index.json
+++ b/sieval/meta/index.json
@@ -180,7 +180,8 @@
         "open-ended"
       ],
       "deps_group": null,
-      "license": "CC-BY-NC-SA-4.0"
+      "license": "CC-BY-NC-SA-4.0",
+      "checksums": {}
     },
     {
       "name": "hmmt_feb_2026",
@@ -264,7 +265,8 @@
         "open-ended"
       ],
       "deps_group": null,
-      "license": "CC-BY-4.0"
+      "license": "CC-BY-4.0",
+      "checksums": {}
     },
     {
       "name": "livecodebench_code_generation",

--- a/sieval/meta/index.json
+++ b/sieval/meta/index.json
@@ -666,11 +666,11 @@
       "deps_group": "math",
       "model_type": "chat",
       "reference_impl": {
-        "source": "IMO-Bench (Google DeepMind)",
+        "source": "IMO-Bench (Google DeepMind) + eth-sri/matharena",
         "url": "https://github.com/EnvCommons/IMO-Bench/blob/66b014f1b3799972ddfc32dbacea51b802586141/answer_verification.py",
-        "notes": "IMO-Bench AnswerBench: reason-step-by-step prompt; answer equivalence via math-verify with a normalized-string fallback (vendored in community/imo_bench.py). Boxed answer format added for non-agentic extraction."
+        "notes": "NON-STRICT / EXPERIMENTAL port of IMO-Bench AnswerBench. Deviations from upstream:\n1. Harness type: upstream is agentic (answer submitted via an `answer` tool call); this is generative — last-\\boxed{} extraction.\n2. Prompt: upstream is the bare 'Please reason step by step.'; we append 'Put your final answer within \\boxed{}.' plus a blank-line separator before the problem.\n3. Grading: verify_math_answer is vendored verbatim (math-verify + normalized-string fallback), but a NON-upstream normalizer verify_answer_gen (gen-mode formatting + multi-answer set matching) contributes ~11% of the score — raw verify_math_answer alone = 260/400 = 65.0%, verify_answer_gen = 293/400 = 73.25% (DeepSeek-V4-Pro).\n4. Data source: HF mirror hf:Hwilner/imo-answerbench (functionally equivalent to upstream's OpenReward answerbench.csv).\n5. Dual lineage: prompt + last-\\boxed{} extraction are from eth-sri/matharena (community/matharena.py); the answer grader is IMO-Bench (community/imo_bench.py, @66b014f1).\nKnown limitation: \\boxed{} extraction conflates format-compliance with math ability; a function-calling submission channel reproducing upstream's answer tool (and dropping verify_answer_gen) is the fidelity fix. Infer prereqs: large max_tokens (~131072) + generous client read-timeout (300s+); the score is budget-sensitive."
       },
-      "status": "stable"
+      "status": "experimental"
     },
     {
       "name": "livecodebench_code_generation_0shot_gen",

--- a/sieval/meta/index.json
+++ b/sieval/meta/index.json
@@ -163,6 +163,26 @@
       "checksums": {}
     },
     {
+      "name": "hmmt_feb_2025",
+      "display_name": "HMMT Feb 2025",
+      "description": "Harvard-MIT Mathematics Tournament, February 2025, 30 problems.",
+      "source": [
+        "hf:MathArena/hmmt_feb_2025@6fdc4277120810ff75aa22d2d5489b91f7a262a1"
+      ],
+      "categories": [
+        {
+          "level1": "Mathematics",
+          "level2": "CompetitionMath"
+        }
+      ],
+      "tags": [
+        "english",
+        "open-ended"
+      ],
+      "deps_group": null,
+      "license": "CC-BY-NC-SA-4.0"
+    },
+    {
       "name": "hmmt_feb_2026",
       "display_name": "HMMT Feb 2026",
       "description": "Harvard-MIT Mathematics Tournament, February 2026, 33 problems.",
@@ -504,6 +524,26 @@
         "source": "lm-evaluation-harness",
         "url": "https://github.com/EleutherAI/lm-evaluation-harness/blob/1dd931087362abba74e0375c8c631295559f48b2/lm_eval/tasks/gsm8k/gsm8k.yaml",
         "notes": "Uses lm-eval-harness strict-match extraction, aligned with the original GSM8K dataset.py #### answer delimiter. Also reports lm-eval-harness flexible-extract as a secondary metric, not as the original GSM8K official metric. Default k=8 follows the DeepSeek-V3 Table 3 comparison target (Qwen2.5-72B-Base GSM8K 8-shot EM = 88.3); DeepSeek-V3 does not specify strict vs flexible extraction."
+      },
+      "status": "stable"
+    },
+    {
+      "name": "hmmt_feb_2025_0shot_gen",
+      "display_name": "HMMT Feb 2025 (0-shot, generative)",
+      "description": "HMMT February 2025 — Harvard-MIT Mathematics Tournament, 30 problems.",
+      "dataset": "hmmt_feb_2025",
+      "eval_mode": "gen",
+      "n_shot": 0,
+      "tags": [
+        "english",
+        "open-ended"
+      ],
+      "deps_group": "math",
+      "model_type": "chat",
+      "reference_impl": {
+        "source": "matharena",
+        "url": "https://github.com/eth-sri/matharena/blob/a11194deff8c67a232974a383795e8a2776b4c6f/configs/competitions/hmmt/hmmt_feb_2025.yaml",
+        "notes": "MathArena-aligned: boxed prompt, last-boxed extraction; equivalence via math-verify."
       },
       "status": "stable"
     },

--- a/sieval/meta/index.json
+++ b/sieval/meta/index.json
@@ -247,6 +247,26 @@
       "checksums": {}
     },
     {
+      "name": "imo_answer_bench",
+      "display_name": "IMO-AnswerBench",
+      "description": "IMO-Bench AnswerBench (Google DeepMind) — 400 short-answer olympiad problems.",
+      "source": [
+        "hf:Hwilner/imo-answerbench@0258becbd00fc07d34862bc8539e61c8742f0d14"
+      ],
+      "categories": [
+        {
+          "level1": "Mathematics",
+          "level2": "CompetitionMath"
+        }
+      ],
+      "tags": [
+        "english",
+        "open-ended"
+      ],
+      "deps_group": null,
+      "license": "CC-BY-4.0"
+    },
+    {
       "name": "livecodebench_code_generation",
       "display_name": "LiveCodeBench Code Generation",
       "description": "LiveCodeBench code generation lite — contamination-free benchmark.",
@@ -627,6 +647,26 @@
         "source": "google-research/instruction_following_eval",
         "url": "https://github.com/google-research/google-research/blob/f97f6adab57bd3065b24169bcfc559dc34d0db84/instruction_following_eval/evaluation_lib.py",
         "notes": "evaluation_lib + instructions_registry vendored from google-research."
+      },
+      "status": "stable"
+    },
+    {
+      "name": "imo_answer_bench_0shot_gen",
+      "display_name": "IMO-AnswerBench (0-shot, generative)",
+      "description": "IMO-Bench AnswerBench (Google DeepMind) — 400 short-answer olympiad problems.",
+      "dataset": "imo_answer_bench",
+      "eval_mode": "gen",
+      "n_shot": 0,
+      "tags": [
+        "english",
+        "open-ended"
+      ],
+      "deps_group": "math",
+      "model_type": "chat",
+      "reference_impl": {
+        "source": "IMO-Bench (Google DeepMind)",
+        "url": "https://github.com/EnvCommons/IMO-Bench/blob/66b014f1b3799972ddfc32dbacea51b802586141/answer_verification.py",
+        "notes": "IMO-Bench AnswerBench: reason-step-by-step prompt; answer equivalence via math-verify with a normalized-string fallback (vendored in community/imo_bench.py). Boxed answer format added for non-agentic extraction."
       },
       "status": "stable"
     },

--- a/sieval/tasks/__init__.pyi
+++ b/sieval/tasks/__init__.pyi
@@ -22,6 +22,9 @@ from .gpqa_diamond_0shot_gen import (
 from .gsm8k_kshot_base_gen import (
     GSM8KFewShotBaseGenTask,
 )
+from .hmmt_feb_2025_0shot_gen import (
+    HMMTFeb2025ZeroShotGenTask,
+)
 from .hmmt_feb_2026_0shot_gen import (
     HMMTFeb2026ZeroShotGenTask,
 )
@@ -64,6 +67,7 @@ __all__ = [
     "DROPFewShotGenTask",
     "GPQADiamondZeroShotGenTask",
     "GSM8KFewShotBaseGenTask",
+    "HMMTFeb2025ZeroShotGenTask",
     "HMMTFeb2026ZeroShotGenTask",
     "HumanEvalZeroShotBaseGenTask",
     "HumanEvalZeroShotGenTask",

--- a/sieval/tasks/__init__.pyi
+++ b/sieval/tasks/__init__.pyi
@@ -37,6 +37,9 @@ from .human_eval_0shot_gen import (
 from .ifeval_0shot_gen import (
     IFEvalZeroShotGenTask,
 )
+from .imo_answer_bench_0shot_gen import (
+    IMOAnswerBenchZeroShotGenTask,
+)
 from .livecodebench_code_generation_0shot_gen import (
     LiveCodeBenchCodeGenerationZeroShotGenTask,
 )
@@ -72,6 +75,7 @@ __all__ = [
     "HumanEvalZeroShotBaseGenTask",
     "HumanEvalZeroShotGenTask",
     "IFEvalZeroShotGenTask",
+    "IMOAnswerBenchZeroShotGenTask",
     "LiveCodeBenchCodeGenerationFewShotBaseGenTask",
     "LiveCodeBenchCodeGenerationZeroShotGenTask",
     "MATH500ZeroShotGenTask",

--- a/sieval/tasks/hmmt_feb_2025_0shot_gen.py
+++ b/sieval/tasks/hmmt_feb_2025_0shot_gen.py
@@ -1,0 +1,135 @@
+"""HMMT February 2025 zero-shot generative task.
+
+AI-Generated Code - Claude Opus 4.8 (Anthropic)
+"""
+
+from typing import TypedDict, override
+
+from loguru import logger
+from openai.types.chat import ChatCompletionUserMessageParam
+
+from sieval.community.matharena import HMMT_INSTRUCTION, build_prompt, extract_answer
+from sieval.core.models import ModelOutput
+from sieval.core.tasks import (
+    EvalMode,
+    ReferenceImpl,
+    Task,
+    sieval_task,
+)
+from sieval.datasets import HMMTFeb2025DatasetSample
+
+
+class Feedback(TypedDict):
+    correct: bool
+    answer: str
+
+
+@sieval_task(
+    name="hmmt_feb_2025_0shot_gen",
+    display_name="HMMT Feb 2025 (0-shot, generative)",
+    description=(
+        "HMMT February 2025 — Harvard-MIT Mathematics Tournament, 30 problems."
+    ),
+    eval_mode=EvalMode.GEN,
+    n_shot=0,
+    tags=("english", "open-ended"),
+    deps_group="math",
+    model_type="chat",
+    reference_impl=ReferenceImpl(
+        source="matharena",
+        url="https://github.com/eth-sri/matharena/blob/a11194deff8c67a232974a383795e8a2776b4c6f/configs/competitions/hmmt/hmmt_feb_2025.yaml",
+        notes=(
+            "MathArena-aligned: boxed prompt, last-boxed extraction; "
+            "equivalence via math-verify."
+        ),
+    ),
+)
+class HMMTFeb2025ZeroShotGenTask(
+    Task[
+        HMMTFeb2025DatasetSample,
+        list[ChatCompletionUserMessageParam],
+        ModelOutput,
+        list[str | None],
+        list[Feedback],
+        dict[str, float],
+    ],
+):
+    def __init__(self, dataset, model, name: str | None = None, k: int = 1, n: int = 1):
+        super().__init__(dataset=dataset, model=model, name=name)
+        self._k = k
+        self._n = n
+
+    @override
+    async def preprocess(self, raw, ctx):
+        return [
+            {
+                "role": "user",
+                "content": build_prompt(HMMT_INSTRUCTION, raw["question"]),
+            },
+        ]
+
+    @override
+    async def infer(self, pre, ctx):
+        return await self.model.agenerate(pre, n=self._n)
+
+    @override
+    async def postprocess(self, inf, ctx):
+        # MathArena-aligned: last \boxed{}; non-strict -> fall back to last integer.
+        return [extract_answer(choice, strict_parsing=False) for choice in inf.texts]
+
+    @override
+    async def feedback(self, post, ctx):
+        from math_verify import parse, verify
+
+        feedbacks: list[Feedback] = []
+        ground_truth = ctx.raw_sample["answer"]
+        for pred in post:
+            if pred is None:
+                feedbacks.append({"correct": False, "answer": ground_truth})
+                continue
+            pred_with_env = f"${pred}$"
+            ref_with_env = f"${ground_truth}$"
+            try:
+                parsed_pred = parse(pred_with_env)
+                parsed_ref = parse(ref_with_env)
+                # math_verify.verify expects the gold answer as the first arg.
+                correct = verify(parsed_ref, parsed_pred)
+            except Exception as e:
+                logger.warning("Feedback failed for sample {}: {}", ctx.sample_id, e)
+                correct = False
+            feedbacks.append({"correct": correct, "answer": ground_truth})
+        return True, feedbacks
+
+    @override
+    async def report(self, finals, fails):
+        total = len(finals) + len(fails)
+        if total == 0:
+            return {"score": 0.0, "fails": len(fails)}
+
+        pass_at_1_total = 0.0
+        pass_at_k_total = 0.0
+        for f in finals:
+            feedbacks = f.feedback_result
+            n_samples = len(feedbacks)
+            correct_num = sum(1 for f in feedbacks if f["correct"])
+            pass_at_1_total += self._pass_at_k(n_samples, correct_num, 1)
+            if self._k > 1:
+                pass_at_k_total += self._pass_at_k(n_samples, correct_num, self._k)
+
+        pass_at_1 = pass_at_1_total * 100 / total
+        metrics = {"score": pass_at_1, "fails": len(fails), "pass@1": pass_at_1}
+        if self._k > 1:
+            metrics[f"pass@{self._k}"] = pass_at_k_total * 100 / total
+        return metrics
+
+    def _pass_at_k(self, n: int, c: int, k: int) -> float:
+        if n < k:
+            return 0.0
+        if c == 0:
+            return 0.0
+        # Formula: 1 - product_{i=0}^{k-1} (n - c - i) / (n - i)
+        # This calculates the probability that all k samples are wrong
+        prob_all_wrong = 1.0
+        for i in range(k):
+            prob_all_wrong *= (n - c - i) / (n - i)
+        return 1.0 - prob_all_wrong

--- a/sieval/tasks/imo_answer_bench_0shot_gen.py
+++ b/sieval/tasks/imo_answer_bench_0shot_gen.py
@@ -1,0 +1,140 @@
+"""IMO-AnswerBench zero-shot generative task.
+
+AI-Generated Code - Claude Opus 4.8 (Anthropic)
+"""
+
+from typing import TypedDict, override
+
+from loguru import logger
+from openai.types.chat import ChatCompletionUserMessageParam
+
+from sieval.community.imo_bench import verify_math_answer
+from sieval.community.matharena import build_prompt, extract_answer
+from sieval.core.models import ModelOutput
+from sieval.core.tasks import (
+    EvalMode,
+    ReferenceImpl,
+    Task,
+    sieval_task,
+)
+from sieval.datasets import IMOAnswerBenchDatasetSample
+
+# IMO-Bench AnswerBench is an agentic harness whose only instruction is
+# "Please reason step by step." and which reads the final answer via a tool call.
+# For a non-agentic generative run we keep that reasoning instruction and add a
+# boxed answer format so the short answer is parseable, then extract the last box.
+IMO_ANSWER_BENCH_INSTRUCTION = (
+    "Please reason step by step. Put your final answer within \\boxed{}."
+)
+
+
+class Feedback(TypedDict):
+    correct: bool
+    answer: str
+
+
+@sieval_task(
+    name="imo_answer_bench_0shot_gen",
+    display_name="IMO-AnswerBench (0-shot, generative)",
+    description=(
+        "IMO-Bench AnswerBench (Google DeepMind) — 400 short-answer olympiad problems."
+    ),
+    eval_mode=EvalMode.GEN,
+    n_shot=0,
+    tags=("english", "open-ended"),
+    deps_group="math",
+    model_type="chat",
+    reference_impl=ReferenceImpl(
+        source="IMO-Bench (Google DeepMind)",
+        url="https://github.com/EnvCommons/IMO-Bench/blob/66b014f1b3799972ddfc32dbacea51b802586141/answer_verification.py",
+        notes=(
+            "IMO-Bench AnswerBench: reason-step-by-step prompt; answer equivalence "
+            "via math-verify with a normalized-string fallback (vendored in "
+            "community/imo_bench.py). Boxed answer format added for non-agentic "
+            "extraction."
+        ),
+    ),
+)
+class IMOAnswerBenchZeroShotGenTask(
+    Task[
+        IMOAnswerBenchDatasetSample,
+        list[ChatCompletionUserMessageParam],
+        ModelOutput,
+        list[str | None],
+        list[Feedback],
+        dict[str, float],
+    ],
+):
+    def __init__(self, dataset, model, name: str | None = None, k: int = 1, n: int = 1):
+        super().__init__(dataset=dataset, model=model, name=name)
+        self._k = k
+        self._n = n
+
+    @override
+    async def preprocess(self, raw, ctx):
+        return [
+            {
+                "role": "user",
+                "content": build_prompt(IMO_ANSWER_BENCH_INSTRUCTION, raw["question"]),
+            },
+        ]
+
+    @override
+    async def infer(self, pre, ctx):
+        return await self.model.agenerate(pre, n=self._n)
+
+    @override
+    async def postprocess(self, inf, ctx):
+        # Last \boxed{}; non-strict -> fall back to last integer (matharena extractor).
+        return [extract_answer(choice, strict_parsing=False) for choice in inf.texts]
+
+    @override
+    async def feedback(self, post, ctx):
+        feedbacks: list[Feedback] = []
+        ground_truth = ctx.raw_sample["answer"]
+        for pred in post:
+            if pred is None:
+                feedbacks.append({"correct": False, "answer": ground_truth})
+                continue
+            try:
+                # IMO-Bench equivalence (math-verify + string fallback); gold first.
+                correct = verify_math_answer(ground_truth, pred)
+            except Exception as e:
+                logger.warning("Feedback failed for sample {}: {}", ctx.sample_id, e)
+                correct = False
+            feedbacks.append({"correct": correct, "answer": ground_truth})
+        return True, feedbacks
+
+    @override
+    async def report(self, finals, fails):
+        total = len(finals) + len(fails)
+        if total == 0:
+            return {"score": 0.0, "fails": len(fails)}
+
+        pass_at_1_total = 0.0
+        pass_at_k_total = 0.0
+        for f in finals:
+            feedbacks = f.feedback_result
+            n_samples = len(feedbacks)
+            correct_num = sum(1 for f in feedbacks if f["correct"])
+            pass_at_1_total += self._pass_at_k(n_samples, correct_num, 1)
+            if self._k > 1:
+                pass_at_k_total += self._pass_at_k(n_samples, correct_num, self._k)
+
+        pass_at_1 = pass_at_1_total * 100 / total
+        metrics = {"score": pass_at_1, "fails": len(fails), "pass@1": pass_at_1}
+        if self._k > 1:
+            metrics[f"pass@{self._k}"] = pass_at_k_total * 100 / total
+        return metrics
+
+    def _pass_at_k(self, n: int, c: int, k: int) -> float:
+        if n < k:
+            return 0.0
+        if c == 0:
+            return 0.0
+        # Formula: 1 - product_{i=0}^{k-1} (n - c - i) / (n - i)
+        # This calculates the probability that all k samples are wrong
+        prob_all_wrong = 1.0
+        for i in range(k):
+            prob_all_wrong *= (n - c - i) / (n - i)
+        return 1.0 - prob_all_wrong

--- a/sieval/tasks/imo_answer_bench_0shot_gen.py
+++ b/sieval/tasks/imo_answer_bench_0shot_gen.py
@@ -1,5 +1,21 @@
 """IMO-AnswerBench zero-shot generative task.
 
+**Experimental / non-strict port** (``status="experimental"`` — not a frozen
+leaderboard contract). IMO-Bench's upstream AnswerBench is an *agentic* harness:
+the agent submits its answer via an ``answer`` tool call. This task reproduces it
+in a *generative* setting (last-``\\boxed{}`` extraction) instead. Every deviation
+from upstream is enumerated in ``reference_impl.notes`` below.
+
+Dual-source lineage: the boxed prompt + last-``\\boxed{}`` extraction follow
+eth-sri/matharena; answer equivalence is vendored verbatim from IMO-Bench's
+``answer_verification.py`` (``community/imo_bench.py``), plus a documented gen-mode
+normalizer (``verify_answer_gen``).
+
+Infer prerequisites: olympiad reasoning traces are very long — set a large output
+budget (``max_tokens`` ≈ 131072) and a generous client read-timeout (300s+). At
+``max_tokens=65536`` ~22% of samples truncate mid-reasoning with no boxed answer
+(scored wrong); the score is therefore budget-sensitive.
+
 AI-Generated Code - Claude Opus 4.8 (Anthropic)
 """
 
@@ -44,14 +60,33 @@ class Feedback(TypedDict):
     tags=("english", "open-ended"),
     deps_group="math",
     model_type="chat",
+    status="experimental",
     reference_impl=ReferenceImpl(
-        source="IMO-Bench (Google DeepMind)",
+        source="IMO-Bench (Google DeepMind) + eth-sri/matharena",
         url="https://github.com/EnvCommons/IMO-Bench/blob/66b014f1b3799972ddfc32dbacea51b802586141/answer_verification.py",
         notes=(
-            "IMO-Bench AnswerBench: reason-step-by-step prompt; answer equivalence "
-            "via math-verify with a normalized-string fallback (vendored in "
-            "community/imo_bench.py). Boxed answer format added for non-agentic "
-            "extraction."
+            "NON-STRICT / EXPERIMENTAL port of IMO-Bench AnswerBench. Deviations "
+            "from upstream:\n"
+            "1. Harness type: upstream is agentic (answer submitted via an `answer` "
+            "tool call); this is generative — last-\\boxed{} extraction.\n"
+            "2. Prompt: upstream is the bare 'Please reason step by step.'; we append "
+            "'Put your final answer within \\boxed{}.' plus a blank-line separator "
+            "before the problem.\n"
+            "3. Grading: verify_math_answer is vendored verbatim (math-verify + "
+            "normalized-string fallback), but a NON-upstream normalizer "
+            "verify_answer_gen (gen-mode formatting + multi-answer set matching) "
+            "contributes ~11% of the score — raw verify_math_answer alone = "
+            "260/400 = 65.0%, verify_answer_gen = 293/400 = 73.25% (DeepSeek-V4-Pro).\n"
+            "4. Data source: HF mirror hf:Hwilner/imo-answerbench (functionally "
+            "equivalent to upstream's OpenReward answerbench.csv).\n"
+            "5. Dual lineage: prompt + last-\\boxed{} extraction are from "
+            "eth-sri/matharena (community/matharena.py); the answer grader is "
+            "IMO-Bench (community/imo_bench.py, @66b014f1).\n"
+            "Known limitation: \\boxed{} extraction conflates format-compliance with "
+            "math ability; a function-calling submission channel reproducing "
+            "upstream's answer tool (and dropping verify_answer_gen) is the fidelity "
+            "fix. Infer prereqs: large max_tokens (~131072) + generous client "
+            "read-timeout (300s+); the score is budget-sensitive."
         ),
     ),
 )

--- a/sieval/tasks/imo_answer_bench_0shot_gen.py
+++ b/sieval/tasks/imo_answer_bench_0shot_gen.py
@@ -8,7 +8,7 @@ from typing import TypedDict, override
 from loguru import logger
 from openai.types.chat import ChatCompletionUserMessageParam
 
-from sieval.community.imo_bench import verify_math_answer
+from sieval.community.imo_bench import verify_answer_gen
 from sieval.community.matharena import build_prompt, extract_answer
 from sieval.core.models import ModelOutput
 from sieval.core.tasks import (
@@ -97,8 +97,9 @@ class IMOAnswerBenchZeroShotGenTask(
                 feedbacks.append({"correct": False, "answer": ground_truth})
                 continue
             try:
-                # IMO-Bench equivalence (math-verify + string fallback); gold first.
-                correct = verify_math_answer(ground_truth, pred)
+                # IMO-Bench equivalence: official math-verify grader + gen-mode
+                # normalization / multi-answer set matching; gold first.
+                correct = verify_answer_gen(ground_truth, pred)
             except Exception as e:
                 logger.warning("Feedback failed for sample {}: {}", ctx.sample_id, e)
                 correct = False

--- a/tests/unit/community/test_imo_bench.py
+++ b/tests/unit/community/test_imo_bench.py
@@ -1,0 +1,28 @@
+"""Unit tests for the vendored IMO-Bench answer verification.
+
+AI-Generated Code - Claude Opus 4.8 (Anthropic)
+"""
+
+from sieval.community.imo_bench import parse_answer, verify_math_answer
+
+
+def test_integer_match():
+    assert verify_math_answer("3", "3") is True
+    assert verify_math_answer("3", "4") is False
+
+
+def test_latex_equivalence_via_math_verify():
+    # math-verify treats these as equal even though the strings differ.
+    assert verify_math_answer("\\frac{1}{2}", "0.5") is True
+
+
+def test_unparseable_falls_back_to_normalized_string():
+    # Non-mathy answers can't be parsed -> case/space-insensitive string compare.
+    assert verify_math_answer("Yes", "yes") is True
+    assert verify_math_answer("red", "blue") is False
+
+
+def test_parse_answer_handles_bare_latex():
+    # Bare LaTeX without $...$ is retried wrapped in a math environment.
+    assert parse_answer("\\frac{1}{2}") != []
+    assert parse_answer("") == []

--- a/tests/unit/community/test_imo_bench.py
+++ b/tests/unit/community/test_imo_bench.py
@@ -70,3 +70,11 @@ def test_gen_is_conservative_no_false_positive():
     )
     assert verify_answer_gen("5", "7") is False
     assert verify_answer_gen("5", None) is False
+
+
+def test_gen_empty_after_normalize_is_not_a_match():
+    # Both reduce to "" under _normalize (\text{...} stripped) — must NOT grade
+    # equal; upstream verify_math_answer returns False here.
+    assert verify_answer_gen("\\text{No}", "\\text{Yes}") is False
+    # Identical text answers are still matched by the verify_math_answer fast path.
+    assert verify_answer_gen("\\text{Yes}", "\\text{Yes}") is True

--- a/tests/unit/community/test_imo_bench.py
+++ b/tests/unit/community/test_imo_bench.py
@@ -3,7 +3,11 @@
 AI-Generated Code - Claude Opus 4.8 (Anthropic)
 """
 
-from sieval.community.imo_bench import parse_answer, verify_math_answer
+from sieval.community.imo_bench import (
+    parse_answer,
+    verify_answer_gen,
+    verify_math_answer,
+)
 
 
 def test_integer_match():
@@ -26,3 +30,43 @@ def test_parse_answer_handles_bare_latex():
     # Bare LaTeX without $...$ is retried wrapped in a math environment.
     assert parse_answer("\\frac{1}{2}") != []
     assert parse_answer("") == []
+
+
+def test_gen_recovers_formatting_only_differences():
+    # $-wrapping / whitespace / \left\right / trailing newline: clearly equal.
+    assert verify_answer_gen("$2^{u-2}$", "2^{u-2}") is True
+    assert verify_answer_gen("(0, 0)", "(0,0)") is True
+    assert verify_answer_gen("$2^n$\n", "2^n") is True
+    assert verify_answer_gen("$\\frac{3}{2}(XZ-XY)$", "\\frac{3}{2}(XZ - XY)") is True
+
+
+def test_gen_recovers_multi_answer_lists():
+    # comma-separated set + "and"/"or" list separators (agent would submit clean).
+    assert verify_answer_gen("3,7", "3 \\text{ and } 7") is True
+    assert (
+        verify_answer_gen(
+            "P(x)=-1, P(x)=x+1",
+            "P(x) = -1 \\quad\\text{or}\\quad P(x) = x+1",
+        )
+        is True
+    )
+
+
+def test_gen_is_conservative_no_false_positive():
+    # Different parameterization / prose-vs-formula must stay wrong (no over-count).
+    assert (
+        verify_answer_gen(
+            "$X(y)=1+(u-1)\\bar{y}$",
+            "X(z)=c\\overline{z}+1 \\text{ for some } c \\text{ with } |c|=1",
+        )
+        is False
+    )
+    assert (
+        verify_answer_gen(
+            "$n=2k, n=3k$",
+            "\\text{All } n \\ge 2 \\text{ divisible by } 2 \\text{ or } 3",
+        )
+        is False
+    )
+    assert verify_answer_gen("5", "7") is False
+    assert verify_answer_gen("5", None) is False

--- a/tests/unit/tasks/test_hmmt_feb_2025_0shot_gen.py
+++ b/tests/unit/tasks/test_hmmt_feb_2025_0shot_gen.py
@@ -1,0 +1,25 @@
+"""Import-discipline test for the HMMT Feb 2025 task.
+
+AI-Generated Code - Claude Opus 4.8 (Anthropic)
+"""
+
+import subprocess
+import sys
+
+
+def test_import_does_not_pull_math_verify():
+    code = (
+        "import sys\n"
+        "import sieval.tasks.hmmt_feb_2025_0shot_gen\n"
+        "assert 'math_verify' not in sys.modules, "
+        "'math_verify must be lazy-imported'\n"
+    )
+    # Run in a fresh interpreter so pytest's already-loaded modules don't mask the
+    # check.
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr

--- a/tests/unit/tasks/test_imo_answer_bench_0shot_gen.py
+++ b/tests/unit/tasks/test_imo_answer_bench_0shot_gen.py
@@ -1,0 +1,25 @@
+"""Import-discipline test for the IMO-AnswerBench task.
+
+AI-Generated Code - Claude Opus 4.8 (Anthropic)
+"""
+
+import subprocess
+import sys
+
+
+def test_import_does_not_pull_math_verify():
+    code = (
+        "import sys\n"
+        "import sieval.tasks.imo_answer_bench_0shot_gen\n"
+        "assert 'math_verify' not in sys.modules, "
+        "'math_verify must be lazy-imported'\n"
+    )
+    # Run in a fresh interpreter so pytest's already-loaded modules don't mask the
+    # check.
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Type

- feature — new benchmark, task, or capability

## Summary

- Add two final-answer math benchmarks, each aligned to its dataset author's reference implementation:
  - **HMMT Feb 2025** (30 problems) — MathArena-aligned (eth-sri/matharena @`a11194de` `configs/competitions/hmmt/hmmt_feb_2025.yaml`): boxed prompt + last-boxed extraction (reuses `community/matharena.py`), equivalence via `math-verify`. Same pipeline as `hmmt_feb_2026`.
  - **IMO-AnswerBench** (400 short-answer Olympiad problems; Google DeepMind IMO-Bench, arXiv 2511.01846) — grading **vendored from the official `answer_verification.py` @`66b014f1`** into `community/imo_bench.py`: `math-verify` equivalence with a normalized-string fallback (NOT an LLM judge). The reference harness is agentic (tool-call answer, "reason step by step"); for a non-agentic generative run we add a boxed answer format and reuse the matharena last-boxed extractor. Ships **`status="experimental"`** — a non-strict port (generative vs upstream's agentic tool-call); every deviation is enumerated in the task's `reference_impl.notes`.
- Datasets pinned to specific HF commits (`MathArena/hmmt_feb_2025@6fdc427`, `Hwilner/imo-answerbench@0258becb`). No `core/` changes; no new dependency (reuses the `[math]` extra).

## Related Issues

Refs the MathArena AIME/HMMT 2026 work (#16) — this PR builds on the same `community/matharena.py`.

## Test Plan

### Automated

- [x] Lint/format clean (`ruff check && ruff format --check`)
- [x] Type check clean (`ty check`)
- [x] Unit tests pass (`pdm run pytest`) — verifier tests (integer / LaTeX-equiv / string fallback) + import-discipline (math-verify stays lazy)

### Manual

All evaluations run **through sieval** (`sieval eval`) against the scitix model API.

**HMMT Feb 2025 — grader+extraction parity** (regrading MathArena's published outputs `MathArena/hmmt_feb_2025_outputs` through this pipeline): reproduces their per-sample `correct` labels with **~100% agreement across 55 models** (exact reproduce for Gemini 3 Pro 97.5%, Grok 4 95.0%, Step 3.5 Flash 98.3%, Kimi K2.5 93.3%, …).

**HMMT Feb 2025 — live run** (sieval, avg@4):

| Model | Ours (sieval) | Reference (MathArena) | Diff |
|---|---|---|---|
| Kimi K2.5 | **95.0%** | 93.3% | **1.7%** (≤3% ✓) |

GLM 5.2 (the default pick) is absent from MathArena's HMMT 2025 set; Kimi K2.5 is the clean scitix∩MathArena match.

**IMO-AnswerBench — grading.** The vendored `verify_math_answer` (`community/imo_bench.py`) is the official `math-verify` grader, verbatim. Because this is a *generative* (non-agentic) run, the model boxes verbose answers (functional forms `P(x)=…`, multi-answer sets, tuples, intervals) that `math_verify.parse` mis-parses — marking correct answers wrong. A thin gen-mode wrapper `verify_answer_gen` (fast-path = the official grader; then conservative identity-only normalization + multi-answer set matching) reconciles the boxed formatting to what the upstream agentic harness receives as a clean tool submission. It recovered **26/310** non-truncated answers (71.6% → 80.0%) with **0 regressions / 0 false positives**. Reference (arXiv 2511.01846): Gemini Deep Think **80.0%**, best non-Gemini **73.1%**, GPT-5 59.0%.

**IMO-AnswerBench — live run** (sieval, DeepSeek-V4-Pro, pass@1, 400 problems):

| Model | Ours (sieval) | Reference (paper best-non-Gemini) | Diff |
|---|---|---|---|
| DeepSeek-V4-Pro | raw grader **65.0%** (260/400) → gen-normalized **73.25%** (293/400) | 73.1% | +0.15% (see caveat) |

> **How 73.25% was reached.** The first naive run read 55.5%, low for two independent, now-fixed reasons. (1) **Grading:** the fix above recovered 26 mis-graded non-truncated answers → 80.0% on that subset. (2) **Truncation:** 88/398 spent the whole 65536-token budget on reasoning without emitting a boxed answer; re-running those at `max_tokens=131072` (the scitix API accepts it — an earlier "context-ceiling" note was wrong) recovered **45** correct, with **10** exceeding even the 131072 reasoning budget (a genuine limit on the hardest problems). Final = 248 (non-truncated, fixed grader) + 45 (truncated re-run) = **293/400 = 73.25%**. DeepSeek-V4-Pro is newer than the paper's DeepSeek R1, so reaching the then-best-non-Gemini level is consistent. Full per-problem outputs on the eval host under `_work/review-hmmt2025-imo/`.
>
> **Caveat — generative-vs-agentic, not a like-for-like reproduction.** The vendored official grader alone scores **65.0%** (260/400); the +8.25 pt to **73.25%** is the non-upstream `verify_answer_gen` normalizer (~11% of the score). The task ships `status="experimental"`. **Infer prereqs:** large `max_tokens` (~131072) + generous client read-timeout (300s+) — at 65536 ~22% truncate, and the 2 fails (samples 78, 80) were client ReadTimeouts on hard problems.

- [x] Dataset loading tested — `sieval dataset download hmmt_feb_2025` (30 rows) and `imo_answer_bench` (400 rows) succeed.

> Full run outputs (per-problem model output, extracted answer, gold, correctness, finish_reason) + the regrade scripts live on the eval host under `_work/` (git-excluded, not committed).

## Checklist

### Required (all PRs)

- [x] PR title follows conventional format
- [x] No internal paths, credentials, or personal info in committed files
- [x] AI-generated code has `AI-Generated Code - <model> (<provider>)` in module docstring (datasets/tasks); `community/` vendored files carry the `# adapted from …/blob/<SHA>/…` provenance header
- [x] No new upper-layer dependencies added to `core/`
- [x] Deleted code verified — no remaining call sites depend on it

### If: New or Modified Benchmark

- [x] Reference paper/repo linked in Summary
- [x] Score comparison table included (model, expected, actual, diff)
- [x] Dataset loading tested (`sieval dataset download <name>` succeeds)
- [x] Task registered in package-level `__init__.py` (auto-synced stubs + meta index)

### If: community/ Changes

- [x] Upstream diff documented — `community/imo_bench.py` vendors `answer_verification.py` verbatim except: lazy `math-verify` import (sieval import discipline) and gold-first arg order (documented in the docstring)
- [x] License attribution preserved (`# adapted from` provenance header with pinned SHA)
