### PR TITLE
feat(hendrycks_math): add full MATH dataset and DeepSeek-Math-aligned base-model task

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev", "drop", "ifbench", "ifeval", "math", "t-eval", "test"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:d2e318510436de5f2157f0c79e01dedbbaa05f5388f4fd0867ac7da504c31612"
+content_hash = "sha256:aadbe110ed98781ee5c51ae38bd40780304ed26da3c371a0fd3f5ff1fd1256ef"
 
 [[metadata.targets]]
 requires_python = ">=3.12,<3.15"
@@ -928,7 +928,7 @@ files = [
 
 [[package]]
 name = "latex2sympy2-extended"
-version = "1.11.0"
+version = "1.10.2"
 requires_python = ">=3.10"
 summary = "Convert LaTeX math to SymPy expressions"
 groups = ["math"]
@@ -937,24 +937,24 @@ dependencies = [
     "sympy",
 ]
 files = [
-    {file = "latex2sympy2_extended-1.11.0-py3-none-any.whl", hash = "sha256:aebb77d52ce269e25028e4bea89ddb14d242ba36bcf7b636496fb5fd9728d234"},
-    {file = "latex2sympy2_extended-1.11.0.tar.gz", hash = "sha256:9695657c81b50abba2636638638618db59f4663ed2a4a12d62cef74a40e28fec"},
+    {file = "latex2sympy2_extended-1.10.2-py3-none-any.whl", hash = "sha256:f910442c5b02a466c1046f47d05cc5285181068b882399281f30102715337fb7"},
+    {file = "latex2sympy2_extended-1.10.2.tar.gz", hash = "sha256:41a517ffcc5a140e910a7d1646ce6ff440817e5f9d48fc8279d88bd0925bc389"},
 ]
 
 [[package]]
 name = "latex2sympy2-extended"
-version = "1.11.0"
+version = "1.10.2"
 extras = ["antlr4_11_0"]
 requires_python = ">=3.10"
 summary = "Convert LaTeX math to SymPy expressions"
 groups = ["math"]
 dependencies = [
     "antlr4-python3-runtime==4.11.0",
-    "latex2sympy2-extended==1.11.0",
+    "latex2sympy2-extended==1.10.2",
 ]
 files = [
-    {file = "latex2sympy2_extended-1.11.0-py3-none-any.whl", hash = "sha256:aebb77d52ce269e25028e4bea89ddb14d242ba36bcf7b636496fb5fd9728d234"},
-    {file = "latex2sympy2_extended-1.11.0.tar.gz", hash = "sha256:9695657c81b50abba2636638638618db59f4663ed2a4a12d62cef74a40e28fec"},
+    {file = "latex2sympy2_extended-1.10.2-py3-none-any.whl", hash = "sha256:f910442c5b02a466c1046f47d05cc5285181068b882399281f30102715337fb7"},
+    {file = "latex2sympy2_extended-1.10.2.tar.gz", hash = "sha256:41a517ffcc5a140e910a7d1646ce6ff440817e5f9d48fc8279d88bd0925bc389"},
 ]
 
 [[package]]
@@ -1195,32 +1195,32 @@ files = [
 
 [[package]]
 name = "math-verify"
-version = "0.9.0"
+version = "0.8.0"
 requires_python = ">=3.10"
 summary = "HuggingFace library for verifying mathematical answers"
 groups = ["math"]
 dependencies = [
-    "latex2sympy2-extended==1.11.0",
+    "latex2sympy2-extended==1.10.2",
 ]
 files = [
-    {file = "math_verify-0.9.0-py3-none-any.whl", hash = "sha256:3703e7c4885354027fa84409d762a596a2906d1fd4deb78361876bd905a76194"},
-    {file = "math_verify-0.9.0.tar.gz", hash = "sha256:45ac6c61344ba056b9e99a660a4bc8d044ed408f730aed68c60435aa5eec4645"},
+    {file = "math_verify-0.8.0-py3-none-any.whl", hash = "sha256:31ca651296d817a9bb3fd58ca1fd0d192dcea709b1e5ecf2d0a4514c16f89087"},
+    {file = "math_verify-0.8.0.tar.gz", hash = "sha256:3295e0adb94bfe553ff6e3189c44f1916a85aa24ab5d1900f2086a706e28f7c4"},
 ]
 
 [[package]]
 name = "math-verify"
-version = "0.9.0"
+version = "0.8.0"
 extras = ["antlr4-11-0"]
 requires_python = ">=3.10"
 summary = "HuggingFace library for verifying mathematical answers"
 groups = ["math"]
 dependencies = [
     "latex2sympy2-extended[antlr4_11_0]",
-    "math-verify==0.9.0",
+    "math-verify==0.8.0",
 ]
 files = [
-    {file = "math_verify-0.9.0-py3-none-any.whl", hash = "sha256:3703e7c4885354027fa84409d762a596a2906d1fd4deb78361876bd905a76194"},
-    {file = "math_verify-0.9.0.tar.gz", hash = "sha256:45ac6c61344ba056b9e99a660a4bc8d044ed408f730aed68c60435aa5eec4645"},
+    {file = "math_verify-0.8.0-py3-none-any.whl", hash = "sha256:31ca651296d817a9bb3fd58ca1fd0d192dcea709b1e5ecf2d0a4514c16f89087"},
+    {file = "math_verify-0.8.0.tar.gz", hash = "sha256:3295e0adb94bfe553ff6e3189c44f1916a85aa24ab5d1900f2086a706e28f7c4"},
 ]
 
 [[package]]

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev", "drop", "ifbench", "ifeval", "math", "t-eval", "test"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:cd1913d87a36d8c8241734a702065412185ca7c3e9949bc22206e4455f272c86"
+content_hash = "sha256:d2e318510436de5f2157f0c79e01dedbbaa05f5388f4fd0867ac7da504c31612"
 
 [[metadata.targets]]
 requires_python = ">=3.12,<3.15"
@@ -162,15 +162,15 @@ files = [
 
 [[package]]
 name = "antlr4-python3-runtime"
-version = "4.13.2"
-summary = "ANTLR 4.13.2 runtime for Python 3"
+version = "4.11.0"
+summary = "ANTLR 4.11.0 runtime for Python 3"
 groups = ["math"]
 dependencies = [
     "typing; python_version < \"3.5\"",
 ]
 files = [
-    {file = "antlr4_python3_runtime-4.13.2-py3-none-any.whl", hash = "sha256:fe3835eb8d33daece0e799090eda89719dbccee7aa39ef94eed3818cafa5a7e8"},
-    {file = "antlr4_python3_runtime-4.13.2.tar.gz", hash = "sha256:909b647e1d2fc2b70180ac586df3933e38919c85f98ccc656a96cd3f25ef3916"},
+    {file = "antlr4-python3-runtime-4.11.0.tar.gz", hash = "sha256:6a46d4f6033c8d7e53c8975cee5d83b3ba1b48157f6beb09a4965062dacfe2e0"},
+    {file = "antlr4_python3_runtime-4.11.0-py3-none-any.whl", hash = "sha256:f523f91387283045f129c343b363a8dda3a07eea62721b8eda95f2d8b817b656"},
 ]
 
 [[package]]
@@ -928,7 +928,7 @@ files = [
 
 [[package]]
 name = "latex2sympy2-extended"
-version = "1.10.2"
+version = "1.11.0"
 requires_python = ">=3.10"
 summary = "Convert LaTeX math to SymPy expressions"
 groups = ["math"]
@@ -937,8 +937,24 @@ dependencies = [
     "sympy",
 ]
 files = [
-    {file = "latex2sympy2_extended-1.10.2-py3-none-any.whl", hash = "sha256:f910442c5b02a466c1046f47d05cc5285181068b882399281f30102715337fb7"},
-    {file = "latex2sympy2_extended-1.10.2.tar.gz", hash = "sha256:41a517ffcc5a140e910a7d1646ce6ff440817e5f9d48fc8279d88bd0925bc389"},
+    {file = "latex2sympy2_extended-1.11.0-py3-none-any.whl", hash = "sha256:aebb77d52ce269e25028e4bea89ddb14d242ba36bcf7b636496fb5fd9728d234"},
+    {file = "latex2sympy2_extended-1.11.0.tar.gz", hash = "sha256:9695657c81b50abba2636638638618db59f4663ed2a4a12d62cef74a40e28fec"},
+]
+
+[[package]]
+name = "latex2sympy2-extended"
+version = "1.11.0"
+extras = ["antlr4_11_0"]
+requires_python = ">=3.10"
+summary = "Convert LaTeX math to SymPy expressions"
+groups = ["math"]
+dependencies = [
+    "antlr4-python3-runtime==4.11.0",
+    "latex2sympy2-extended==1.11.0",
+]
+files = [
+    {file = "latex2sympy2_extended-1.11.0-py3-none-any.whl", hash = "sha256:aebb77d52ce269e25028e4bea89ddb14d242ba36bcf7b636496fb5fd9728d234"},
+    {file = "latex2sympy2_extended-1.11.0.tar.gz", hash = "sha256:9695657c81b50abba2636638638618db59f4663ed2a4a12d62cef74a40e28fec"},
 ]
 
 [[package]]
@@ -1179,16 +1195,32 @@ files = [
 
 [[package]]
 name = "math-verify"
-version = "0.8.0"
+version = "0.9.0"
 requires_python = ">=3.10"
 summary = "HuggingFace library for verifying mathematical answers"
 groups = ["math"]
 dependencies = [
-    "latex2sympy2-extended==1.10.2",
+    "latex2sympy2-extended==1.11.0",
 ]
 files = [
-    {file = "math_verify-0.8.0-py3-none-any.whl", hash = "sha256:31ca651296d817a9bb3fd58ca1fd0d192dcea709b1e5ecf2d0a4514c16f89087"},
-    {file = "math_verify-0.8.0.tar.gz", hash = "sha256:3295e0adb94bfe553ff6e3189c44f1916a85aa24ab5d1900f2086a706e28f7c4"},
+    {file = "math_verify-0.9.0-py3-none-any.whl", hash = "sha256:3703e7c4885354027fa84409d762a596a2906d1fd4deb78361876bd905a76194"},
+    {file = "math_verify-0.9.0.tar.gz", hash = "sha256:45ac6c61344ba056b9e99a660a4bc8d044ed408f730aed68c60435aa5eec4645"},
+]
+
+[[package]]
+name = "math-verify"
+version = "0.9.0"
+extras = ["antlr4-11-0"]
+requires_python = ">=3.10"
+summary = "HuggingFace library for verifying mathematical answers"
+groups = ["math"]
+dependencies = [
+    "latex2sympy2-extended[antlr4_11_0]",
+    "math-verify==0.9.0",
+]
+files = [
+    {file = "math_verify-0.9.0-py3-none-any.whl", hash = "sha256:3703e7c4885354027fa84409d762a596a2906d1fd4deb78361876bd905a76194"},
+    {file = "math_verify-0.9.0.tar.gz", hash = "sha256:45ac6c61344ba056b9e99a660a4bc8d044ed408f730aed68c60435aa5eec4645"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,9 @@ ifeval = [
 ]
 math = [
   "latex2sympy2-extended>=1.10.2",
-  "math-verify>=0.8.0",
+  # antlr4-11-0 extra pins antlr4-python3-runtime==4.11.0, which sympy 1.14's
+  # LaTeX grammar needs for DeepSeek symbolic_equal's parse_latex to work.
+  "math-verify[antlr4-11-0]>=0.8.0",
   "regex>=2024.0.0",
 ]
 t-eval = ["numpy<=2.2", "sentence-transformers>=5.1.2"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,9 @@ math = [
   "latex2sympy2-extended>=1.10.2",
   # antlr4-11-0 extra pins antlr4-python3-runtime==4.11.0, which sympy 1.14's
   # LaTeX grammar needs for DeepSeek symbolic_equal's parse_latex to work.
-  "math-verify[antlr4-11-0]>=0.8.0",
+  # Pinned ==0.8.0: a >= floor re-resolves to 0.9.0, which changes `%` parsing
+  # and shifts sibling scorers (math_500_0shot_gen, imo_answer_bench).
+  "math-verify[antlr4-11-0]==0.8.0",
   "regex>=2024.0.0",
 ]
 t-eval = ["numpy<=2.2", "sentence-transformers>=5.1.2"]

--- a/sieval/community/deepseek_math.py
+++ b/sieval/community/deepseek_math.py
@@ -27,17 +27,13 @@ Shared across the DeepSeek-Math GSM8K and MATH tasks:
   (`few_shot_prompts/cot_minerva_math_4_shot.py` + the `math-cot-test` path).
 
 Deviations from upstream:
-- `symbolic_equal` calls `sympy.parsing.latex.parse_latex`, whose ANTLR backend
-  requires the `antlr4-python3-runtime` build that sympy's LaTeX grammar was
-  generated against. The version resolved in this env (transitively, via
-  `math_verify`'s `latex2sympy2_extended`) does not match, so `parse_latex`
-  raises and DeepSeek's own `_parse` fallback (`parse_expr`, then the raw
-  string) takes over. `symbolic_equal` is the LAST layer of `math_equal`; the
-  string / numeric (with percentage) / tuple-interval / matrix / equation
-  layers above it are unaffected. (`math_equal` is called with the default
-  `timeout=False`, so the `symbolic_equal_process` / `call_with_timeout` path is
-  unused here, but both are kept so `math_equal` stays byte-faithful and
-  callable with `timeout=True`.)
+- `math_equal` is only ever called with the default `timeout=False` (via
+  `eval_math` / `is_correct` and the GSM8K path), so the
+  `symbolic_equal_process` / `call_with_timeout` multiprocessing path is unused
+  here; both are kept verbatim so `math_equal` stays byte-faithful and callable
+  with `timeout=True`. (`symbolic_equal`'s `parse_latex` works once
+  `antlr4-python3-runtime` is pinned to 4.11.0 in the `[math]` extra — sympy
+  1.14's LaTeX grammar requires that ANTLR runtime.)
 - The two debug `print` statements in `is_correct`'s list-branch ``'2,3,4'``
   guard are dropped (they fire during normal scoring — a library must not write
   to stdout). The lone `print(item)` before the final `NotImplementedError`

--- a/sieval/community/deepseek_math.py
+++ b/sieval/community/deepseek_math.py
@@ -16,12 +16,15 @@ answer-handling utilities from the pinned commit
 * `math_equal` / `is_correct` — string, then numeric (with percentage /
   interval / matrix / equation handling), then sympy symbolic equivalence.
 
-`sieval.tasks.gsm8k_0shot_gen` calls `extract_answer(exhaust=False)` (=
-DeepSeek's `extract_last_single_answer`) and `is_correct` (=
-`eval_last_single_answer`). DeepSeek's MATH multi-answer helpers
-(`extract_math_answer` / `eval_math`) and few-shot prompt are intentionally
-omitted; they can be vendored byte-faithfully alongside a future MATH task that
-needs them.
+Shared across the DeepSeek-Math GSM8K and MATH tasks:
+* `sieval.tasks.gsm8k_0shot_gen` calls `extract_answer(exhaust=False)` (=
+  DeepSeek's `extract_last_single_answer`) and `is_correct` (=
+  `eval_last_single_answer`).
+* `sieval.tasks.hendrycks_math_kshot_base_gen` calls the Minerva 4-shot prompt
+  (`few_shot_prompt` / `format_prompt` / `STOP_WORDS`), the multi-answer
+  extractors (`extract_math_answer` / `extract_math_few_shot_cot_answer`), and
+  `eval_math` — all vendored byte-faithfully from the same pinned commit
+  (`few_shot_prompts/cot_minerva_math_4_shot.py` + the `math-cot-test` path).
 
 Deviations from upstream:
 - `symbolic_equal` calls `sympy.parsing.latex.parse_latex`, whose ANTLR backend
@@ -491,3 +494,102 @@ def is_correct(item, pred_key='prediction', prec=1e-3):
     else:
         print(item, flush=True)
         raise NotImplementedError()
+
+
+# --- MATH (CoT) path: Minerva 4-shot prompt + multi-answer extraction/scoring ---
+# Vendored from the same pinned commit: few_shot_prompts/cot_minerva_math_4_shot.py
+# (MinervaMathPrompt) and the math-cot-test extract_math_answer / eval_math path.
+
+few_shot_prompt = """Problem:
+Find the domain of the expression $\\frac{\\sqrt{x-2}}{\\sqrt{5-x}}$.}
+
+Solution:
+The expressions inside each square root must be non-negative.
+Therefore, $x-2 \\ge 0$, so $x\\ge2$, and $5 - x \\ge 0$, so $x \\le 5$.
+Also, the denominator cannot be equal to zero, so $5-x>0$, which gives $x<5$.
+Therefore, the domain of the expression is $\\boxed{[2,5)}$.
+Final Answer: The final answer is $[2,5)$. I hope it is correct.
+
+Problem:
+If $\\det \\mathbf{A} = 2$ and $\\det \\mathbf{B} = 12,$ then find $\\det (\\mathbf{A} \\mathbf{B}).$
+
+Solution:
+We have that $\\det (\\mathbf{A} \\mathbf{B}) = (\\det \\mathbf{A})(\\det \\mathbf{B}) = (2)(12) = \\boxed{24}.$
+Final Answer: The final answer is $24$. I hope it is correct.
+
+Problem:
+Terrell usually lifts two 20-pound weights 12 times. If he uses two 15-pound weights instead, how many times must Terrell lift them in order to lift the same total weight?
+
+Solution:
+If Terrell lifts two 20-pound weights 12 times, he lifts a total of $2\\cdot 12\\cdot20=480$ pounds of weight.  If he lifts two 15-pound weights instead for $n$ times, he will lift a total of $2\\cdot15\\cdot n=30n$ pounds of weight.  Equating this to 480 pounds, we can solve for $n$: \\begin{align*}
+30n&=480\\\\
+\\Rightarrow\\qquad n&=480/30=\\boxed{16}
+\\end{align*}
+Final Answer: The final answer is $16$. I hope it is correct.
+
+Problem:
+If the system of equations
+
+\\begin{align*}
+6x-4y&=a,\\\\
+6y-9x &=b.
+\\end{align*}has a solution $(x, y)$ where $x$ and $y$ are both nonzero, find $\\frac{a}{b},$ assuming $b$ is nonzero.
+
+Solution:
+If we multiply the first equation by $-\\frac{3}{2}$, we obtain
+
+$$6y-9x=-\\frac{3}{2}a.$$Since we also know that $6y-9x=b$, we have
+
+$$-\\frac{3}{2}a=b\\Rightarrow\\frac{a}{b}=\\boxed{-\\frac{2}{3}}.$$
+Final Answer: The final answer is $-\\frac{2}{3}$. I hope it is correct."""
+
+
+STOP_WORDS = ["\nProblem:"]
+
+
+def format_prompt(task_input: str, task_output: str = "") -> str:
+    prompt = f"{few_shot_prompt}\n\nProblem:\n{task_input}\n\nSolution:\n{task_output}"
+    return prompt.rstrip()
+
+
+def extract_math_answer(question, reasoning, task):
+    answer = []
+    for ans in extract_answer(reasoning, exhaust=True):
+        if 'separated by commas' in question and all(ch not in ans for ch in '()[]'):
+            answer.extend([a.strip() for a in ans.split(",")])
+        elif regex.search(r"\\text\{\s*and\s*\}", ans):
+            answer.extend([a.strip() for a in regex.sub(r"\\text\{\s*and\s*\}", "[SEP]", ans).split("[SEP]")])
+        else:
+            answer.append(ans.strip())
+    return answer
+
+def extract_math_few_shot_cot_answer(question, reasoning, task):
+    if 'Problem:' in reasoning:
+        reasoning = reasoning.split("Problem:", 1)[0]
+    return extract_math_answer(question, reasoning, task)
+
+def eval_math(item, pred_key='prediction', prec=1e-3):
+    pred = item[pred_key]
+    if pred_key == 'program_output' and isinstance(pred, str):
+        pred = [pred]
+    ans = item['answer']
+    if isinstance(pred, list) and isinstance(ans, list):
+        # for some questions in MATH, `reference` repeats answers
+        _ans = []
+        for a in ans:
+            if a not in _ans:
+                _ans.append(a)
+        ans = _ans
+        # some predictions for MATH questions also repeats answers
+        _pred = []
+        for a in pred:
+            if a not in _pred:
+                _pred.append(a)
+        # some predictions mistakenly box non-answer strings
+        pred = _pred[-len(ans):]
+
+    item.update({
+        pred_key: pred,
+        'answer': ans
+    })
+    return is_correct(item, pred_key=pred_key, prec=prec)

--- a/sieval/community/deepseek_math.py
+++ b/sieval/community/deepseek_math.py
@@ -4,10 +4,10 @@
 """
 DeepSeek-Math answer extraction and answer equivalence.
 
-Faithful port — trimmed to exactly what the GSM8K 0-shot task consumes — of the
-answer-handling utilities from the pinned commit
-(`data_processing/answer_extraction.py`, `eval/eval_utils.py`,
-`eval/eval_script.py`):
+Faithful port of the DeepSeek-Math answer-handling utilities from the pinned
+commit (`data_processing/answer_extraction.py`, `eval/eval_utils.py`,
+`eval/eval_script.py`), serving both the GSM8K 0-shot task and the MATH few-shot
+task (per-consumer breakdown below):
 
 * `extract_answer` (with `extract_boxed_answers` / `extract_program_output` /
   `strip_string`) — pull the final answer out of a model's reasoning: last

--- a/sieval/datasets/__init__.pyi
+++ b/sieval/datasets/__init__.pyi
@@ -33,6 +33,10 @@ from .hellaswag import (
     HellaSwagDataset,
     HellaSwagDatasetSample,
 )
+from .hendrycks_math import (
+    HendrycksMathDataset,
+    HendrycksMathDatasetSample,
+)
 from .hmmt_feb_2025 import (
     HMMTFeb2025Dataset,
     HMMTFeb2025DatasetSample,
@@ -115,6 +119,8 @@ __all__ = [
     "HMMTFeb2026DatasetSample",
     "HellaSwagDataset",
     "HellaSwagDatasetSample",
+    "HendrycksMathDataset",
+    "HendrycksMathDatasetSample",
     "HumanEvalDataset",
     "HumanEvalDatasetSample",
     "IFBenchDataset",

--- a/sieval/datasets/hendrycks_math.py
+++ b/sieval/datasets/hendrycks_math.py
@@ -6,6 +6,10 @@ complete benchmark — 7,500 train + 5,000 test problems. The source schema has
 no ``answer`` column; the answer is the ``\\boxed{...}`` value inside
 ``solution`` (extract task-side, e.g. via ``sieval.community.deepseek_math``).
 
+Data-source note: DeepSeek-Math's ``math-cot-test`` loads its bundled
+``datasets/math/test.jsonl``; this loads ``EleutherAI/hendrycks_math`` instead —
+verified equivalent (5,000 test rows, same 7 subjects).
+
 AI-Generated Code - Claude Opus 4.8 (Anthropic)
 """
 

--- a/sieval/datasets/hendrycks_math.py
+++ b/sieval/datasets/hendrycks_math.py
@@ -1,0 +1,72 @@
+"""
+Full Hendrycks MATH dataset (all 7 subjects, train + test).
+
+Distinct from ``math_500`` (the 500-problem MATH-500 subset): this is the
+complete benchmark — 7,500 train + 5,000 test problems. The source schema has
+no ``answer`` column; the answer is the ``\\boxed{...}`` value inside
+``solution`` (extract task-side, e.g. via ``sieval.community.deepseek_math``).
+
+AI-Generated Code - Claude Opus 4.8 (Anthropic)
+"""
+
+from typing import TypedDict, override
+
+from datasets import DatasetDict as HFDatasetDict
+from datasets import concatenate_datasets, load_dataset
+
+from sieval.core.datasets import (
+    Category,
+    Dataset,
+    Level1Category,
+    sieval_dataset,
+)
+from sieval.core.utils.hf import ensure_dataset_dict
+
+HENDRYCKS_MATH_REVISION = "21a5633873b6a120296cce3e2df9d5550074f4a3"
+
+# HF config names (one per subject); concatenated in this fixed order so the
+# combined splits are reproducible.
+SUBJECTS = (
+    "algebra",
+    "counting_and_probability",
+    "geometry",
+    "intermediate_algebra",
+    "number_theory",
+    "prealgebra",
+    "precalculus",
+)
+
+
+class HendrycksMathDatasetSample(TypedDict):
+    problem: str
+    level: str
+    type: str
+    solution: str
+
+
+@sieval_dataset(
+    name="hendrycks_math",
+    display_name="Hendrycks MATH",
+    description="Full Hendrycks MATH — 12,500 competition problems across 7 subjects.",
+    source=f"hf:EleutherAI/hendrycks_math@{HENDRYCKS_MATH_REVISION}",
+    categories=(Category(Level1Category.MATHEMATICS, "AdvancedMath"),),
+    tags=("english", "open-ended"),
+    license="MIT",
+)
+class HendrycksMathDataset(Dataset[HendrycksMathDatasetSample]):
+    @override
+    def load(self, name_or_path: str, **kwargs) -> HFDatasetDict:
+        train_subsets = []
+        test_subsets = []
+        for subject in SUBJECTS:
+            subset = ensure_dataset_dict(
+                load_dataset(name_or_path, name=subject, **kwargs)
+            )
+            train_subsets.append(subset["train"])
+            test_subsets.append(subset["test"])
+        return HFDatasetDict(
+            {
+                "train": concatenate_datasets(train_subsets),
+                "test": concatenate_datasets(test_subsets),
+            }
+        )

--- a/sieval/meta/index.json
+++ b/sieval/meta/index.json
@@ -737,7 +737,7 @@
       "reference_impl": {
         "source": "DeepSeek-Math",
         "url": "https://github.com/deepseek-ai/DeepSeek-Math/tree/b8b0f8ce093d80bf8e9a641e44142f06d092c305/evaluation",
-        "notes": "math-cot-test path: MinervaMathPrompt 4-shot, extract_math_few_shot_cot_answer (list-valued) + eval_math/math_equal. symbolic_equal's parse_latex degraded via DeepSeek's own fallback (antlr4 conflict with math_verify); other math_equal layers intact."
+        "notes": "math-cot-test path: MinervaMathPrompt 4-shot, extract_math_few_shot_cot_answer (list-valued) + eval_math/math_equal."
       },
       "status": "stable"
     },

--- a/sieval/meta/index.json
+++ b/sieval/meta/index.json
@@ -185,6 +185,27 @@
       "checksums": {}
     },
     {
+      "name": "hendrycks_math",
+      "display_name": "Hendrycks MATH",
+      "description": "Full Hendrycks MATH — 12,500 competition problems across 7 subjects.",
+      "source": [
+        "hf:EleutherAI/hendrycks_math@21a5633873b6a120296cce3e2df9d5550074f4a3"
+      ],
+      "categories": [
+        {
+          "level1": "Mathematics",
+          "level2": "AdvancedMath"
+        }
+      ],
+      "tags": [
+        "english",
+        "open-ended"
+      ],
+      "deps_group": null,
+      "license": "MIT",
+      "checksums": {}
+    },
+    {
       "name": "hmmt_feb_2025",
       "display_name": "HMMT Feb 2025",
       "description": "Harvard-MIT Mathematics Tournament, February 2025, 30 problems.",
@@ -696,6 +717,27 @@
         "source": "lm-evaluation-harness",
         "url": "https://github.com/EleutherAI/lm-evaluation-harness/blob/1dd931087362abba74e0375c8c631295559f48b2/lm_eval/tasks/hellaswag/hellaswag.yaml",
         "notes": "multiple_choice log-likelihood; acc + acc_norm (character-length normalized, reported as score). Few-shot exemplars (k, default 10) sampled from train, rendered 'query gold_ending' and joined by blank lines per lm-eval; k=0 is 0-shot. Continuation log-probs read via echoed alogprobs; context/continuation split by char offset (no tokenizer at this layer). Infra requirement: echo scoring reads the prompt's input logprobs, so the serving backend's prefix caching must be disabled (cached positions are not recomputed -> truncated logprobs); the backend layer owns the specific flag."
+      },
+      "status": "stable"
+    },
+    {
+      "name": "hendrycks_math_kshot_base_gen",
+      "display_name": "Hendrycks MATH (few-shot, base generative)",
+      "description": "Full Hendrycks MATH DeepSeek-Math 4-shot CoT base-model eval.",
+      "dataset": "hendrycks_math",
+      "eval_mode": "gen",
+      "n_shot": 4,
+      "tags": [
+        "english",
+        "open-ended",
+        "base-model"
+      ],
+      "deps_group": "math",
+      "model_type": "gen",
+      "reference_impl": {
+        "source": "DeepSeek-Math",
+        "url": "https://github.com/deepseek-ai/DeepSeek-Math/tree/b8b0f8ce093d80bf8e9a641e44142f06d092c305/evaluation",
+        "notes": "math-cot-test path: MinervaMathPrompt 4-shot, extract_math_few_shot_cot_answer (list-valued) + eval_math/math_equal. symbolic_equal's parse_latex degraded via DeepSeek's own fallback (antlr4 conflict with math_verify); other math_equal layers intact."
       },
       "status": "stable"
     },

--- a/sieval/tasks/__init__.pyi
+++ b/sieval/tasks/__init__.pyi
@@ -28,6 +28,9 @@ from .gsm8k_kshot_base_gen import (
 from .hellaswag_kshot_ppl import (
     HellaSwagFewShotPPLTask,
 )
+from .hendrycks_math_kshot_base_gen import (
+    HendrycksMathFewShotBaseGenTask,
+)
 from .hmmt_feb_2025_0shot_gen import (
     HMMTFeb2025ZeroShotGenTask,
 )
@@ -95,6 +98,7 @@ __all__ = [
     "HMMTFeb2025ZeroShotGenTask",
     "HMMTFeb2026ZeroShotGenTask",
     "HellaSwagFewShotPPLTask",
+    "HendrycksMathFewShotBaseGenTask",
     "HumanEvalZeroShotBaseGenTask",
     "HumanEvalZeroShotGenTask",
     "IFBenchZeroShotGenTask",

--- a/sieval/tasks/hendrycks_math_kshot_base_gen.py
+++ b/sieval/tasks/hendrycks_math_kshot_base_gen.py
@@ -15,11 +15,11 @@ The shot count is fixed at 4 (the exemplars are a single baked-in prompt string
 upstream; there is no per-shot knob), and the reference answer is extracted from
 the ``solution`` column the same way DeepSeek's ``process_math_test`` does.
 
-Deviation: ``math_equal``'s ``symbolic_equal`` calls ``parse_latex`` (needs
-``antlr4-python3-runtime==4.11``, conflicting with the ``4.9.x`` pinned by
-``math_verify``); DeepSeek's own ``parse_expr``/string fallback then applies.
-``symbolic_equal`` is ``math_equal``'s last layer — string/numeric/tuple/matrix
-layers are intact. See the community module docstring.
+Deviation from upstream ``process_math_test``: reference extraction is not
+wrapped in a ``try/except`` that drops the sample — a failed boxed extraction
+counts as a wrong answer, not a dropped one. Immaterial in practice (all 5,000
+test rows carry a ``\\boxed`` answer). Extraction/equivalence deviations
+(dropped debug prints, unused ``timeout`` path) are in the community docstring.
 
 Repro decoding (greedy, matching DeepSeek's ``run_cot_eval.py``): temperature=0,
 top_p=1, max_gen_toks=1024.
@@ -68,9 +68,7 @@ class Feedback(TypedDict):
         url="https://github.com/deepseek-ai/DeepSeek-Math/tree/b8b0f8ce093d80bf8e9a641e44142f06d092c305/evaluation",
         notes=(
             "math-cot-test path: MinervaMathPrompt 4-shot, "
-            "extract_math_few_shot_cot_answer (list-valued) + eval_math/math_equal. "
-            "symbolic_equal's parse_latex degraded via DeepSeek's own fallback "
-            "(antlr4 conflict with math_verify); other math_equal layers intact."
+            "extract_math_few_shot_cot_answer (list-valued) + eval_math/math_equal."
         ),
     ),
 )
@@ -129,11 +127,11 @@ class HendrycksMathFewShotBaseGenTask(
         # a pipeline failure counts as wrong, not as an excluded sample.
         total = len(finals) + len(fails)
         if total == 0:
-            return {"score": 0.0, "fails": len(fails), "exact_match": 0.0}
+            return {"score": 0.0, "fails": len(fails), "accuracy": 0.0}
         correct_num = sum(1 for ctx in finals if ctx.feedback_result["correct"])
-        exact_match = 100 * correct_num / total
+        accuracy = 100 * correct_num / total
         return {
-            "score": exact_match,
+            "score": accuracy,
             "fails": len(fails),
-            "exact_match": exact_match,
+            "accuracy": accuracy,
         }

--- a/sieval/tasks/hendrycks_math_kshot_base_gen.py
+++ b/sieval/tasks/hendrycks_math_kshot_base_gen.py
@@ -1,0 +1,139 @@
+"""
+Hendrycks MATH few-shot base-model task, aligned with DeepSeek-Math evaluation.
+
+Strict port of DeepSeek-Math's ``math-cot-test`` path (pinned commit
+``b8b0f8ce``): the Minerva 4-shot CoT prompt (``MinervaMathPrompt``,
+``Problem:\\n...\\n\\nSolution:\\n``, stop ``["\\nProblem:"]``); DeepSeek's own
+answer extraction (``extract_math_few_shot_cot_answer`` ->
+``extract_math_answer`` -> ``extract_answer`` + DeepSeek ``strip_string``); and
+``eval_math`` -> ``is_correct`` -> ``math_equal``. Extraction returns a LIST of
+answers (multi-answer questions) and ``eval_math`` set-matches the predicted and
+reference answer lists. All of this lives verbatim in
+``sieval.community.deepseek_math``.
+
+The shot count is fixed at 4 (the exemplars are a single baked-in prompt string
+upstream; there is no per-shot knob), and the reference answer is extracted from
+the ``solution`` column the same way DeepSeek's ``process_math_test`` does.
+
+Deviation: ``math_equal``'s ``symbolic_equal`` calls ``parse_latex`` (needs
+``antlr4-python3-runtime==4.11``, conflicting with the ``4.9.x`` pinned by
+``math_verify``); DeepSeek's own ``parse_expr``/string fallback then applies.
+``symbolic_equal`` is ``math_equal``'s last layer — string/numeric/tuple/matrix
+layers are intact. See the community module docstring.
+
+Repro decoding (greedy, matching DeepSeek's ``run_cot_eval.py``): temperature=0,
+top_p=1, max_gen_toks=1024.
+
+AI-Generated Code - Claude Opus 4.8 (Anthropic)
+"""
+
+from typing import TypedDict, override
+
+from sieval.community.deepseek_math import (
+    STOP_WORDS,
+    eval_math,
+    extract_math_answer,
+    extract_math_few_shot_cot_answer,
+    format_prompt,
+)
+from sieval.core.models import ModelOutput
+from sieval.core.tasks import (
+    EvalMode,
+    ReferenceImpl,
+    Task,
+    sieval_task,
+)
+from sieval.datasets import HendrycksMathDatasetSample
+
+N_SHOT = 4
+
+
+class Feedback(TypedDict):
+    correct: bool
+    answer: list[str]
+    prediction: list[str]
+
+
+@sieval_task(
+    name="hendrycks_math_kshot_base_gen",
+    display_name="Hendrycks MATH (few-shot, base generative)",
+    description="Full Hendrycks MATH DeepSeek-Math 4-shot CoT base-model eval.",
+    eval_mode=EvalMode.GEN,
+    n_shot=N_SHOT,
+    tags=("english", "open-ended", "base-model"),
+    deps_group="math",
+    model_type="gen",
+    reference_impl=ReferenceImpl(
+        source="DeepSeek-Math",
+        url="https://github.com/deepseek-ai/DeepSeek-Math/tree/b8b0f8ce093d80bf8e9a641e44142f06d092c305/evaluation",
+        notes=(
+            "math-cot-test path: MinervaMathPrompt 4-shot, "
+            "extract_math_few_shot_cot_answer (list-valued) + eval_math/math_equal. "
+            "symbolic_equal's parse_latex degraded via DeepSeek's own fallback "
+            "(antlr4 conflict with math_verify); other math_equal layers intact."
+        ),
+    ),
+)
+class HendrycksMathFewShotBaseGenTask(
+    Task[
+        HendrycksMathDatasetSample,
+        str,
+        ModelOutput,
+        list[str],
+        Feedback,
+        dict[str, float],
+    ]
+):
+    def __init__(
+        self,
+        dataset,
+        model,
+        name: str | None = None,
+        *,
+        stop: tuple[str, ...] = tuple(STOP_WORDS),
+    ):
+        super().__init__(dataset=dataset, model=model, name=name)
+        self._stop = stop
+
+    @override
+    async def preprocess(self, raw, ctx):
+        return format_prompt(raw["problem"], "")
+
+    @override
+    async def infer(self, pre, ctx):
+        if self._stop:
+            return await self.model.agenerate(pre, stop=list(self._stop))
+        return await self.model.agenerate(pre)
+
+    @override
+    async def postprocess(self, inf, ctx):
+        text = inf.texts[0] if inf.texts else ""
+        return extract_math_few_shot_cot_answer(ctx.raw_sample["problem"], text, "cot")
+
+    @override
+    async def feedback(self, post, ctx):
+        reference = extract_math_answer(
+            ctx.raw_sample["problem"], ctx.raw_sample["solution"], "cot"
+        )
+        correct = bool(eval_math({"prediction": post, "answer": reference}))
+        return True, {
+            "correct": correct,
+            "answer": reference,
+            "prediction": post,
+        }
+
+    @override
+    async def report(self, finals, fails):
+        # Accuracy over the full requested set (finals + fails), matching the
+        # gsm8k-0shot-gen DeepSeek-Math sibling and DeepSeek's full-set accuracy:
+        # a pipeline failure counts as wrong, not as an excluded sample.
+        total = len(finals) + len(fails)
+        if total == 0:
+            return {"score": 0.0, "fails": len(fails), "exact_match": 0.0}
+        correct_num = sum(1 for ctx in finals if ctx.feedback_result["correct"])
+        exact_match = 100 * correct_num / total
+        return {
+            "score": exact_match,
+            "fails": len(fails),
+            "exact_match": exact_match,
+        }

--- a/tests/unit/community/test_deepseek_math.py
+++ b/tests/unit/community/test_deepseek_math.py
@@ -1,0 +1,55 @@
+"""Unit tests for the DeepSeek-Math eval adaptation.
+
+AI-Generated Code - Claude Opus 4.8 (Anthropic)
+"""
+
+from sieval.community.deepseek_math import (
+    STOP_WORDS,
+    eval_math,
+    extract_math_answer,
+    extract_math_few_shot_cot_answer,
+    format_prompt,
+)
+
+_FA = "\nFinal Answer: The final answer is ${}$. I hope it is correct."
+
+
+def test_stop_words_have_leading_newline():
+    assert STOP_WORDS == ["\nProblem:"]
+
+
+def test_format_prompt_minerva_layout():
+    p = format_prompt("Find $x$.", "")
+    assert p.count("Problem:\n") == 5  # 4 baked exemplars + query
+    assert p.endswith("Problem:\nFind $x$.\n\nSolution:")  # rstrip drops trailing nl
+
+
+def test_extract_prefers_final_answer_line():
+    assert extract_math_few_shot_cot_answer("q", f"work{_FA.format('24')}", "cot") == [
+        "24"
+    ]
+
+
+def test_extract_truncates_hallucinated_next_problem():
+    text = f"work{_FA.format('24')}\n\nProblem:\nnext\n\nSolution: $99$"
+    assert extract_math_few_shot_cot_answer("q", text, "cot") == ["24"]
+
+
+def test_extract_falls_back_to_boxed():
+    # no "Final Answer" line -> boxed extraction
+    assert extract_math_few_shot_cot_answer("q", "so $\\boxed{7}$", "cot") == ["7"]
+
+
+def test_reference_answer_is_list_from_boxed_solution():
+    assert extract_math_answer("q", "thus $\\boxed{[2,5)}$.", "cot") == ["[2,5)"]
+
+
+def test_eval_math_set_matches_lists():
+    # order-insensitive multiset matching of pred vs ref lists
+    assert bool(eval_math({"prediction": ["3", "1", "2"], "answer": ["1", "2", "3"]}))
+    assert not bool(eval_math({"prediction": ["1", "2"], "answer": ["1", "2", "3"]}))
+
+
+def test_eval_math_percentage_numeric_layer():
+    # math_equal numeric layer: 50\% == 0.5 (no parse_latex needed)
+    assert bool(eval_math({"prediction": ["50\\%"], "answer": ["0.5"]}))

--- a/tests/unit/tasks/test_hendrycks_math_kshot_base_gen.py
+++ b/tests/unit/tasks/test_hendrycks_math_kshot_base_gen.py
@@ -1,0 +1,173 @@
+"""Unit tests for the Hendrycks MATH (DeepSeek-Math) few-shot base task.
+
+AI-Generated Code - Claude Opus 4.8 (Anthropic)
+"""
+
+import pytest
+from datasets import Dataset as HFDataset
+from datasets import DatasetDict as HFDatasetDict
+
+from sieval.core.models import ModelOutput
+from sieval.core.models.gen_model import GenModel
+from sieval.core.tasks import TaskContext
+from sieval.datasets.hendrycks_math import (
+    HendrycksMathDataset,
+    HendrycksMathDatasetSample,
+)
+from sieval.tasks.hendrycks_math_kshot_base_gen import (
+    N_SHOT,
+    HendrycksMathFewShotBaseGenTask,
+)
+
+_FA = "\nFinal Answer: The final answer is ${}$. I hope it is correct."
+
+
+class _CapturingGenModel(GenModel):
+    def __init__(self):
+        super().__init__(model="mock-gen", api_key="fake")
+        self.last_kwargs: dict[str, object] = {}
+
+    async def _agenerate_impl(self, prompt: str, **kwargs) -> ModelOutput:
+        _ = prompt
+        self.last_kwargs = dict(kwargs)
+        return ModelOutput(
+            model=self.meta(), texts=[f"$\\boxed{{16}}${_FA.format('16')}"]
+        )
+
+    async def _alogprobs_impl(
+        self,
+        prompt: str,
+        *,
+        max_tokens: int = 1,
+        logprobs: int = 5,
+        echo: bool = True,
+        temperature: float = 0.0,
+        **kwargs,
+    ) -> ModelOutput:
+        _ = (prompt, max_tokens, logprobs, echo, temperature, kwargs)
+        return ModelOutput(model=self.meta(), texts=[""])
+
+
+def _sample(
+    problem: str = "What is 8 + 8?",
+    solution: str = "We get $\\boxed{16}$.",
+) -> HendrycksMathDatasetSample:
+    return {
+        "problem": problem,
+        "level": "Level 1",
+        "type": "Algebra",
+        "solution": solution,
+    }
+
+
+def _task() -> tuple[HendrycksMathFewShotBaseGenTask, _CapturingGenModel]:
+    dataset = HendrycksMathDataset(
+        _hf_dict=HFDatasetDict(
+            {
+                "train": HFDataset.from_list([dict(_sample())]),
+                "test": HFDataset.from_list([dict(_sample())]),
+            }
+        )
+    )
+    model = _CapturingGenModel()
+    return HendrycksMathFewShotBaseGenTask(dataset, model), model
+
+
+def test_default_shot_count():
+    assert N_SHOT == 4
+
+
+@pytest.mark.anyio
+async def test_preprocess_is_deepseek_minerva_prompt():
+    task, _ = _task()
+    raw = _sample(problem="Find $x$.")
+    pre = await task.preprocess(raw, TaskContext(sample_id=0, raw_sample=raw))
+    # 4 baked exemplars + the query block.
+    assert pre.count("Problem:\n") == 5
+    # DeepSeek formatting: "Solution:\n" and rstrip => ends exactly at "Solution:".
+    assert pre.endswith("Problem:\nFind $x$.\n\nSolution:")
+    assert "Final Answer: The final answer is" in pre
+
+
+@pytest.mark.anyio
+async def test_infer_forwards_deepseek_stop_only():
+    task, model = _task()
+    await task.infer("prompt", TaskContext(sample_id=0, raw_sample=_sample()))
+    assert model.last_kwargs == {"stop": ["\nProblem:"]}
+    assert "temperature" not in model.last_kwargs
+    assert "max_tokens" not in model.last_kwargs
+
+
+@pytest.mark.anyio
+async def test_postprocess_returns_list_via_final_answer():
+    task, _ = _task()
+    inf = ModelOutput(model=task.model.meta(), texts=[f"reasoning{_FA.format('16')}"])
+    post = await task.postprocess(inf, TaskContext(sample_id=0, raw_sample=_sample()))
+    assert post == ["16"]
+
+
+@pytest.mark.anyio
+async def test_postprocess_stops_at_next_problem_block():
+    # extract_math_few_shot_cot_answer drops a hallucinated next "Problem:".
+    task, _ = _task()
+    text = f"reasoning{_FA.format('16')}\n\nProblem:\nNext q\n\nSolution: $99$"
+    inf = ModelOutput(model=task.model.meta(), texts=[text])
+    post = await task.postprocess(inf, TaskContext(sample_id=0, raw_sample=_sample()))
+    assert post == ["16"]
+
+
+@pytest.mark.anyio
+async def test_feedback_scores_against_solution_via_eval_math():
+    task, _ = _task()
+    raw = _sample(solution="Therefore $\\boxed{16}$.")
+    finalize, correct_fb = await task.feedback(
+        ["16"], TaskContext(sample_id=0, raw_sample=raw)
+    )
+    _, wrong_fb = await task.feedback(["17"], TaskContext(sample_id=1, raw_sample=raw))
+
+    assert finalize is True
+    assert correct_fb["correct"] is True
+    assert correct_fb["answer"] == ["16"]
+    assert correct_fb["prediction"] == ["16"]
+    assert wrong_fb["correct"] is False
+
+
+@pytest.mark.anyio
+async def test_feedback_percentage_equivalence():
+    # math_equal's numeric layer treats 50\% as 0.5 (include_percentage),
+    # independent of the (env-degraded) parse_latex symbolic layer.
+    task, _ = _task()
+    raw = _sample(solution="So $\\boxed{0.5}$.")
+    _, fb = await task.feedback(["50\\%"], TaskContext(sample_id=0, raw_sample=raw))
+    assert fb["correct"] is True
+
+
+@pytest.mark.anyio
+async def test_report_counts_fails_as_wrong():
+    # Denominator is finals + fails (DeepSeek full-set accuracy): a pipeline
+    # failure counts as wrong. With 1 correct + 1 wrong final and 1 fail, the
+    # score is 1/3 = 33.3 — NOT 50.0 (which excluding fails would give).
+    task, _ = _task()
+    raw = _sample()
+    correct = TaskContext(
+        sample_id=0,
+        raw_sample=raw,
+        feedback_result={"correct": True, "answer": ["16"], "prediction": ["16"]},
+    )
+    wrong = TaskContext(
+        sample_id=1,
+        raw_sample=raw,
+        feedback_result={"correct": False, "answer": ["16"], "prediction": ["17"]},
+    )
+    failed = TaskContext(sample_id=2, raw_sample=raw)  # pipeline failure, no feedback
+    report = await task.report([correct, wrong], [failed])
+    assert report["fails"] == 1
+    assert report["score"] == pytest.approx(100 / 3)
+    assert report["exact_match"] == pytest.approx(100 / 3)
+
+
+@pytest.mark.anyio
+async def test_report_empty_is_zero():
+    task, _ = _task()
+    report = await task.report([], [])
+    assert report == {"score": 0.0, "fails": 0, "exact_match": 0.0}

--- a/tests/unit/tasks/test_hendrycks_math_kshot_base_gen.py
+++ b/tests/unit/tasks/test_hendrycks_math_kshot_base_gen.py
@@ -163,11 +163,11 @@ async def test_report_counts_fails_as_wrong():
     report = await task.report([correct, wrong], [failed])
     assert report["fails"] == 1
     assert report["score"] == pytest.approx(100 / 3)
-    assert report["exact_match"] == pytest.approx(100 / 3)
+    assert report["accuracy"] == pytest.approx(100 / 3)
 
 
 @pytest.mark.anyio
 async def test_report_empty_is_zero():
     task, _ = _task()
     report = await task.report([], [])
-    assert report == {"score": 0.0, "fails": 0, "exact_match": 0.0}
+    assert report == {"score": 0.0, "fails": 0, "accuracy": 0.0}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Type

- feature — new benchmark, task, or capability
 
## Summary

- Add `hendrycks_math_kshot_base_gen` (`HendrycksMathFewShotBaseGenTask`): full Hendrycks MATH (5,000-test) base-model task — a strict port of DeepSeek-Math's `math-cot-test` (Minerva 4-shot CoT prompt + DeepSeek's list-valued extraction + `eval_math`/`math_equal`). Ref: https://github.com/deepseek-ai/DeepSeek-Math/tree/b8b0f8ce093d80bf8e9a641e44142f06d092c305/evaluation
- Add `hendrycks_math` dataset (EleutherAI/hendrycks_math, revision-pinned).
- Extend the existing `sieval/community/deepseek_math.py` (landed in #29) with the MATH-specific helpers (`few_shot_prompt`/`format_prompt`/`STOP_WORDS`, `extract_math_answer`, `extract_math_few_shot_cot_answer`, `eval_math`) — vendored verbatim from the same pinned commit; verified 0/5000 mismatch vs upstream modules.

## Test Plan

### Automated

- [x] Lint/format clean (`ruff check && ruff format --check`)
- [x] Type check clean (`ty check` or `mypy --strict`)
- [x] Unit tests pass (`pdm run pytest`) <!-- delete if benchmark-only PR -->

### Manual

- [x] Qwen2.5-72B-Base, full Hendrycks MATH (5,000 test), greedy, deterministic seed=0, `max_gen_toks=1024`, `tp_size=2`:

  | Model | Expected| Actual | Diff |
  | --- | --- | --- | --- |
  | Qwen2.5-72B-Base | 54.4 (DeepSeek-V3 report) | 61.74 | +7.34(+7.34%) |

61.74 is the stored 1024/tp2 generations re-scored under the fixed `parse_latex` (antlr 4.11.0) — the generations are unchanged, only the scorer's last layer. The run's stored `report.json` shows 60.60 because it was scored before the antlr fix; a fresh run with the merged deps reproduces 61.74. The result is above the report's 54.4; most likely a harness difference (the report's number is DeepSeek-V3's internal eval, not the open-source `math-cot-test` this ports — verified byte-identical, 0/5000 mismatch).

Reproducibility: `deterministic: true` pins the seed but not batch-invariant kernels, so `tp_size` shifts the score ~1pp under identical decoding — fix `tp_size` when reproducing.


## Checklist

### Required (all PRs)

- [x] PR title follows conventional format (`type(scope): description`)
- [x] No internal paths, credentials, or personal info in committed files
- [x] AI-generated code has `AI-Generated Code - <model> (<provider>)` in module docstring
- [x] No new upper-layer dependencies added to `core/`
- [x] Deleted code verified — no remaining call sites depend on it

### If: New or Modified Benchmark

- [x] Reference paper/repo linked in Summary
- [x] Score comparison table included (model, expected, actual, diff)
- [x] Dataset loading tested (`sieval dataset download <name>` succeeds)
- [x] Task registered in package-level `__init__.py`

### If: community/ Changes

- [x] Upstream diff documented (what differs and why)
- [x] License attribution preserved