### PR TITLE
feat(gsm8k): add DeepSeek-Math-aligned 0-shot chat-model task

### DIFF
--- a/sieval/community/deepseek_math.py
+++ b/sieval/community/deepseek_math.py
@@ -1,0 +1,567 @@
+# Adapted from DeepSeek-AI DeepSeek-Math, pinned commit:
+# https://github.com/deepseek-ai/DeepSeek-Math/tree/b8b0f8ce093d80bf8e9a641e44142f06d092c305/evaluation
+# Sources: data_processing/answer_extraction.py, eval/eval_utils.py, eval/eval_script.py.
+"""
+DeepSeek-Math MATH (CoT) answer extraction and equivalence.
+
+Faithful port of the `math-cot-test` evaluation path: the Minerva 4-shot prompt
+(`MinervaMathPrompt`), `extract_math_few_shot_cot_answer` (-> `extract_math_answer`
+-> `extract_answer` + DeepSeek's own `strip_string`), and `eval_math` (-> `is_correct`
+-> `math_equal`). Answers are LISTS (multi-answer questions) and `eval_math` does
+set-matching between the predicted and reference answer lists.
+
+Deviations from upstream:
+- `symbolic_equal` calls `sympy.parsing.latex.parse_latex`, which needs
+  `antlr4-python3-runtime==4.11`; this env pins `4.9.x` (via `math_verify`'s
+  `latex2sympy2_extended`), so `parse_latex` raises and DeepSeek's own
+  `_parse` fallback (`parse_expr` then the raw string) takes over. `symbolic_equal`
+  is the LAST layer of `math_equal`; the string / numeric (with percentage) /
+  tuple-interval / matrix / equation layers above it are unaffected.
+  (`eval_math` calls `math_equal` with the default `timeout=False`, so the
+  `symbolic_equal_process` / `call_with_timeout` path is unused here, but both
+  are kept so `math_equal` stays byte-faithful and callable with `timeout=True`.)
+- Two debug `print` statements inside `is_correct` are dropped (a library must not
+  write to stdout); control flow is otherwise verbatim.
+
+AI-Generated Code - Claude Opus 4.8 (Anthropic)
+"""
+
+import multiprocessing
+import re
+from copy import deepcopy
+from math import isclose
+from typing import Union
+
+import regex
+from sympy import N, simplify
+from sympy.parsing.latex import parse_latex
+from sympy.parsing.sympy_parser import parse_expr
+
+few_shot_prompt = """Problem:
+Find the domain of the expression $\\frac{\\sqrt{x-2}}{\\sqrt{5-x}}$.}
+
+Solution:
+The expressions inside each square root must be non-negative.
+Therefore, $x-2 \\ge 0$, so $x\\ge2$, and $5 - x \\ge 0$, so $x \\le 5$.
+Also, the denominator cannot be equal to zero, so $5-x>0$, which gives $x<5$.
+Therefore, the domain of the expression is $\\boxed{[2,5)}$.
+Final Answer: The final answer is $[2,5)$. I hope it is correct.
+
+Problem:
+If $\\det \\mathbf{A} = 2$ and $\\det \\mathbf{B} = 12,$ then find $\\det (\\mathbf{A} \\mathbf{B}).$
+
+Solution:
+We have that $\\det (\\mathbf{A} \\mathbf{B}) = (\\det \\mathbf{A})(\\det \\mathbf{B}) = (2)(12) = \\boxed{24}.$
+Final Answer: The final answer is $24$. I hope it is correct.
+
+Problem:
+Terrell usually lifts two 20-pound weights 12 times. If he uses two 15-pound weights instead, how many times must Terrell lift them in order to lift the same total weight?
+
+Solution:
+If Terrell lifts two 20-pound weights 12 times, he lifts a total of $2\\cdot 12\\cdot20=480$ pounds of weight.  If he lifts two 15-pound weights instead for $n$ times, he will lift a total of $2\\cdot15\\cdot n=30n$ pounds of weight.  Equating this to 480 pounds, we can solve for $n$: \\begin{align*}
+30n&=480\\\\
+\\Rightarrow\\qquad n&=480/30=\\boxed{16}
+\\end{align*}
+Final Answer: The final answer is $16$. I hope it is correct.
+
+Problem:
+If the system of equations
+
+\\begin{align*}
+6x-4y&=a,\\\\
+6y-9x &=b.
+\\end{align*}has a solution $(x, y)$ where $x$ and $y$ are both nonzero, find $\\frac{a}{b},$ assuming $b$ is nonzero.
+
+Solution:
+If we multiply the first equation by $-\\frac{3}{2}$, we obtain
+
+$$6y-9x=-\\frac{3}{2}a.$$Since we also know that $6y-9x=b$, we have
+
+$$-\\frac{3}{2}a=b\\Rightarrow\\frac{a}{b}=\\boxed{-\\frac{2}{3}}.$$
+Final Answer: The final answer is $-\\frac{2}{3}$. I hope it is correct."""
+
+
+STOP_WORDS = ["\nProblem:"]
+
+
+def format_prompt(task_input: str, task_output: str = "") -> str:
+    prompt = f"{few_shot_prompt}\n\nProblem:\n{task_input}\n\nSolution:\n{task_output}"
+    return prompt.rstrip()
+
+def _fix_fracs(string):
+    substrs = string.split("\\frac")
+    new_str = substrs[0]
+    if len(substrs) > 1:
+        substrs = substrs[1:]
+        for substr in substrs:
+            new_str += "\\frac"
+            if len(substr) > 0 and substr[0] == "{":
+                new_str += substr
+            else:
+                try:
+                    assert len(substr) >= 2
+                except:
+                    return string
+                a = substr[0]
+                b = substr[1]
+                if b != "{":
+                    if len(substr) > 2:
+                        post_substr = substr[2:]
+                        new_str += "{" + a + "}{" + b + "}" + post_substr
+                    else:
+                        new_str += "{" + a + "}{" + b + "}"
+                else:
+                    if len(substr) > 2:
+                        post_substr = substr[2:]
+                        new_str += "{" + a + "}" + b + post_substr
+                    else:
+                        new_str += "{" + a + "}" + b
+    string = new_str
+    return string
+
+def _fix_a_slash_b(string):
+    if len(string.split("/")) != 2:
+        return string
+    a = string.split("/")[0]
+    b = string.split("/")[1]
+    try:
+        if "sqrt" not in a:
+            a = int(a)
+        if "sqrt" not in b:
+            b = int(b)
+        assert string == "{}/{}".format(a, b)
+        new_string = "\\frac{" + str(a) + "}{" + str(b) + "}"
+        return new_string
+    except:
+        return string
+
+def _fix_sqrt(string):
+    _string = re.sub(r"\\sqrt(-?[0-9.a-zA-Z]+)", r"\\sqrt{\1}", string)
+    _string = re.sub(r"\\sqrt\s+(\w+)$", r"\\sqrt{\1}", _string)
+    return _string
+
+def _fix_tan(string):
+    _string = re.sub(r"\\tan(-?[0-9.a-zA-Z]+)", r"\\tan{\1}", string)
+    _string = re.sub(r"\\tan\s+(\w+)$", r"\\tan{\1}", _string)
+    return _string
+
+def strip_string(string):
+    string = str(string).strip()
+    # linebreaks
+    string = string.replace("\n", "")
+
+    # right "."
+    string = string.rstrip(".")
+
+    # remove inverse spaces
+    string = string.replace("\\!", "")
+    # string = string.replace("\\ ", "")
+
+    # replace \\ with \
+    # string = string.replace("\\\\", "\\")
+    # string = string.replace("\\\\", "\\")
+
+    if string.startswith("\\text{") and string.endswith("}"):
+        string = string.split("{", 1)[1][:-1]
+
+    # replace tfrac and dfrac with frac
+    string = string.replace("tfrac", "frac")
+    string = string.replace("dfrac", "frac")
+    string = string.replace("cfrac", "frac")
+
+    # remove \left and \right
+    string = string.replace("\\left", "")
+    string = string.replace("\\right", "")
+
+    # Remove unit: miles, dollars if after is not none
+    _string = re.sub(r"\\text{.*?}$", "", string).strip()
+    if _string != "" and _string != string:
+        # print("Warning: unit not removed: '{}' -> '{}'".format(string, _string))
+        string = _string
+
+    # Remove circ (degrees)
+    string = string.replace("^{\\circ}", "").strip()
+    string = string.replace("^\\circ", "").strip()
+
+    string = regex.sub(r"\{(c|m)?m\}(\^(2|3))?", "", string).strip()
+    string = regex.sub(r"p\.m\.$", "", string).strip()
+    string = regex.sub(r"(\d)\s*t$", r"\1", string).strip()
+
+    # remove dollar signs
+    string = string.replace("\\$", "")
+    string = string.replace("$", "")
+
+    # string = string.replace("\\text", "")
+    string = string.replace("x\\in", "")
+
+    # remove percentage
+    string = string.replace("\\%", "%")
+    string = string.replace("\%", "%")
+    # string = string.replace("%", "")
+
+    # " 0." equivalent to " ." and "{0." equivalent to "{." Alternatively, add "0" if "." is the start of the string
+    string = string.replace(" .", " 0.")
+    string = string.replace("{.", "{0.")
+
+    # cdot
+    string = string.replace("\\cdot", "")
+
+    # inf
+    string = string.replace("infinity", "\\infty")
+    if "\\infty" not in string:
+        string = string.replace("inf", "\\infty")
+    string = string.replace("+\\inity", "\\infty")
+
+    # and 
+    # string = string.replace("and", "")
+    string = string.replace("\\mathbf", "")
+    string = string.replace("\\mathrm", "")
+
+    # use regex to remove \mbox{...}
+    string = re.sub(r"\\mbox{.*?}", "", string)
+
+    # quote
+    string.replace("'", "")
+    string.replace("\"", "")
+    
+    # i, j
+    if "j" in string and "i" not in string:
+        string = string.replace("j", "i")
+
+    # replace a.000b where b is not number or b is end, with ab, use regex
+    string = re.sub(r"(\d+)\.0+([^\d])", r"\1\2", string)
+    string = re.sub(r"(\d+)\.0+$", r"\1", string)
+
+    # if empty, return empty string
+    if len(string) == 0:
+        return string
+    if string[0] == ".":
+        string = "0" + string
+
+    # to consider: get rid of e.g. "k = " or "q = " at beginning
+    # if len(string.split("=")) == 2:
+    #     if len(string.split("=")[0]) <= 2:
+    #         string = string.split("=")[1]
+
+    string = _fix_sqrt(string)
+    string = _fix_tan(string)
+    string = string.replace(" ", "")
+
+    # \frac1b or \frac12 --> \frac{1}{b} and \frac{1}{2}, etc. Even works with \frac1{72} (but not \frac{72}1). Also does a/b --> \\frac{a}{b}
+    string = _fix_fracs(string)
+
+    # NOTE: X/Y changed to \frac{X}{Y} in dataset, but in simple cases fix in case the model output is X/Y
+    string = _fix_a_slash_b(string)
+
+    string = regex.sub(r"(\\|,|\.)+$", "", string)
+
+    return string
+
+def extract_boxed_answers(text):
+    answers = []
+    for piece in text.split('boxed{')[1:]:
+        n = 0
+        for i in range(len(piece)):
+            if piece[i] == '{':
+                n += 1
+            elif piece[i] == '}':
+                n -= 1
+                if n < 0:
+                    if i + 1 < len(piece) and piece[i + 1] == '%':
+                        answers.append(piece[: i + 1])
+                    else:
+                        answers.append(piece[:i])
+                    break
+    return answers
+
+def extract_program_output(pred_str):
+    """
+    extract output between the last ```output\n...\n```
+    """
+    if "```output" not in pred_str:
+        return ""
+    if '```output' in pred_str:
+        pred_str = pred_str.split('```output')[-1]
+    if '```' in pred_str:
+        pred_str = pred_str.split('```')[0]
+    output = pred_str.strip()
+    return output
+
+def extract_answer(pred_str, exhaust=False):
+    pred = []
+    if 'final answer is $' in pred_str and '$. I hope' in pred_str:
+        tmp = pred_str.split('final answer is $', 1)[1]
+        pred = [tmp.split('$. I hope', 1)[0].strip()]
+    elif 'boxed' in pred_str:
+        pred = extract_boxed_answers(pred_str)
+    elif ('he answer is' in pred_str):
+        pred = [pred_str.split('he answer is')[-1].strip()]
+    else:
+        program_output = extract_program_output(pred_str)
+        if program_output != "":
+            # fall back to program
+            pred.append(program_output)
+        else: # use the last number
+            pattern = '-?\d*\.?\d+'
+            ans = re.findall(pattern, pred_str.replace(",", ""))
+            if(len(ans) >= 1):
+                ans = ans[-1]
+            else:
+                ans = ''
+            if ans:
+                pred.append(ans)
+
+    # multiple line
+    _pred = []
+    for ans in pred:
+        ans = ans.strip().split("\n")[0]
+        ans = ans.lstrip(":")
+        ans = ans.rstrip(".")
+        ans = ans.rstrip("/")
+        ans = strip_string(ans)
+        _pred.append(ans)
+    if exhaust:
+        return _pred
+    else:
+        return _pred[-1] if _pred else ""
+
+def extract_math_answer(question, reasoning, task):
+    answer = []
+    for ans in extract_answer(reasoning, exhaust=True):
+        if 'separated by commas' in question and all(ch not in ans for ch in '()[]'):
+            answer.extend([a.strip() for a in ans.split(",")])
+        elif regex.search(r"\\text\{\s*and\s*\}", ans):
+            answer.extend([a.strip() for a in regex.sub(r"\\text\{\s*and\s*\}", "[SEP]", ans).split("[SEP]")])
+        else:
+            answer.append(ans.strip())
+    return answer
+
+def extract_math_few_shot_cot_answer(question, reasoning, task):
+    if 'Problem:' in reasoning:
+        reasoning = reasoning.split("Problem:", 1)[0]
+    return extract_math_answer(question, reasoning, task)
+
+def parse_digits(num):
+    # format: 234.23 || 23%
+    num = regex.sub(',', '', str(num))
+    try:
+        return float(num)
+    except:
+        if num.endswith('%'):
+            num = num[:-1]
+            if num.endswith('\\'):
+                num = num[:-1]
+            try:
+                return float(num) / 100
+            except:
+                pass
+    return None
+
+def is_digit(num):
+    # paired with parse_digits
+    return parse_digits(num) is not None
+
+def symbolic_equal(a, b):
+    def _parse(s):
+        for f in [parse_latex, parse_expr]:
+            try:
+                return f(s)
+            except:
+                pass
+        return s
+    a = _parse(a)
+    b = _parse(b)
+
+    try:
+        if simplify(a-b) == 0:
+            return True
+    except:
+        pass
+
+    try:
+        if isclose(N(a), N(b), abs_tol=1e-3):
+            return True
+    except:
+        pass
+    return False
+
+
+def symbolic_equal_process(a, b, output_queue):
+    result = symbolic_equal(a, b)
+    output_queue.put(result)
+
+
+def call_with_timeout(func, *args, timeout=1, **kwargs):
+    output_queue = multiprocessing.Queue()
+    process_args = args + (output_queue,)
+    process = multiprocessing.Process(target=func, args=process_args, kwargs=kwargs)
+    process.start()
+    process.join(timeout)
+
+    if process.is_alive():
+        process.terminate()
+        process.join()
+        return False
+
+    return output_queue.get()
+
+
+def math_equal(prediction: Union[bool, float, str],
+                reference: Union[float, str],
+                include_percentage: bool = True,
+                is_close: bool = True,
+                timeout: bool = False,
+                ) -> bool:
+    """
+    Exact match of math if and only if:
+    1. numerical equal: both can convert to float and are equal
+    2. symbolic equal: both can convert to sympy expression and are equal
+    """
+    if str(prediction) == str(reference):
+        return True
+
+    try: # 1. numerical equal
+        if is_digit(prediction) and is_digit(reference):
+            prediction = parse_digits(prediction)
+            reference = parse_digits(reference)
+            # number questions
+            if include_percentage:
+                gt_result = [reference / 100, reference, reference * 100]
+            else:
+                gt_result = [reference]
+            for item in gt_result:
+                try:
+                    if is_close:
+                        if isclose(item, prediction, abs_tol=1e-3):
+                            return True
+                    else:
+                        if item == prediction:
+                            return True
+                except Exception:
+                    continue
+            return False
+    except:
+        pass
+
+    if not prediction and prediction not in [0, False]:
+        return False
+
+    # 2. symbolic equal
+    reference = str(reference).strip()
+    prediction = str(prediction).strip()
+
+    if regex.match(r'(\(|\[).+(\)|\])', prediction) is not None and regex.match(r'(\(|\[).+(\)|\])', reference) is not None:
+        pred_parts = prediction[1:-1].split(",")
+        ref_parts = reference[1:-1].split(",")
+        if len(pred_parts) == len(ref_parts):
+            if all([math_equal(pred_parts[i], ref_parts[i], include_percentage, is_close) for i in range(len(pred_parts))]):
+                return True
+
+    if (prediction.startswith("\\begin{pmatrix}") or prediction.startswith("\\begin{bmatrix}")) and (prediction.endswith("\\end{pmatrix}") or prediction.endswith("\\end{bmatrix}")) and \
+        (reference.startswith("\\begin{pmatrix}") or reference.startswith("\\begin{bmatrix}")) and (reference.endswith("\\end{pmatrix}") or reference.endswith("\\end{bmatrix}")):
+        pred_lines = [line.strip() for line in prediction[len("\\begin{pmatrix}"): -len("\\end{pmatrix}")].split("\\\\") if line.strip()]
+        ref_lines = [line.strip() for line in reference[len("\\begin{pmatrix}"): -len("\\end{pmatrix}")].split("\\\\") if line.strip()]
+        matched = True
+        if len(pred_lines) == len(ref_lines):
+            for pred_line, ref_line in zip(pred_lines, ref_lines):
+                pred_parts = pred_line.split("&")
+                ref_parts = ref_line.split("&")
+                if len(pred_parts) == len(ref_parts):
+                    if not all([math_equal(pred_parts[i], ref_parts[i], include_percentage, is_close) for i in range(len(pred_parts))]):
+                        matched = False
+                        break
+                else:
+                    matched = False
+                if not matched:
+                    break
+        else:
+            matched = False
+        if matched:
+            return True
+
+    if prediction.count('=') == 1 and reference.count('=') == 1:
+        pred = prediction.split('=')
+        pred = f"{pred[0].strip()} - ({pred[1].strip()})"
+        ref = reference.split('=')
+        ref = f"{ref[0].strip()} - ({ref[1].strip()})"
+        if symbolic_equal(pred, ref) or symbolic_equal(f"-({pred})", ref):
+            return True
+    elif prediction.count('=') == 1 and len(prediction.split('=')[0].strip()) <= 2 and '=' not in reference:
+        if math_equal(prediction.split('=')[1], reference, include_percentage, is_close):
+            return True
+    elif reference.count('=') == 1 and len(reference.split('=')[0].strip()) <= 2 and '=' not in prediction:
+        if math_equal(prediction, reference.split('=')[1], include_percentage, is_close):
+            return True
+
+    # symbolic equal with sympy
+    if timeout:
+        if call_with_timeout(symbolic_equal_process, prediction, reference):
+            return True
+    else:
+        if symbolic_equal(prediction, reference):
+            return True
+
+    return False
+
+def is_correct(item, pred_key='prediction', prec=1e-3):
+    pred = item[pred_key]
+    ans = item['answer']
+    if isinstance(pred, list) and isinstance(ans, list):
+        pred_matched = set()
+        ans_matched = set()
+        for i in range(len(pred)):
+            for j in range(len(ans)):
+                item_cpy = deepcopy(item)
+                item_cpy.update({
+                    pred_key: pred[i],
+                    'answer': ans[j]
+                })
+                if is_correct(item_cpy, pred_key=pred_key, prec=prec):
+                    pred_matched.add(i)
+                    ans_matched.add(j)
+        return len(pred_matched) == len(pred) and len(ans_matched) == len(ans)
+    elif isinstance(pred, str) and isinstance(ans, str):
+        if '\\cup' in pred and '\\cup' in ans:
+            item = deepcopy(item)
+            item.update({
+                pred_key: pred.split('\\cup'),
+                'answer': ans.split('\\cup'),
+            })
+            return is_correct(item, pred_key=pred_key, prec=prec)
+        else:
+            label = False
+            try:
+                label = abs(float(regex.sub(r',', '', str(pred))) - float(regex.sub(r',', '', str(ans)))) < prec
+            except:
+                pass
+            label = label or (ans and pred == ans) or math_equal(pred, ans)
+            return label
+    else:
+        print(item, flush=True)
+        raise NotImplementedError()
+
+def eval_math(item, pred_key='prediction', prec=1e-3):
+    pred = item[pred_key]
+    if pred_key == 'program_output' and isinstance(pred, str):
+        pred = [pred]
+    ans = item['answer']
+    if isinstance(pred, list) and isinstance(ans, list):
+        # for some questions in MATH, `reference` repeats answers
+        _ans = []
+        for a in ans:
+            if a not in _ans:
+                _ans.append(a)
+        ans = _ans
+        # some predictions for MATH questions also repeats answers
+        _pred = []
+        for a in pred:
+            if a not in _pred:
+                _pred.append(a)
+        # some predictions mistakenly box non-answer strings
+        pred = _pred[-len(ans):]
+
+    item.update({
+        pred_key: pred,
+        'answer': ans
+    })
+    return is_correct(item, pred_key=pred_key, prec=prec)

