### PR TITLE
feat(tasks): add clp eval mode + naming category

### DIFF
--- a/.claude/rules/tasks.md
+++ b/.claude/rules/tasks.md
@@ -11,7 +11,9 @@ paths:
     - `_gen.py` → `model_type = "chat"`
     - `_base_gen.py` → `model_type = "gen"` (base model, uses GenModel)
     - `_ppl.py` → `model_type = "gen"` (perplexity, uses GenModel)
+    - `_clp.py` → `model_type = "gen"` (conditional next-token log-prob, uses GenModel)
 - Class naming: `<Benchmark><ShotType><Mode>Task` — words for shot count (`ZeroShot`, `FewShot`)
+- `ppl` vs `clp` distinction: see `sieval/tasks/CLAUDE.md`.
 
 ## Checklist for New Benchmarks
 

--- a/scripts/check_preflight.py
+++ b/scripts/check_preflight.py
@@ -44,7 +44,7 @@ _MD_RELATIVE_LINK = re.compile(r"\[([^\]]*)\]\(([^)]+)\)")
 _GH_NON_PERMANENT = re.compile(r"github\.com/[^/]+/[^/]+/blob/(main|master|develop)/")
 
 _TASK_FILE_PATTERN = re.compile(
-    r"^[a-z][a-z0-9_]*_(\d+|k)shot_(gen|base_gen|ppl|llmjudge_gen)\.py$"
+    r"^[a-z][a-z0-9_]*_(\d+|k)shot_(gen|base_gen|ppl|clp|llmjudge_gen)\.py$"
 )
 _DATASET_SUFFIX_PATTERN = re.compile(r"(Dataset|DatasetSample|CSVSample)$")
 

--- a/sieval/cli/task/commands.py
+++ b/sieval/cli/task/commands.py
@@ -37,7 +37,8 @@ def list_cmd(
         str | None, typer.Option("--domain", help="Filter by Level1Category.")
     ] = None,
     eval_mode: Annotated[
-        str | None, typer.Option("--eval-mode", help="Filter by eval mode (gen/ppl).")
+        str | None,
+        typer.Option("--eval-mode", help="Filter by eval mode (gen/ppl/clp)."),
     ] = None,
     data_dir: Annotated[
         str | None, typer.Option("--data-dir", help="Override data directory.")

--- a/sieval/core/tasks/meta.py
+++ b/sieval/core/tasks/meta.py
@@ -14,7 +14,7 @@ Not frozen (may change within schema_version=1):
     Python-side internals.
 
 Frozen enum values:
-    EvalMode: gen, ppl.
+    EvalMode: gen, ppl, clp.
     Status: stable, experimental, deprecated.
 
 AI-Generated Code - Claude Opus 4.6 (Anthropic)
@@ -40,6 +40,9 @@ class EvalMode(StrEnum):
     # PPL covers perplexity-based (logprobs).
     GEN = "gen"
     PPL = "ppl"
+    # CLP: next-token conditional log-prob over a fixed set of option tokens
+    # (single inference); vs PPL = full-sequence perplexity (n inferences).
+    CLP = "clp"
 
 
 @dataclass(frozen=True, slots=True)

--- a/sieval/tasks/CLAUDE.md
+++ b/sieval/tasks/CLAUDE.md
@@ -9,8 +9,17 @@ File: `<task>_<N>shot_<mode>.py` — suffix determines `model_type`:
 | `_gen.py` | `"chat"` |
 | `_base_gen.py` | `"gen"` |
 | `_ppl.py` | `"gen"` |
+| `_clp.py` | `"gen"` |
 
 Class: `<Benchmark><ShotType><Mode>Task` — words for shot count (`ZeroShot`, `FewShot`).
+
+### `ppl` vs `clp`
+
+- `ppl` — pick the answer whose full `context + candidate` has the highest
+  sequence likelihood; one inference per candidate, any answer length.
+- `clp` — pick the answer by the next single token's log-prob over a fixed set
+  of option tokens, read from the API's `top_logprobs` in one inference.
+  Single-token / labeled-choice answers only; tokenizer-sensitive.
 
 ## Key Rules
 

--- a/tests/unit/core/tasks/test_meta.py
+++ b/tests/unit/core/tasks/test_meta.py
@@ -114,7 +114,12 @@ def test_eval_mode_is_str_enum():
 
 
 def test_eval_mode_has_expected_members():
-    assert {m.value for m in EvalMode} == {"gen", "ppl"}
+    assert {m.value for m in EvalMode} == {"gen", "ppl", "clp"}
+
+
+def test_eval_mode_clp_value_and_roundtrip():
+    assert EvalMode.CLP.value == "clp"
+    assert EvalMode("clp") is EvalMode.CLP
 
 
 def test_reference_impl_requires_source_and_url():
@@ -453,6 +458,12 @@ def test_sieval_task_sets_protocol_tags_from_eval_mode_and_n_shot():
         pass
 
     assert TGenFew.tags == frozenset({"gen", "few_shot"})
+
+    @sieval_task(**_valid_kwargs(name="p_clp_zero", eval_mode=EvalMode.CLP, n_shot=0))
+    class TClpZero(_StubTask):
+        pass
+
+    assert TClpZero.tags == frozenset({"clp", "zero_shot"})
 
 
 def test_sieval_task_sets_class_model_type():

--- a/tests/unit/scripts/test_check_preflight.py
+++ b/tests/unit/scripts/test_check_preflight.py
@@ -19,6 +19,7 @@ if _SCRIPTS_DIR not in sys.path:
     sys.path.insert(0, _SCRIPTS_DIR)
 
 from check_preflight import (  # noqa: E402  # type: ignore[unresolved-import]  # scripts/ added to sys.path at runtime
+    _TASK_FILE_PATTERN,
     CheckResult,
     PreflightRunner,
     _dataset_integrity_violations,
@@ -751,6 +752,35 @@ class TestCheckTasks:
         results = runner.check_tasks()
         naming_results = [r for r in results if "naming" in r.message.lower()]
         assert len(naming_results) >= 1
+
+
+class TestTaskFileNamingPattern:
+    """Unit tests for the task-file naming regex (`_TASK_FILE_PATTERN`)."""
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "cmmlu_kshot_clp.py",
+            "foo_5shot_clp.py",
+            "foo_0shot_gen.py",
+            "foo_kshot_base_gen.py",
+            "foo_3shot_ppl.py",
+            "foo_2shot_llmjudge_gen.py",
+        ],
+    )
+    def test_accepts_valid_suffixes(self, name):
+        assert _TASK_FILE_PATTERN.match(name) is not None
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "foo_clp.py",  # missing shot segment
+            "foo_5shot_clp_extra.py",  # trailing junk
+            "foo_5shot_clpx.py",  # not a known mode
+        ],
+    )
+    def test_rejects_malformed(self, name):
+        assert _TASK_FILE_PATTERN.match(name) is None
 
 
 class TestCheckDatasets:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Type