--- a/sieval/community/deepseek_math.py
+++ b/sieval/community/deepseek_math.py
@@ -2,26 +2,44 @@
 # https://github.com/deepseek-ai/DeepSeek-Math/tree/b8b0f8ce093d80bf8e9a641e44142f06d092c305/evaluation
 # Sources: data_processing/answer_extraction.py, eval/eval_utils.py, eval/eval_script.py.
 """
-DeepSeek-Math MATH (CoT) answer extraction and equivalence.
+DeepSeek-Math answer extraction and answer equivalence.
 
-Faithful port of the `math-cot-test` evaluation path: the Minerva 4-shot prompt
-(`MinervaMathPrompt`), `extract_math_few_shot_cot_answer` (-> `extract_math_answer`
--> `extract_answer` + DeepSeek's own `strip_string`), and `eval_math` (-> `is_correct`
--> `math_equal`). Answers are LISTS (multi-answer questions) and `eval_math` does
-set-matching between the predicted and reference answer lists.
+Faithful port — trimmed to exactly what the GSM8K 0-shot task consumes — of the
+answer-handling utilities from the pinned commit
+(`data_processing/answer_extraction.py`, `eval/eval_utils.py`,
+`eval/eval_script.py`):
+
+* `extract_answer` (with `extract_boxed_answers` / `extract_program_output` /
+  `strip_string`) — pull the final answer out of a model's reasoning: last
+  ``\\boxed{...}`` if present, else the text after ``"he answer is"``, else the
+  last number; then normalize.
+* `math_equal` / `is_correct` — string, then numeric (with percentage /
+  interval / matrix / equation handling), then sympy symbolic equivalence.
+
+`sieval.tasks.gsm8k_0shot_gen` calls `extract_answer(exhaust=False)` (=
+DeepSeek's `extract_last_single_answer`) and `is_correct` (=
+`eval_last_single_answer`). DeepSeek's MATH multi-answer helpers
+(`extract_math_answer` / `eval_math`) and few-shot prompt are intentionally
+omitted; they can be vendored byte-faithfully alongside a future MATH task that
+needs them.
 
 Deviations from upstream:
-- `symbolic_equal` calls `sympy.parsing.latex.parse_latex`, which needs
-  `antlr4-python3-runtime==4.11`; this env pins `4.9.x` (via `math_verify`'s
-  `latex2sympy2_extended`), so `parse_latex` raises and DeepSeek's own
-  `_parse` fallback (`parse_expr` then the raw string) takes over. `symbolic_equal`
-  is the LAST layer of `math_equal`; the string / numeric (with percentage) /
-  tuple-interval / matrix / equation layers above it are unaffected.
-  (`eval_math` calls `math_equal` with the default `timeout=False`, so the
-  `symbolic_equal_process` / `call_with_timeout` path is unused here, but both
-  are kept so `math_equal` stays byte-faithful and callable with `timeout=True`.)
-- Two debug `print` statements inside `is_correct` are dropped (a library must not
-  write to stdout); control flow is otherwise verbatim.
+- `symbolic_equal` calls `sympy.parsing.latex.parse_latex`, whose ANTLR backend
+  requires the `antlr4-python3-runtime` build that sympy's LaTeX grammar was
+  generated against. The version resolved in this env (transitively, via
+  `math_verify`'s `latex2sympy2_extended`) does not match, so `parse_latex`
+  raises and DeepSeek's own `_parse` fallback (`parse_expr`, then the raw
+  string) takes over. `symbolic_equal` is the LAST layer of `math_equal`; the
+  string / numeric (with percentage) / tuple-interval / matrix / equation
+  layers above it are unaffected. (`math_equal` is called with the default
+  `timeout=False`, so the `symbolic_equal_process` / `call_with_timeout` path is
+  unused here, but both are kept so `math_equal` stays byte-faithful and
+  callable with `timeout=True`.)
+- The two debug `print` statements in `is_correct`'s list-branch ``'2,3,4'``
+  guard are dropped (they fire during normal scoring — a library must not write
+  to stdout). The lone `print(item)` before the final `NotImplementedError`
+  (unreachable for GSM8K's single-string answers) is kept verbatim; control flow
+  is otherwise byte-faithful.
 
 AI-Generated Code - Claude Opus 4.8 (Anthropic)
 """
@@ -37,56 +55,6 @@ from sympy import N, simplify
 from sympy.parsing.latex import parse_latex
 from sympy.parsing.sympy_parser import parse_expr
 
-few_shot_prompt = """Problem:
-Find the domain of the expression $\\frac{\\sqrt{x-2}}{\\sqrt{5-x}}$.}
-
-Solution:
-The expressions inside each square root must be non-negative.
-Therefore, $x-2 \\ge 0$, so $x\\ge2$, and $5 - x \\ge 0$, so $x \\le 5$.
-Also, the denominator cannot be equal to zero, so $5-x>0$, which gives $x<5$.
-Therefore, the domain of the expression is $\\boxed{[2,5)}$.
-Final Answer: The final answer is $[2,5)$. I hope it is correct.
-
-Problem:
-If $\\det \\mathbf{A} = 2$ and $\\det \\mathbf{B} = 12,$ then find $\\det (\\mathbf{A} \\mathbf{B}).$
-
-Solution:
-We have that $\\det (\\mathbf{A} \\mathbf{B}) = (\\det \\mathbf{A})(\\det \\mathbf{B}) = (2)(12) = \\boxed{24}.$
-Final Answer: The final answer is $24$. I hope it is correct.
-
-Problem:
-Terrell usually lifts two 20-pound weights 12 times. If he uses two 15-pound weights instead, how many times must Terrell lift them in order to lift the same total weight?
-
-Solution:
-If Terrell lifts two 20-pound weights 12 times, he lifts a total of $2\\cdot 12\\cdot20=480$ pounds of weight.  If he lifts two 15-pound weights instead for $n$ times, he will lift a total of $2\\cdot15\\cdot n=30n$ pounds of weight.  Equating this to 480 pounds, we can solve for $n$: \\begin{align*}
-30n&=480\\\\
-\\Rightarrow\\qquad n&=480/30=\\boxed{16}
-\\end{align*}
-Final Answer: The final answer is $16$. I hope it is correct.
-
-Problem:
-If the system of equations
-
-\\begin{align*}
-6x-4y&=a,\\\\
-6y-9x &=b.
-\\end{align*}has a solution $(x, y)$ where $x$ and $y$ are both nonzero, find $\\frac{a}{b},$ assuming $b$ is nonzero.
-
-Solution:
-If we multiply the first equation by $-\\frac{3}{2}$, we obtain
-
-$$6y-9x=-\\frac{3}{2}a.$$Since we also know that $6y-9x=b$, we have
-
-$$-\\frac{3}{2}a=b\\Rightarrow\\frac{a}{b}=\\boxed{-\\frac{2}{3}}.$$
-Final Answer: The final answer is $-\\frac{2}{3}$. I hope it is correct."""
-
-
-STOP_WORDS = ["\nProblem:"]
-
-
-def format_prompt(task_input: str, task_output: str = "") -> str:
-    prompt = f"{few_shot_prompt}\n\nProblem:\n{task_input}\n\nSolution:\n{task_output}"
-    return prompt.rstrip()
 
 def _fix_fracs(string):
     substrs = string.split("\\frac")