- feature — new benchmark, task, or capability

## Summary

- Adds `EvalMode.CLP` ("clp") — next-token conditional log-prob over a fixed set of option tokens (single inference), distinct from `PPL` (full-sequence perplexity, n inferences); aligns with [OpenCompass's ppl/clp split](https://opencompass.readthedocs.io/en/latest/get_started/faq.html#:~:text=Similar%20to%20ppl,used%20in%20OpenCompass.).
- Wires `clp` through the seam: preflight naming regex + docs (naming table, `ppl`/`clp` distinction). No consumer task, no scoring helper, and no anomaly routing here — those land with the first `clp` task to keep the seam pure and avoid unreachable code.
- No consumer task and no scoring helper here — these ship with the first clp task to avoid uncalled code.
- No behavior change for existing tasks; `meta/index.json` is unchanged.
- Frozen-schema note: adding an enum value is additive (not a rename/removal/type-change) → no `schema_version` bump required.

## Test Plan

### Automated

- [x] Lint/format clean (`ruff check && ruff format --check`)
- [x] Type check clean (`ty check` or `mypy --strict`)
- [x] Unit tests pass (`pdm run pytest`) <!-- delete if benchmark-only PR -->

### Manual

- [x] Flipped cmmlu to `EvalMode.CLP` locally (reverted, not committed): the
  staged pipeline ran end-to-end via a mock GenModel and `cls.tags` synthesized
  `clp`.

## Checklist

### Required (all PRs)

- [x] PR title follows conventional format (`type(scope): description`)
- [x] No internal paths, credentials, or personal info in committed files
- [x] AI-generated code has `AI-Generated Code - <model> (<provider>)` in module docstring
- [x] No new upper-layer dependencies added to `core/`
- [x] Deleted code verified — no remaining call sites depend on it