@@ -325,22 +293,6 @@ def extract_answer(pred_str, exhaust=False):
     else:
         return _pred[-1] if _pred else ""
 
-def extract_math_answer(question, reasoning, task):
-    answer = []
-    for ans in extract_answer(reasoning, exhaust=True):
-        if 'separated by commas' in question and all(ch not in ans for ch in '()[]'):
-            answer.extend([a.strip() for a in ans.split(",")])
-        elif regex.search(r"\\text\{\s*and\s*\}", ans):
-            answer.extend([a.strip() for a in regex.sub(r"\\text\{\s*and\s*\}", "[SEP]", ans).split("[SEP]")])
-        else:
-            answer.append(ans.strip())
-    return answer
-
-def extract_math_few_shot_cot_answer(question, reasoning, task):
-    if 'Problem:' in reasoning:
-        reasoning = reasoning.split("Problem:", 1)[0]
-    return extract_math_answer(question, reasoning, task)
-
 def parse_digits(num):
     # format: 234.23 || 23%
     num = regex.sub(',', '', str(num))
@@ -539,29 +491,3 @@ def is_correct(item, pred_key='prediction', prec=1e-3):
     else:
         print(item, flush=True)
         raise NotImplementedError()
-
-def eval_math(item, pred_key='prediction', prec=1e-3):
-    pred = item[pred_key]
-    if pred_key == 'program_output' and isinstance(pred, str):
-        pred = [pred]
-    ans = item['answer']
-    if isinstance(pred, list) and isinstance(ans, list):
-        # for some questions in MATH, `reference` repeats answers
-        _ans = []
-        for a in ans:
-            if a not in _ans:
-                _ans.append(a)
-        ans = _ans
-        # some predictions for MATH questions also repeats answers
-        _pred = []
-        for a in pred:
-            if a not in _pred:
-                _pred.append(a)
-        # some predictions mistakenly box non-answer strings
-        pred = _pred[-len(ans):]
-
-    item.update({
-        pred_key: pred,
-        'answer': ans
-    })
-    return is_correct(item, pred_key=pred_key, prec=prec)

--- a/sieval/meta/index.json
+++ b/sieval/meta/index.json
@@ -572,6 +572,27 @@
       "status": "stable"
     },
     {
+      "name": "gsm8k_0shot_gen",
+      "display_name": "GSM8K (0-shot, generative)",
+      "description": "GSM8K 0-shot chat-model eval aligned with the DeepSeek-Math pipeline.",
+      "dataset": "gsm8k",
+      "eval_mode": "gen",
+      "n_shot": 0,
+      "tags": [
+        "english",
+        "math-word-problems",
+        "open-ended"
+      ],
+      "deps_group": "math",
+      "model_type": "chat",
+      "reference_impl": {
+        "source": "deepseek-ai/DeepSeek-Math",
+        "url": "https://github.com/deepseek-ai/DeepSeek-Math/tree/b8b0f8ce093d80bf8e9a641e44142f06d092c305/evaluation",
+        "notes": "gsm8k-test zero-shot CoT protocol: user turn = question + \"Please reason step by step, and put your final answer within \\boxed{}.\", chat template applied by the serving backend; extract_answer(exhaust=False) (= extract_last_single_answer) and is_correct/math_equal (= eval_last_single_answer) scoring are vendored byte-for-byte in sieval.community.deepseek_math. Gold derived from openai/gsm8k like process_gsm8k_test (answer.split('####')[-1], commas removed)."
+      },
+      "status": "stable"
+    },
+    {
       "name": "gsm8k_kshot_base_gen",
       "display_name": "GSM8K (few-shot, base generative)",
       "description": "GSM8K few-shot base-model strict-match EM evaluation.",

--- a/sieval/tasks/__init__.pyi
+++ b/sieval/tasks/__init__.pyi
@@ -19,6 +19,9 @@ from .drop_kshot_gen import (
 from .gpqa_diamond_0shot_gen import (
     GPQADiamondZeroShotGenTask,
 )
+from .gsm8k_0shot_gen import (
+    GSM8KZeroShotGenTask,
+)
 from .gsm8k_kshot_base_gen import (
     GSM8KFewShotBaseGenTask,
 )
@@ -76,6 +79,7 @@ __all__ = [
     "DROPFewShotGenTask",
     "GPQADiamondZeroShotGenTask",
     "GSM8KFewShotBaseGenTask",
+    "GSM8KZeroShotGenTask",
     "HMMTFeb2025ZeroShotGenTask",
     "HMMTFeb2026ZeroShotGenTask",
     "HumanEvalZeroShotBaseGenTask",

--- a/sieval/tasks/gsm8k_0shot_gen.py
+++ b/sieval/tasks/gsm8k_0shot_gen.py
@@ -1,0 +1,147 @@
+"""
+GSM8K 0-shot generative task, aligned with DeepSeek-Math evaluation.
+
+Strict port of DeepSeek-Math's ``gsm8k-test`` zero-shot (CoT, instruct/chat)
+path (pinned commit ``b8b0f8ce``, ``configs/zero_shot_test_configs.json``):
+
+* Prompt (``run_subset_parallel.py::markup_question``, language="en", task="cot"):
+  the user turn is ``{question}`` followed by ``"\\nPlease reason step by step,
+  and put your final answer within \\boxed{}."``; the serving backend applies the
+  model's own chat template (``apply_chat_template``, add_generation_prompt=True
+  — see ``replicate/predict_instruct.py``).
+* Answer extraction: DeepSeek's ``extract_last_single_answer`` is exactly
+  ``extract_answer(reasoning, exhaust=False)`` — last ``\\boxed{...}`` if present,
+  else text after ``"he answer is"``, else the last number; then ``strip_string``
+  normalization. We call ``extract_answer(..., exhaust=False)`` directly.
+* Scoring: DeepSeek's ``eval_last_single_answer`` is ``is_correct`` (numeric
+  isclose with %-variants, then sympy symbolic fallback). We call ``is_correct``
+  directly. ``score`` is this accuracy.
+
+All extraction/scoring lives verbatim in ``sieval.community.deepseek_math`` (the
+same vendored module the MATH task uses).
+
+Deviations from the DeepSeek-Math repo (documented, not silent):
+
+* Gold answer: DeepSeek's bundled ``datasets/gsm8k/test.jsonl`` stores ``answer``
+  as the bare post-``####`` number. This task loads ``openai/gsm8k`` (the
+  GSM8KDataset source), so the gold is derived the same way ``process_gsm8k_test``
+  does: ``answer.split("####")[-1].strip()`` with commas removed. Questions are
+  identical.
+* The chat template is applied by the inference backend (sglang/vLLM serving the
+  instruct checkpoint) rather than in-process, as in DeepSeek's harness.
+
+Comparison target: DeepSeek-LLM-7B-Chat GSM8K = 63.0 (DeepSeek LLM report,
+Table 6, 0-shot). That number is for DeepSeek-LLM-7B-Chat while this pipeline is
+DeepSeek-Math's; both share the answer-extraction lineage. The model under test,
+its prompt rendering, and its chat template govern how close the score lands.
+
+Repro decoding (model-layer assets — set via ``models:`` / ``infer_args``, not
+in this code): greedy ``temperature=0``, ``top_p=1.0``, ``max_tokens=1024``,
+stop = the model's EOS only (DeepSeek's ``run_cot_eval.py`` SamplingParams for
+zero-shot CoT).
+
+AI-Generated Code - Claude Opus 4.8 (Anthropic)
+"""
+
+from typing import TypedDict, override
+
+from openai.types.chat import ChatCompletionUserMessageParam
+
+from sieval.core.models import ModelOutput
+from sieval.core.tasks import (
+    EvalMode,
+    ReferenceImpl,
+    Task,
+    sieval_task,
+)
+from sieval.datasets import GSM8KDatasetSample
+
+# Verbatim from run_subset_parallel.py::markup_question (language="en",
+# task="cot"): f"{content}\nPlease reason step by step, and put your final
+# answer within " + "\\boxed{}."
+COT_INSTRUCTION = (
+    "\nPlease reason step by step, and put your final answer within \\boxed{}."
+)
+
+
+class Feedback(TypedDict):
+    correct: bool
+    answer: str
+    prediction: str
+
+
+def _gold_answer(answer: str) -> str:
+    # DeepSeek process_gsm8k_test gold: item['answer'].replace(',', ''); for the
+    # openai/gsm8k schema that bare number is answer.split('####')[-1].strip().
+    return answer.split("####")[-1].strip().replace(",", "")
+
+
+@sieval_task(
+    name="gsm8k_0shot_gen",
+    display_name="GSM8K (0-shot, generative)",
+    description="GSM8K 0-shot chat-model eval aligned with the DeepSeek-Math pipeline.",
+    eval_mode=EvalMode.GEN,
+    n_shot=0,
+    tags=("english", "math-word-problems", "open-ended"),
+    deps_group="math",
+    model_type="chat",
+    reference_impl=ReferenceImpl(
+        source="deepseek-ai/DeepSeek-Math",
+        url=(
+            "https://github.com/deepseek-ai/DeepSeek-Math/tree/b8b0f8ce093d80bf8e9a641e44142f06d092c305/evaluation"
+        ),
+        notes=(
+            "gsm8k-test zero-shot CoT protocol: user turn = question + "
+            '"Please reason step by step, and put your final answer within '
+            '\\boxed{}.", chat template applied by the serving backend; '
+            "extract_answer(exhaust=False) (= extract_last_single_answer) and "
+            "is_correct/math_equal (= eval_last_single_answer) scoring are "
+            "vendored byte-for-byte in sieval.community.deepseek_math. Gold "
+            "derived from openai/gsm8k like process_gsm8k_test "
+            "(answer.split('####')[-1], commas removed)."
+        ),
+    ),
+)
+class GSM8KZeroShotGenTask(
+    Task[
+        GSM8KDatasetSample,
+        list[ChatCompletionUserMessageParam],
+        ModelOutput,
+        str,
+        Feedback,
+        dict[str, float],
+    ]
+):
+    @override
+    async def preprocess(self, raw, ctx):
+        return [
+            {"role": "user", "content": raw["question"] + COT_INSTRUCTION},
+        ]
+
+    @override
+    async def infer(self, pre, ctx):
+        return await self.model.agenerate(pre)
+
+    @override
+    async def postprocess(self, inf, ctx):
+        from sieval.community.deepseek_math import extract_answer
+
+        text = inf.texts[0] if inf.texts else ""
+        return extract_answer(text, exhaust=False)
+
+    @override
+    async def feedback(self, post, ctx):
+        from sieval.community.deepseek_math import is_correct
+
+        gold = _gold_answer(ctx.raw_sample["answer"])
+        correct = is_correct({"prediction": post, "answer": gold})
+        return True, {"correct": correct, "answer": gold, "prediction": post}
+
+    @override
+    async def report(self, finals, fails):
+        count = len(finals)
+        if count == 0:
+            return {"score": 0.0, "fails": len(fails), "accuracy": 0.0}
+        correct_num = sum(1 for ctx in finals if ctx.feedback_result["correct"])
+        accuracy = 100 * correct_num / count
+        return {"score": accuracy, "fails": len(fails), "accuracy": accuracy}

--- a/sieval/tasks/gsm8k_0shot_gen.py
+++ b/sieval/tasks/gsm8k_0shot_gen.py
@@ -17,8 +17,9 @@ path (pinned commit ``b8b0f8ce``, ``configs/zero_shot_test_configs.json``):
   isclose with %-variants, then sympy symbolic fallback). We call ``is_correct``
   directly. ``score`` is this accuracy.
 
-All extraction/scoring lives verbatim in ``sieval.community.deepseek_math`` (the
-same vendored module the MATH task uses).
+All extraction/scoring lives verbatim in ``sieval.community.deepseek_math``
+(vendored byte-faithfully from DeepSeek-Math's ``answer_extraction.py`` /
+``eval_utils.py`` / ``eval_script.py`` at the pinned commit).
 
 Deviations from the DeepSeek-Math repo (documented, not silent):
 
@@ -139,9 +140,12 @@ class GSM8KZeroShotGenTask(
 
     @override
     async def report(self, finals, fails):
-        count = len(finals)
-        if count == 0:
+        # Accuracy over the full requested set (finals + fails), matching the
+        # math-0shot-gen family and DeepSeek's full-set accuracy: a pipeline
+        # failure counts as wrong, not as an excluded sample.
+        total = len(finals) + len(fails)
+        if total == 0:
             return {"score": 0.0, "fails": len(fails), "accuracy": 0.0}
         correct_num = sum(1 for ctx in finals if ctx.feedback_result["correct"])
-        accuracy = 100 * correct_num / count
+        accuracy = 100 * correct_num / total
         return {"score": accuracy, "fails": len(fails), "accuracy": accuracy}

--- a/tests/unit/tasks/test_gsm8k_0shot_gen.py
+++ b/tests/unit/tasks/test_gsm8k_0shot_gen.py
@@ -1,0 +1,166 @@
+"""Unit tests for the DeepSeek-Math-aligned GSM8K 0-shot task.
+
+AI-Generated Code - Claude Opus 4.8 (Anthropic)
+"""
+
+import pytest
+from datasets import Dataset as HFDataset
+from datasets import DatasetDict as HFDatasetDict
+
+from sieval.core.models import ModelOutput
+from sieval.core.models.chat_model import ChatModel
+from sieval.core.tasks import TaskContext
+from sieval.datasets.gsm8k import GSM8KDataset, GSM8KDatasetSample
+from sieval.tasks.gsm8k_0shot_gen import (
+    COT_INSTRUCTION,
+    GSM8KZeroShotGenTask,
+    _gold_answer,
+)
+
+
+class _CapturingChatModel(ChatModel):
+    def __init__(self, text: str):
+        super().__init__(model="mock-chat", api_key="fake")
+        self.last_kwargs: dict[str, object] = {}
+        self._text = text
+
+    async def _agenerate_impl(self, prompt, **kwargs) -> ModelOutput:
+        _ = prompt
+        self.last_kwargs = dict(kwargs)
+        return ModelOutput(model=self.meta(), texts=[self._text])
+
+    async def _alogprobs_impl(
+        self,
+        prompt,
+        *,
+        max_tokens: int = 1,
+        logprobs: int = 5,
+        echo: bool = True,
+        temperature: float = 0.0,
+        **kwargs,
+    ) -> ModelOutput:
+        _ = (prompt, max_tokens, logprobs, echo, temperature, kwargs)
+        return ModelOutput(model=self.meta(), texts=[""])
+
+
+def _sample(answer: str = "Solution.\n#### 42") -> GSM8KDatasetSample:
+    return {"question": "What is 40 + 2?", "answer": answer}
+
+
+def _task(text: str):
+    dataset = GSM8KDataset(
+        _hf_dict=HFDatasetDict({"test": HFDataset.from_list([dict(_sample())])})
+    )
+    model = _CapturingChatModel(text=text)
+    return GSM8KZeroShotGenTask(dataset, model), model
+
+
+# --- Pinning: prompt instruction is byte-for-byte DeepSeek markup_question(en, cot) ---
+
+
+def test_cot_instruction_pinned():
+    assert COT_INSTRUCTION == (
+        "\nPlease reason step by step, and put your final answer within \\boxed{}."
+    )
+
+
+@pytest.mark.anyio
+async def test_preprocess_appends_instruction_single_user_turn():
+    task, _ = _task("x")
+    messages = await task.preprocess(
+        _sample(), TaskContext(sample_id=0, raw_sample=_sample())
+    )
+    assert len(messages) == 1
+    assert messages[0]["role"] == "user"
+    assert messages[0]["content"] == "What is 40 + 2?" + COT_INSTRUCTION
+
+
+# --- Gold derivation matches process_gsm8k_test (####-split, commas removed) ---
+
+
+def test_gold_answer_strip_and_decomma():
+    assert _gold_answer("reasoning ...\n#### 1,000") == "1000"
+    assert _gold_answer("#### 42") == "42"
+
+
+# --- postprocess uses DeepSeek extract_answer(exhaust=False): boxed wins ---
+
+
+@pytest.mark.anyio
+async def test_postprocess_prefers_boxed():
+    task, model = _task("x")
+    inf = ModelOutput(
+        model=model.meta(), texts=["Work.\nSo the answer is $\\boxed{42}$."]
+    )
+    post = await task.postprocess(inf, TaskContext(sample_id=0, raw_sample=_sample()))
+    assert post == "42"
+
+
+@pytest.mark.anyio
+async def test_postprocess_last_number_fallback():
+    task, model = _task("x")
+    inf = ModelOutput(model=model.meta(), texts=["first 12 then finally 30"])
+    post = await task.postprocess(inf, TaskContext(sample_id=0, raw_sample=_sample()))
+    assert post == "30"
+
+
+# --- scoring via vendored is_correct/math_equal (numeric isclose) ---
+
+
+@pytest.mark.anyio
+async def test_feedback_numeric_equal_via_math_equal():
+    task, model = _task("x")
+    raw = _sample(answer="Work.\n#### 1,000")
+    inf = ModelOutput(
+        model=model.meta(), texts=["...so the answer is $\\boxed{1000.0}$."]
+    )
+    ctx = TaskContext(sample_id=0, raw_sample=raw, infer_result=inf)
+    post = await task.postprocess(inf, ctx)
+    finalize, fb = await task.feedback(post, ctx)
+    assert finalize is True
+    assert fb["answer"] == "1000"
+    assert fb["correct"] is True
+
+
+@pytest.mark.anyio
+async def test_feedback_wrong_answer():
+    task, model = _task("x")
+    raw = _sample(answer="Work.\n#### 42")
+    inf = ModelOutput(model=model.meta(), texts=["The answer is $\\boxed{7}$."])
+    ctx = TaskContext(sample_id=0, raw_sample=raw, infer_result=inf)
+    post = await task.postprocess(inf, ctx)
+    _, fb = await task.feedback(post, ctx)
+    assert fb["correct"] is False
+
+
+# --- report accuracy + infer injects no decode params ---
+
+
+@pytest.mark.anyio
+async def test_report_accuracy():
+    task, _ = _task("x")
+    raw = _sample()
+    finals = [
+        TaskContext(sample_id=0, raw_sample=raw, feedback_result={"correct": True}),
+        TaskContext(sample_id=1, raw_sample=raw, feedback_result={"correct": False}),
+    ]
+    report = await task.report(finals, [])
+    assert report == {"score": 50.0, "fails": 0, "accuracy": 50.0}
+
+
+@pytest.mark.anyio
+async def test_report_empty_finals():
+    task, _ = _task("x")
+    report = await task.report([], [])
+    assert report == {"score": 0.0, "fails": 0, "accuracy": 0.0}
+
+
+@pytest.mark.anyio
+async def test_infer_injects_no_decode_params():
+    task, model = _task("x")
+    pre = await task.preprocess(
+        _sample(), TaskContext(sample_id=0, raw_sample=_sample())
+    )
+    await task.infer(pre, TaskContext(sample_id=0, raw_sample=_sample()))
+    for forbidden in ("temperature", "top_p", "max_tokens", "n", "stop"):
+        assert forbidden not in model.last_kwargs

--- a/tests/unit/tasks/test_gsm8k_0shot_gen.py
+++ b/tests/unit/tasks/test_gsm8k_0shot_gen.py
@@ -156,6 +156,20 @@ async def test_report_empty_finals():
 
 
 @pytest.mark.anyio
+async def test_report_counts_fails_in_denominator():
+    # Denominator is len(finals) + len(fails), matching the math-0shot-gen
+    # family: a pipeline failure counts as wrong, not as an excluded sample.
+    task, _ = _task("x")
+    raw = _sample()
+    finals = [
+        TaskContext(sample_id=0, raw_sample=raw, feedback_result={"correct": True}),
+    ]
+    fails = [TaskContext(sample_id=1, raw_sample=raw)]
+    report = await task.report(finals, fails)
+    assert report == {"score": 50.0, "fails": 1, "accuracy": 50.0}
+
+
+@pytest.mark.anyio
 async def test_infer_injects_no_decode_params():
     task, model = _task("x")
     pre = await task.preprocess(


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Type

- feature — new benchmark, task, or capability

## Summary

- Add `gsm8k_0shot_gen` (`GSM8KZeroShotGenTask`): a 0-shot chat GSM8K task aligned with DeepSeek-Math's `gsm8k-test` eval path (pinned commit  `b8b0f8ce`). Prompt = question + "Please reason step by step, and put your
  final answer within \boxed{}."; the chat template is applied by the serving backend; greedy decoding `temperature=0, top_p=1.0, max_tokens=1024`.
- Vendor DeepSeek-Math's answer extraction + scoring byte-for-byte into `sieval/community/deepseek_math.py` (identical to the sieval-math repo's copy, so the two PRs share the file conflict-free). The task uses `extract_answer(exhaust=False)` (= DeepSeek `extract_last_single_answer`) and `is_correct`/`math_equal` (= `eval_last_single_answer`).
- Gold derived from `openai/gsm8k` like DeepSeek's `process_gsm8k_test` (`answer.split("####")[-1]`, commas removed).
- Reference: DeepSeek-Math evaluation (https://github.com/deepseek-ai/DeepSeek-Math/tree/b8b0f8ce093d80bf8e9a641e44142f06d092c305/evaluation); target score from the DeepSeek LLM report (arXiv:2401.02954), Table 6.

## Test Plan

### Automated

- [x] Lint/format clean (`ruff check && ruff format --check`)
- [x] Type check clean (`ty check` or `mypy --strict`)
- [x] Unit tests pass (`pdm run pytest`) <!-- delete if benchmark-only PR -->

### Manual
  Model: DeepSeek-LLM-7B-Chat (sglang, bf16, greedy temperature=0, top_p=1.0, max_tokens=1024), full 1319-sample GSM8K test split, 0 failures.
  | Model | Expected | Actual | Diff |
  |---|---|---|---|
  | DeepSeek-LLM-7B-Chat | 63.0 (DeepSeek LLM report, Table 6) | 63.31 | +0.31 (+0.31%) |

## Checklist

### Required (all PRs)

- [x] PR title follows conventional format (`type(scope): description`)
- [x] No internal paths, credentials, or personal info in committed files
- [x] AI-generated code has `AI-Generated Code - <model> (<provider>)` in module docstring
- [x] No new upper-layer dependencies added to `core/`
- [x] Deleted code verified — no remaining call sites depend on it

### If: New or Modified Benchmark

- [x] Reference paper/repo linked in Summary
- [x] Score comparison table included (model, expected, actual, diff)
- [x] Dataset loading tested (`sieval dataset download <name>` succeeds)
- [x] Task registered in package-level `__init__.py`

### If: community/ Changes

- [x] Upstream diff documented (what differs and why)
- [x] License attribution preserved