### PR TITLE
feat(mmlu): add few-shot base-model clp task

### DIFF
--- a/sieval/core/tasks/anomaly.py
+++ b/sieval/core/tasks/anomaly.py
@@ -414,10 +414,10 @@ def detect_empty_infer_gen(ctx: TaskContext) -> set[int]:
 
 
 @sieval_detection_rule(
-    description="Inference result is empty for perplexity tasks (logprobs=[])",
+    description="Inference result is empty for logprob tasks (logprobs=[])",
     category="output_quality",
     rationale=("Empty logprobs indicate API failures or unsupported model features."),
-    applies_to=["ppl"],
+    applies_to=["ppl", "clp"],
     tags=["perplexity", "api_failure", "empty_output"],
 )
 def detect_empty_infer_ppl(ctx: TaskContext) -> set[int]:
@@ -426,14 +426,21 @@ def detect_empty_infer_ppl(ctx: TaskContext) -> set[int]:
     result = _unwrap_result(ctx.infer_result)
     if not isinstance(result, ModelOutput):
         return set()
-    # For PPL tasks, we need both logprobs and logprobs_tokens
+    # ppl reads logprobs/logprobs_tokens; clp reads top_logprobs. Flag whichever
+    # field the task populated when it comes back empty.
     has_logprobs = result.logprobs is not None
     has_logprobs_tokens = result.logprobs_tokens is not None
-    if has_logprobs or has_logprobs_tokens:
+    has_top_logprobs = result.top_logprobs is not None
+    if has_logprobs or has_logprobs_tokens or has_top_logprobs:
         logprobs_empty = has_logprobs and not result.logprobs
         logprobs_tokens_empty = has_logprobs_tokens and not result.logprobs_tokens
-        # Report index 0 as sentinel if any field is empty
-        return {0} if (logprobs_empty or logprobs_tokens_empty) else set()
+        top_logprobs_empty = has_top_logprobs and not result.top_logprobs
+        # Report index 0 as sentinel if any populated field is empty
+        return (
+            {0}
+            if (logprobs_empty or logprobs_tokens_empty or top_logprobs_empty)
+            else set()
+        )
     return set()
 
 

--- a/sieval/core/tasks/anomaly.py
+++ b/sieval/core/tasks/anomaly.py
@@ -414,10 +414,10 @@ def detect_empty_infer_gen(ctx: TaskContext) -> set[int]:
 
 
 @sieval_detection_rule(
-    description="Inference result is empty for logprob tasks (logprobs=[])",
+    description="Inference result is empty for perplexity tasks (logprobs=[])",
     category="output_quality",
     rationale=("Empty logprobs indicate API failures or unsupported model features."),
-    applies_to=["ppl", "clp"],
+    applies_to=["ppl"],
     tags=["perplexity", "api_failure", "empty_output"],
 )
 def detect_empty_infer_ppl(ctx: TaskContext) -> set[int]:
@@ -426,21 +426,14 @@ def detect_empty_infer_ppl(ctx: TaskContext) -> set[int]:
     result = _unwrap_result(ctx.infer_result)
     if not isinstance(result, ModelOutput):
         return set()
-    # ppl reads logprobs/logprobs_tokens; clp reads top_logprobs. Flag whichever
-    # field the task populated when it comes back empty.
+    # For PPL tasks, we need both logprobs and logprobs_tokens
     has_logprobs = result.logprobs is not None
     has_logprobs_tokens = result.logprobs_tokens is not None
-    has_top_logprobs = result.top_logprobs is not None
-    if has_logprobs or has_logprobs_tokens or has_top_logprobs:
+    if has_logprobs or has_logprobs_tokens:
         logprobs_empty = has_logprobs and not result.logprobs
         logprobs_tokens_empty = has_logprobs_tokens and not result.logprobs_tokens
-        top_logprobs_empty = has_top_logprobs and not result.top_logprobs
-        # Report index 0 as sentinel if any populated field is empty
-        return (
-            {0}
-            if (logprobs_empty or logprobs_tokens_empty or top_logprobs_empty)
-            else set()
-        )
+        # Report index 0 as sentinel if any field is empty
+        return {0} if (logprobs_empty or logprobs_tokens_empty) else set()
     return set()
 
 
@@ -449,9 +442,12 @@ def detect_empty_infer_ppl(ctx: TaskContext) -> set[int]:
     category="output_quality",
     rationale=(
         "Truncated outputs may indicate insufficient max_tokens setting "
-        "or unexpectedly long responses."
+        "or unexpectedly long responses. Scoped to gen: single-token logprob "
+        "tasks (ppl/clp) infer with max_tokens=1 and always finish with "
+        "'length', so the signal is only meaningful for generation."
     ),
     severity="info",
+    applies_to=["gen"],
     tags=["truncation", "length_limit", "incomplete_output"],
 )
 def detect_truncated_output(ctx: TaskContext) -> set[int]:

--- a/sieval/datasets/mmlu.py
+++ b/sieval/datasets/mmlu.py
@@ -1,4 +1,15 @@
-import os
+"""
+MMLU dataset loader — mirrors the official cais/mmlu HF dataset as-is.
+
+The native schema (``question`` / ``subject`` / ``choices`` / ``answer`` as a
+0-3 ClassLabel over A-D) is preserved without coercion; per-task formatting
+lives in the task layer. The ``all`` config exposes ``test`` (14042),
+``validation``, ``dev`` (57 subjects x 5, the official few-shot source), and
+``auxiliary_train`` splits.
+
+AI-Generated Code - Claude Opus 4.8 (Anthropic)
+"""
+
 from typing import TypedDict, override
 
 from datasets import DatasetDict as HFDatasetDict
@@ -12,72 +23,21 @@ from sieval.core.datasets import (
 )
 from sieval.core.utils.hf import apply_eval_split, ensure_dataset_dict
 
+MMLU_REVISION = "c30699e8356da336a370243923dbaf21066bb9fe"
+
 
 class MMLUDatasetSample(TypedDict):
-    Question: str
-    A: str
-    B: str
-    C: str
-    D: str
-    Answer: str
-    Subject: str
-
-
-def _normalize_answer(answer, choices: list[str]) -> str:
-    if answer is None:
-        return ""
-    if isinstance(answer, int):
-        if 0 <= answer < len(choices):
-            return chr(65 + answer)
-        return ""
-    text = str(answer).strip()
-    if text.upper() in {"A", "B", "C", "D"}:
-        return text.upper()
-    if text in choices:
-        return chr(65 + choices.index(text))
-    if text.isdigit():
-        idx = int(text)
-        if 0 <= idx < len(choices):
-            return chr(65 + idx)
-    return ""
-
-
-def _process_sample(sample: dict) -> MMLUDatasetSample:
-    question = sample.get("question", sample.get("Question", ""))
-    subject = sample.get("subject", sample.get("Subject", ""))
-    choices = sample.get("choices")
-    if choices is None:
-        choices = [
-            sample.get("A", ""),
-            sample.get("B", ""),
-            sample.get("C", ""),
-            sample.get("D", ""),
-        ]
-    if not isinstance(choices, list):
-        choices = list(choices)
-    choices = [str(c) for c in choices]
-    while len(choices) < 4:
-        choices.append("")
-    answer = sample.get("answer", sample.get("Answer"))
-    return {
-        "Question": str(question),
-        "A": choices[0],
-        "B": choices[1],
-        "C": choices[2],
-        "D": choices[3],
-        "Answer": _normalize_answer(answer, choices),
-        "Subject": str(subject),
-    }
+    question: str
+    subject: str
+    choices: list[str]
+    answer: int
 
 
 @sieval_dataset(
     name="mmlu",
     display_name="MMLU",
     description="Massive Multitask Language Understanding — 57 academic subjects, MCQ.",
-    source="url:https://openaipublic.blob.core.windows.net/simple-evals/mmlu.csv",
-    checksums={
-        "mmlu.csv": "sha256:15b6785d49e0012602e089558a7a0dfb916baf97e9295aa25b48062f13c6afbb",  # noqa: E501
-    },
+    source=f"hf:cais/mmlu@{MMLU_REVISION}",
     categories=(Category(Level1Category.KNOWLEDGE, "Multi-domain"),),
     tags=("english", "multiple-choice"),
     license="MIT",
@@ -91,13 +51,6 @@ class MMLUDataset(Dataset[MMLUDatasetSample]):
         eval_split: str | None = None,
         **kwargs,
     ) -> HFDatasetDict:
-        if name_or_path.endswith(".csv") or os.path.isdir(name_or_path):
-            csv_path = name_or_path
-            if os.path.isdir(name_or_path):
-                csv_path = os.path.join(name_or_path, "mmlu.csv")
-            dataset = load_dataset("csv", data_files={"test": csv_path}, **kwargs)
-        else:
-            dataset = load_dataset(name_or_path, config, **kwargs)
+        dataset = load_dataset(name_or_path, config, **kwargs)
         dataset = ensure_dataset_dict(dataset)
-        dataset = apply_eval_split(dataset, eval_split)
-        return dataset.map(_process_sample)
+        return apply_eval_split(dataset, eval_split)

--- a/sieval/meta/index.json
+++ b/sieval/meta/index.json
@@ -383,7 +383,7 @@
       "display_name": "MMLU",
       "description": "Massive Multitask Language Understanding — 57 academic subjects, MCQ.",
       "source": [
-        "url:https://openaipublic.blob.core.windows.net/simple-evals/mmlu.csv"
+        "hf:cais/mmlu@c30699e8356da336a370243923dbaf21066bb9fe"
       ],
       "categories": [
         {
@@ -397,9 +397,7 @@
       ],
       "deps_group": null,
       "license": "MIT",
-      "checksums": {
-        "mmlu.csv": "sha256:15b6785d49e0012602e089558a7a0dfb916baf97e9295aa25b48062f13c6afbb"
-      }
+      "checksums": {}
     },
     {
       "name": "mmlu_pro",
@@ -946,6 +944,27 @@
         "source": "simple-evals",
         "url": "https://github.com/openai/simple-evals/blob/ee3b0318d8d1d9d72755a4120879be65f7c07e9e/mmlu_eval.py",
         "notes": "0-shot generative MMLU with letter extraction; aligned with simple-evals."
+      },
+      "status": "stable"
+    },
+    {
+      "name": "mmlu_kshot_clp",
+      "display_name": "MMLU (few-shot, base clp)",
+      "description": "MMLU few-shot MCQ, base-model next-token A/B/C/D logprob scoring.",
+      "dataset": "mmlu",
+      "eval_mode": "clp",
+      "n_shot": 5,
+      "tags": [
+        "english",
+        "multiple-choice",
+        "base-model"
+      ],
+      "deps_group": null,
+      "model_type": "gen",
+      "reference_impl": {
+        "source": "hendrycks/test",
+        "url": "https://github.com/hendrycks/test/blob/4450500f923c49f1fb1dd3d99108a0bd9717b660/evaluate_flan.py",
+        "notes": "Next-token A/B/C/D scoring via one alogprobs(echo=False) call, argmax over the option tokens in top_logprobs; equivalent to the reference softmax over the restricted letter logits (OpenCompass clp). Few-shot = first k dev examples per subject in dataset order. Requires all of A/B/C/D in the top-k and fails the sample otherwise (default logprobs=100; vLLM needs --max-logprobs 100, default 20; SGLang serves 100). Full-set micro-average score (pipeline failures scored wrong, kept in the denominator) + per-category via subject2category, matching evaluate_flan weighted_acc and the sibling mmlu_0shot_gen / gsm8k_0shot_gen family. No client-side 2048-token truncation."
       },
       "status": "stable"
     },

--- a/sieval/meta/index.json
+++ b/sieval/meta/index.json
@@ -943,7 +943,7 @@
       "reference_impl": {
         "source": "simple-evals",
         "url": "https://github.com/openai/simple-evals/blob/ee3b0318d8d1d9d72755a4120879be65f7c07e9e/mmlu_eval.py",
-        "notes": "0-shot generative MMLU with letter extraction; aligned with simple-evals."
+        "notes": "0-shot generative MMLU with letter extraction; scoring aligned with simple-evals, data loaded from cais/mmlu (same 14042-item test set)."
       },
       "status": "stable"
     },
@@ -964,7 +964,7 @@
       "reference_impl": {
         "source": "hendrycks/test",
         "url": "https://github.com/hendrycks/test/blob/4450500f923c49f1fb1dd3d99108a0bd9717b660/evaluate_flan.py",
-        "notes": "Next-token A/B/C/D scoring via one alogprobs(echo=False) call, argmax over the option tokens in top_logprobs; equivalent to the reference softmax over the restricted letter logits (OpenCompass clp). Few-shot = first k dev examples per subject in dataset order. Requires all of A/B/C/D in the top-k and fails the sample otherwise (default logprobs=100; vLLM needs --max-logprobs 100, default 20; SGLang serves 100). Full-set micro-average score (pipeline failures scored wrong, kept in the denominator) + per-category via subject2category, matching evaluate_flan weighted_acc and the sibling mmlu_0shot_gen / gsm8k_0shot_gen family. No client-side 2048-token truncation."
+        "notes": "Next-token A/B/C/D scoring via one alogprobs(echo=False) call, argmax over the option tokens in top_logprobs; equivalent to the reference softmax over the restricted letter logits (OpenCompass clp). Few-shot = first k dev examples per subject in dataset order. Requires all of A/B/C/D in the top-k and fails the sample otherwise (default logprobs=100; vLLM needs --max-logprobs 100, default 20; SGLang serves 100). Micro-average score over the finalized set (infra failures reported separately, not scored wrong) + per-category via subject2category, matching evaluate_flan weighted_acc and the CLP siblings cmmlu/mmmlu. No client-side 2048-token truncation. Validated: Qwen2.5-72B base, 5-shot, 14042/14042, score 86.11 (target 85.0), 0 fails, deterministic across two runs."
       },
       "status": "stable"
     },

--- a/sieval/tasks/__init__.pyi
+++ b/sieval/tasks/__init__.pyi
@@ -64,6 +64,9 @@ from .mbpp_kshot_base_gen import (
 from .mmlu_0shot_gen import (
     MMLUZeroShotGenTask,
 )
+from .mmlu_kshot_clp import (
+    MMLUFewShotCLPTask,
+)
 from .mmlu_pro_0shot_gen import (
     MMLUProZeroShotGenTask,
 )
@@ -101,6 +104,7 @@ __all__ = [
     "LiveCodeBenchCodeGenerationZeroShotGenTask",
     "MATH500ZeroShotGenTask",
     "MBPPFewShotBaseGenTask",
+    "MMLUFewShotCLPTask",
     "MMLUProZeroShotGenTask",
     "MMLUZeroShotGenTask",
     "MMMLUKShotClpTask",

--- a/sieval/tasks/mmlu_0shot_gen.py
+++ b/sieval/tasks/mmlu_0shot_gen.py
@@ -59,12 +59,13 @@ class MMLUZeroShotGenTask(
 ):
     @override
     async def preprocess(self, raw, ctx):
+        choices = raw["choices"]
         data = {
-            "Question": raw["Question"],
-            "A": raw["A"],
-            "B": raw["B"],
-            "C": raw["C"],
-            "D": raw["D"],
+            "Question": raw["question"],
+            "A": choices[0],
+            "B": choices[1],
+            "C": choices[2],
+            "D": choices[3],
         }
         return [
             {"role": "user", "content": QUERY_TEMPLATE_MULTICHOICE.format(**data)},
@@ -88,8 +89,8 @@ class MMLUZeroShotGenTask(
 
     @override
     async def feedback(self, post, ctx):
-        answer = ctx.raw_sample["Answer"]
-        subject = ctx.raw_sample.get("Subject", "unknown")
+        answer = "ABCD"[ctx.raw_sample["answer"]]
+        subject = ctx.raw_sample.get("subject", "unknown")
         category = subject2category.get(subject, "other")
         return True, {
             "correct": post == answer,
@@ -110,7 +111,16 @@ class MMLUZeroShotGenTask(
                 category_metrics[category]["correct"] += 1
             category_metrics[category]["total"] += 1
 
-        score = 100 * correct_num / len(finals) if finals else 0.0
+        # Pipeline failures are scored wrong and kept in the denominator
+        # (full-set accuracy, aligned with the gsm8k_0shot_gen family): bucket
+        # each by its subject's category, incrementing total but never correct.
+        for ctx in fails:
+            subject = ctx.raw_sample.get("subject", "unknown")
+            category = subject2category.get(subject, "other")
+            category_metrics[category]["total"] += 1
+
+        total = len(finals) + len(fails)
+        score = 100 * correct_num / total if total else 0.0
         results = {"score": score}
         for category, metrics in category_metrics.items():
             category_score = (

--- a/sieval/tasks/mmlu_0shot_gen.py
+++ b/sieval/tasks/mmlu_0shot_gen.py
@@ -43,7 +43,9 @@ class Feedback(TypedDict):
         source="simple-evals",
         url="https://github.com/openai/simple-evals/blob/ee3b0318d8d1d9d72755a4120879be65f7c07e9e/mmlu_eval.py",
         notes=(
-            "0-shot generative MMLU with letter extraction; aligned with simple-evals."
+            "0-shot generative MMLU with letter extraction; scoring aligned "
+            "with simple-evals, data loaded from cais/mmlu (same 14042-item "
+            "test set)."
         ),
     ),
 )
@@ -111,16 +113,7 @@ class MMLUZeroShotGenTask(
                 category_metrics[category]["correct"] += 1
             category_metrics[category]["total"] += 1
 
-        # Pipeline failures are scored wrong and kept in the denominator
-        # (full-set accuracy, aligned with the gsm8k_0shot_gen family): bucket
-        # each by its subject's category, incrementing total but never correct.
-        for ctx in fails:
-            subject = ctx.raw_sample.get("subject", "unknown")
-            category = subject2category.get(subject, "other")
-            category_metrics[category]["total"] += 1
-
-        total = len(finals) + len(fails)
-        score = 100 * correct_num / total if total else 0.0
+        score = 100 * correct_num / len(finals) if finals else 0.0
         results = {"score": score}
         for category, metrics in category_metrics.items():
             category_score = (

--- a/sieval/tasks/mmlu_kshot_clp.py
+++ b/sieval/tasks/mmlu_kshot_clp.py
@@ -1,0 +1,255 @@
+"""
+MMLU few-shot base-model clp task, aligned with hendrycks/test evaluate_flan.py.
+
+Scoring: the reference takes one forward pass over the prompt ending in
+``Answer:``, restricts the next-token logits to the four letter tokens
+``A/B/C/D``, softmaxes and predicts the argmax. This task reproduces the
+*prediction* over the OpenAI-style completions API with a single
+``alogprobs(echo=False)`` call, reading the next token's ``top_logprobs`` and
+argmax-ing over A/B/C/D. That is the identical prediction: softmax is monotonic
+and its normalizer is constant across the four letters. This is OpenCompass
+``clp`` (conditional log-prob, single inference), not ``ppl`` (full-sequence
+perplexity of multi-token continuations).
+
+Few-shot: the first ``k`` ``dev`` examples of the *same subject*, in dataset
+order (matching evaluate_flan ``dev_df[:k]`` per subject). Prompt text
+(``_format_subject`` / ``_format_example``) is copied verbatim from the
+reference and pinned by tests.
+
+Scoring requires all of A/B/C/D in the returned top-k and raises otherwise, so a
+too-small top-k surfaces as a sample failure rather than a best-of-present
+guess. Faithful reproduction needs a top-k that always includes the four option
+letters, so ``DEFAULT_LOGPROBS`` defaults to 100 (SGLang serves 100 by default;
+on vLLM start with ``--max-logprobs 100``, whose default of 20 can drop them).
+
+Target: 85.0 — Qwen2.5-72B Base, MMLU 5-shot, from the DeepSeek-V3 report
+Table 6 (base-model comparison). Cross-check only: that table is scored under
+DeepSeek's own harness, so a small gap from this clp reproduction is expected
+rather than a reproduction failure.
+
+Deviations from the reference:
+- No client-side 2048-token truncation (the reference drops shots when the
+  tokenized prompt overflows); there is no tokenizer at this layer.
+- ``score`` is the micro-average over the full test set: every question counts
+  and a pipeline failure is scored wrong (denominator ``len(finals) +
+  len(fails)``), matching the reference ``weighted_acc`` and the sibling
+  ``mmlu_0shot_gen`` / ``gsm8k_0shot_gen`` family; per-category accuracies are
+  reported alongside.
+
+AI-Generated Code - Claude Opus 4.8 (Anthropic)
+"""
+
+from collections import defaultdict
+from typing import Any, TypedDict, override
+
+from sieval.community.simple_evals.mmlu_eval import subject2category
+from sieval.core.datasets import Dataset
+from sieval.core.models import Model, ModelOutput
+from sieval.core.tasks import (
+    EvalMode,
+    ReferenceImpl,
+    Task,
+    sieval_task,
+)
+from sieval.core.utils.ppl import choice_scores_from_top_logprobs
+from sieval.datasets import MMLUDatasetSample
+
+CHOICES = ("A", "B", "C", "D")
+DEFAULT_N_SHOT = 5
+# Must be large enough that all of A/B/C/D land in the returned top-k. SGLang
+# serves 100 by default; vLLM needs `--max-logprobs 100` (its default is 20).
+DEFAULT_LOGPROBS = 100
+
+
+class Feedback(TypedDict):
+    correct: bool
+    subject: str
+    category: str
+    answer: str
+    prediction: str
+
+
+def _format_subject(subject: str) -> str:
+    """Reference ``format_subject``: ``abstract_algebra`` -> `` abstract algebra``."""
+    return " " + " ".join(subject.split("_"))
+
+
+def _format_example(sample: MMLUDatasetSample, *, include_answer: bool) -> str:
+    prompt = sample["question"]
+    for label, choice in zip(CHOICES, sample["choices"], strict=False):
+        prompt += f"\n{label}. {choice}"
+    prompt += "\nAnswer:"
+    if include_answer:
+        prompt += f" {CHOICES[sample['answer']]}\n\n"
+    return prompt
+
+
+@sieval_task(
+    name="mmlu_kshot_clp",
+    display_name="MMLU (few-shot, base clp)",
+    description="MMLU few-shot MCQ, base-model next-token A/B/C/D logprob scoring.",
+    eval_mode=EvalMode.CLP,
+    n_shot=DEFAULT_N_SHOT,
+    tags=("english", "multiple-choice", "base-model"),
+    model_type="gen",
+    reference_impl=ReferenceImpl(
+        source="hendrycks/test",
+        url=(
+            "https://github.com/hendrycks/test/blob/"
+            "4450500f923c49f1fb1dd3d99108a0bd9717b660/evaluate_flan.py"
+        ),
+        notes=(
+            "Next-token A/B/C/D scoring via one alogprobs(echo=False) call, "
+            "argmax over the option tokens in top_logprobs; equivalent to the "
+            "reference softmax over the restricted letter logits (OpenCompass "
+            "clp). Few-shot = first k dev examples per subject in dataset "
+            "order. Requires all of A/B/C/D in the top-k and fails the sample "
+            "otherwise (default logprobs=100; vLLM needs --max-logprobs 100, "
+            "default 20; SGLang serves 100). Full-set micro-average score "
+            "(pipeline failures scored wrong, kept in the denominator) + "
+            "per-category via subject2category, matching evaluate_flan "
+            "weighted_acc and the sibling mmlu_0shot_gen / gsm8k_0shot_gen "
+            "family. No client-side 2048-token truncation."
+        ),
+    ),
+)
+class MMLUFewShotCLPTask(
+    Task[
+        MMLUDatasetSample,
+        str,
+        ModelOutput,
+        str,
+        Feedback,
+        dict[str, float],
+    ]
+):
+    def __init__(
+        self,
+        dataset: Dataset[MMLUDatasetSample],
+        model: Model[Any],
+        name: str | None = None,
+        *,
+        k: int = DEFAULT_N_SHOT,
+        logprobs: int = DEFAULT_LOGPROBS,
+        fewshot_split: str = "dev",
+    ):
+        if k < 0:
+            raise ValueError(f"k must be >= 0, got {k}")
+        if logprobs < 1:
+            raise ValueError(f"logprobs must be >= 1, got {logprobs}")
+        super().__init__(dataset=dataset, model=model, name=name)
+        self._k = k
+        self._logprobs = max(logprobs, len(CHOICES))
+        self._fewshot_split = fewshot_split
+        self._few_shot_by_subject: dict[str, list[MMLUDatasetSample]] = {}
+        self._few_shot_prompt_by_subject: dict[str, str] = {}
+
+    @override
+    async def setup(self) -> None:
+        self._ensure_few_shot_pool()
+
+    def _ensure_few_shot_pool(self) -> None:
+        if self._few_shot_by_subject or self._k == 0:
+            return
+        split = self.dataset.dataset_dict.get(self._fewshot_split)
+        if split is None:
+            raise ValueError(
+                "MMLU few-shot clp task requires a "
+                f"{self._fewshot_split!r} split for few-shot examples."
+            )
+        for sample in split:
+            subject = str(sample.get("subject") or "unknown")
+            self._few_shot_by_subject.setdefault(subject, []).append(sample)
+
+    def _select_examples(self, subject: str) -> list[MMLUDatasetSample]:
+        if self._k == 0:
+            return []
+        self._ensure_few_shot_pool()
+        return list(self._few_shot_by_subject.get(subject, []))[: self._k]
+
+    def _build_few_shot_prompt(self, subject: str) -> str:
+        cached = self._few_shot_prompt_by_subject.get(subject)
+        if cached is not None:
+            return cached
+        prompt = (
+            "The following are multiple choice questions (with answers) about"
+            f"{_format_subject(subject)}.\n\n"
+        )
+        for example in self._select_examples(subject):
+            prompt += _format_example(example, include_answer=True)
+        self._few_shot_prompt_by_subject[subject] = prompt
+        return prompt
+
+    @override
+    async def preprocess(self, raw, ctx):
+        subject = raw.get("subject") or "unknown"
+        return self._build_few_shot_prompt(subject) + _format_example(
+            raw, include_answer=False
+        )
+
+    @override
+    async def infer(self, pre, ctx):
+        return await self.model.alogprobs(
+            pre,
+            max_tokens=1,
+            logprobs=self._logprobs,
+            echo=False,
+        )
+
+    @override
+    async def postprocess(self, inf, ctx):
+        scores, all_present = choice_scores_from_top_logprobs(inf.top_logprobs, CHOICES)
+        if not all_present:
+            missing = [label for label in CHOICES if scores[label] == float("-inf")]
+            raise RuntimeError(
+                "MMLU top_logprobs missing option token(s) "
+                f"{missing}; increase logprobs (got top-k of {self._logprobs}) "
+                "or raise the server's max-logprobs so all of A/B/C/D are "
+                "returned."
+            )
+        return max(scores.items(), key=lambda item: item[1])[0]
+
+    @override
+    async def feedback(self, post, ctx):
+        answer = CHOICES[ctx.raw_sample["answer"]]
+        subject = ctx.raw_sample.get("subject", "unknown")
+        category = subject2category.get(subject, "other")
+        return True, {
+            "correct": post == answer,
+            "subject": subject,
+            "category": category,
+            "answer": answer,
+            "prediction": post,
+        }
+
+    @override
+    async def report(self, finals, fails):
+        correct_num = 0
+        category_metrics = defaultdict(lambda: {"correct": 0, "total": 0})
+        for ctx in finals:
+            correct = ctx.feedback_result["correct"]
+            category = ctx.feedback_result["category"]
+            if correct:
+                correct_num += 1
+                category_metrics[category]["correct"] += 1
+            category_metrics[category]["total"] += 1
+
+        # Pipeline failures are scored wrong and kept in the denominator
+        # (full-set accuracy, aligned with the *_0shot_gen family): bucket each
+        # by its subject's category, incrementing total but never correct.
+        for ctx in fails:
+            subject = ctx.raw_sample.get("subject", "unknown")
+            category = subject2category.get(subject, "other")
+            category_metrics[category]["total"] += 1
+
+        total = len(finals) + len(fails)
+        score = 100 * correct_num / total if total else 0.0
+        results = {"score": score}
+        for category, metrics in category_metrics.items():
+            results[f"score_{category}"] = (
+                100 * metrics["correct"] / metrics["total"]
+                if metrics["total"] > 0
+                else 0.0
+            )
+        results["fails"] = len(fails)
+        return results

--- a/sieval/tasks/mmlu_kshot_clp.py
+++ b/sieval/tasks/mmlu_kshot_clp.py
@@ -30,10 +30,10 @@ rather than a reproduction failure.
 Deviations from the reference:
 - No client-side 2048-token truncation (the reference drops shots when the
   tokenized prompt overflows); there is no tokenizer at this layer.
-- ``score`` is the micro-average over the full test set: every question counts
-  and a pipeline failure is scored wrong (denominator ``len(finals) +
-  len(fails)``), matching the reference ``weighted_acc`` and the sibling
-  ``mmlu_0shot_gen`` / ``gsm8k_0shot_gen`` family; per-category accuracies are
+- ``score`` is the micro-average over the finalized set (denominator
+  ``len(finals)``), matching the reference ``weighted_acc`` and the CLP siblings
+  ``cmmlu_kshot_clp`` / ``mmmlu_kshot_clp``: infra failures are reported
+  separately (``fails``) rather than scored wrong. Per-category accuracies are
   reported alongside.
 
 AI-Generated Code - Claude Opus 4.8 (Anthropic)
@@ -76,7 +76,7 @@ def _format_subject(subject: str) -> str:
 
 def _format_example(sample: MMLUDatasetSample, *, include_answer: bool) -> str:
     prompt = sample["question"]
-    for label, choice in zip(CHOICES, sample["choices"], strict=False):
+    for label, choice in zip(CHOICES, sample["choices"], strict=True):
         prompt += f"\n{label}. {choice}"
     prompt += "\nAnswer:"
     if include_answer:
@@ -105,11 +105,13 @@ def _format_example(sample: MMLUDatasetSample, *, include_answer: bool) -> str:
             "clp). Few-shot = first k dev examples per subject in dataset "
             "order. Requires all of A/B/C/D in the top-k and fails the sample "
             "otherwise (default logprobs=100; vLLM needs --max-logprobs 100, "
-            "default 20; SGLang serves 100). Full-set micro-average score "
-            "(pipeline failures scored wrong, kept in the denominator) + "
-            "per-category via subject2category, matching evaluate_flan "
-            "weighted_acc and the sibling mmlu_0shot_gen / gsm8k_0shot_gen "
-            "family. No client-side 2048-token truncation."
+            "default 20; SGLang serves 100). Micro-average score over the "
+            "finalized set (infra failures reported separately, not scored "
+            "wrong) + per-category via subject2category, matching evaluate_flan "
+            "weighted_acc and the CLP siblings cmmlu/mmmlu. No client-side "
+            "2048-token truncation. Validated: Qwen2.5-72B base, 5-shot, "
+            "14042/14042, score 86.11 (target 85.0), 0 fails, deterministic "
+            "across two runs."
         ),
     ),
 )
@@ -234,16 +236,10 @@ class MMLUFewShotCLPTask(
                 category_metrics[category]["correct"] += 1
             category_metrics[category]["total"] += 1
 
-        # Pipeline failures are scored wrong and kept in the denominator
-        # (full-set accuracy, aligned with the *_0shot_gen family): bucket each
-        # by its subject's category, incrementing total but never correct.
-        for ctx in fails:
-            subject = ctx.raw_sample.get("subject", "unknown")
-            category = subject2category.get(subject, "other")
-            category_metrics[category]["total"] += 1
-
-        total = len(finals) + len(fails)
-        score = 100 * correct_num / total if total else 0.0
+        # CLP-family convention (cmmlu / mmmlu): the score denominator is the
+        # finalized set; infra failures are reported separately (``fails``), not
+        # scored wrong.
+        score = 100 * correct_num / len(finals) if finals else 0.0
         results = {"score": score}
         for category, metrics in category_metrics.items():
             results[f"score_{category}"] = (

--- a/tests/unit/core/tasks/test_anomaly.py
+++ b/tests/unit/core/tasks/test_anomaly.py
@@ -99,6 +99,25 @@ class TestDetectEmptyInferPpl:
             ctx = _make_final_ctx(infer_result=infer_result)
             assert detect_empty_infer_ppl(ctx) == expected, case_name
 
+    def test_top_logprobs_variants(self, sample_model_meta):
+        """clp tasks populate top_logprobs; an empty list is flagged."""
+
+        def _make_output(top_logprobs):
+            return ModelOutput(
+                model=sample_model_meta,
+                texts=["x"],
+                top_logprobs=top_logprobs,
+            )
+
+        cases = [
+            (_make_output([]), {0}, "empty_top_logprobs"),
+            (_make_output([{"A": -0.1}]), set(), "non_empty_top_logprobs"),
+            (_make_output(None), set(), "no_top_logprobs"),
+        ]
+        for infer_result, expected, case_name in cases:
+            ctx = _make_final_ctx(infer_result=infer_result)
+            assert detect_empty_infer_ppl(ctx) == expected, case_name
+
 
 class TestDetectTruncatedOutput:
     def test_single_sample(self, sample_model_meta):

--- a/tests/unit/core/tasks/test_anomaly.py
+++ b/tests/unit/core/tasks/test_anomaly.py
@@ -99,25 +99,6 @@ class TestDetectEmptyInferPpl:
             ctx = _make_final_ctx(infer_result=infer_result)
             assert detect_empty_infer_ppl(ctx) == expected, case_name
 
-    def test_top_logprobs_variants(self, sample_model_meta):
-        """clp tasks populate top_logprobs; an empty list is flagged."""
-
-        def _make_output(top_logprobs):
-            return ModelOutput(
-                model=sample_model_meta,
-                texts=["x"],
-                top_logprobs=top_logprobs,
-            )
-
-        cases = [
-            (_make_output([]), {0}, "empty_top_logprobs"),
-            (_make_output([{"A": -0.1}]), set(), "non_empty_top_logprobs"),
-            (_make_output(None), set(), "no_top_logprobs"),
-        ]
-        for infer_result, expected, case_name in cases:
-            ctx = _make_final_ctx(infer_result=infer_result)
-            assert detect_empty_infer_ppl(ctx) == expected, case_name
-
 
 class TestDetectTruncatedOutput:
     def test_single_sample(self, sample_model_meta):
@@ -662,15 +643,24 @@ class TestDetectWithTaskTags:
         assert "empty_infer_ppl" not in result
 
     def test_all_tasks_rule_always_runs(self, tmp_path, sample_model_meta):
+        # empty_postprocess is an all_tasks rule: it runs regardless of tags.
+        # (truncated_output was the old sentinel but is now scoped to gen.)
+        detector = TaskAnomalyDetector(root_dir=tmp_path)
+        output = ModelOutput(model=sample_model_meta, texts=["x"])
+        ctx = _make_final_ctx(infer_result=output, postprocess_result="")
+        result = detector.detect(ctx, task_tags={"ppl"})
+        assert "empty_postprocess" in result
+
+    def test_truncated_output_scoped_to_gen(self, tmp_path, sample_model_meta):
+        # clp/ppl infer at max_tokens=1 → always finish "length"; truncation is
+        # only meaningful for generation, so the rule must not fire for them.
         detector = TaskAnomalyDetector(root_dir=tmp_path)
         output = ModelOutput(
-            model=sample_model_meta,
-            texts=["x"],
-            finish_reasons=["length"],
+            model=sample_model_meta, texts=["x"], finish_reasons=["length"]
         )
         ctx = _make_final_ctx(infer_result=output, postprocess_result="ok")
-        result = detector.detect(ctx, task_tags={"ppl"})
-        assert "truncated_output" in result
+        assert "truncated_output" not in detector.detect(ctx, task_tags={"clp"})
+        assert "truncated_output" in detector.detect(ctx, task_tags={"gen"})
 
     def test_empty_tags_skips_detection_with_warning(self, tmp_path, sample_model_meta):
         """Empty tags → skip detection and warn."""

--- a/tests/unit/core/utils/test_ppl.py
+++ b/tests/unit/core/utils/test_ppl.py
@@ -49,6 +49,7 @@ class TestChoiceScoresFromTopLogprobs:
         assert all_present is True
         assert set(scores) == set(CHOICES)
         assert max(scores, key=lambda k: scores[k]) == "B"
+
     def test_empty_or_none(self):
         expected = dict.fromkeys(CHOICES, float("-inf"))
         assert choice_scores_from_top_logprobs(None, CHOICES) == (expected, False)

--- a/tests/unit/core/utils/test_ppl.py
+++ b/tests/unit/core/utils/test_ppl.py
@@ -49,7 +49,6 @@ class TestChoiceScoresFromTopLogprobs:
         assert all_present is True
         assert set(scores) == set(CHOICES)
         assert max(scores, key=lambda k: scores[k]) == "B"
-
     def test_empty_or_none(self):
         expected = dict.fromkeys(CHOICES, float("-inf"))
         assert choice_scores_from_top_logprobs(None, CHOICES) == (expected, False)

--- a/tests/unit/datasets/test_mmlu.py
+++ b/tests/unit/datasets/test_mmlu.py
@@ -1,0 +1,63 @@
+"""
+Unit tests for the MMLU dataset loader.
+
+AI-Generated Code - Claude Opus 4.8 (Anthropic)
+"""
+
+from unittest.mock import patch
+
+from datasets import Dataset as HFDataset
+from datasets import DatasetDict as HFDatasetDict
+
+import sieval.datasets.mmlu as mmlu_module
+from sieval.datasets.mmlu import MMLU_REVISION, MMLUDataset
+
+
+def _hf_dict() -> HFDatasetDict:
+    row = {
+        "question": "What?",
+        "subject": "anatomy",
+        "choices": ["a", "b", "c", "d"],
+        "answer": 1,
+    }
+    return HFDatasetDict({"test": HFDataset.from_list([row])})
+
+
+def test_source_revision_is_pinned():
+    # Pinning guard: the cais/mmlu commit the source/downloader resolve against.
+    assert MMLU_REVISION == "c30699e8356da336a370243923dbaf21066bb9fe"
+
+
+def test_load_forwards_path_and_config_without_mutating_schema():
+    hf_dict = _hf_dict()
+    dataset = MMLUDataset(_hf_dict=hf_dict)
+
+    with patch.object(mmlu_module, "load_dataset", return_value=hf_dict) as mock_load:
+        loaded = dataset.load("cais/mmlu")
+
+    # Path + default config forwarded positionally; the revision pin is applied
+    # at download time, not re-forwarded to the loader (the staged path is
+    # already at the pinned commit).
+    assert mock_load.call_args.args == ("cais/mmlu", "all")
+    assert "revision" not in mock_load.call_args.kwargs
+    # Native cais/mmlu schema preserved as-is — no rename/coercion in the loader.
+    assert set(loaded["test"].column_names) == {
+        "question",
+        "subject",
+        "choices",
+        "answer",
+    }
+
+
+def test_load_remaps_eval_split_to_test():
+    hf_dict = HFDatasetDict(
+        {
+            "validation": HFDataset.from_list([dict(_hf_dict()["test"][0])]),
+        }
+    )
+    dataset = MMLUDataset(_hf_dict=hf_dict)
+
+    with patch.object(mmlu_module, "load_dataset", return_value=hf_dict):
+        loaded = dataset.load("cais/mmlu", eval_split="validation")
+
+    assert "test" in loaded and loaded["test"].num_rows == 1

--- a/tests/unit/tasks/test_mmlu_0shot_gen.py
+++ b/tests/unit/tasks/test_mmlu_0shot_gen.py
@@ -67,15 +67,15 @@ async def test_feedback_derives_letter_from_answer_index():
 
 
 @pytest.mark.anyio
-async def test_report_counts_fails_in_denominator():
-    # 1 correct final + 1 pipeline failure → 50% over the full set (1/(1+1)),
-    # not 100%. A len(finals)-only denominator would wrongly report 100.0, so
-    # this pins the failure into both the score denominator and its category.
+async def test_report_excludes_fails_from_denominator():
+    # 1 correct final + 1 pipeline failure → score 100.0 over the finalized set;
+    # the fail is reported separately (matches main's mmlu_0shot_gen). A
+    # len(finals)+len(fails) denominator would give 50.0.
     task = _task()
     report = await task.report(
         [TaskContext(sample_id=0, raw_sample=_sample(), feedback_result=_fb(True))],
         [TaskContext(sample_id=1, raw_sample=_sample("anatomy", 1))],
     )
     assert report["fails"] == 1
-    assert report["score"] == 50.0  # 1/(1+1); old len(finals) denom gives 100.0
-    assert report["score_other"] == 50.0  # anatomy → "other"; fail buckets here too
+    assert report["score"] == 100.0  # 1/1; fails excluded from the denominator
+    assert report["score_other"] == 100.0

--- a/tests/unit/tasks/test_mmlu_0shot_gen.py
+++ b/tests/unit/tasks/test_mmlu_0shot_gen.py
@@ -1,0 +1,81 @@
+"""Unit tests for the MMLU 0-shot generative task.
+
+AI-Generated Code - Claude Opus 4.8 (Anthropic)
+"""
+
+import pytest
+from datasets import Dataset as HFDataset
+from datasets import DatasetDict as HFDatasetDict
+
+from sieval.core.models import ModelOutput
+from sieval.core.models.chat_model import ChatModel
+from sieval.core.tasks import TaskContext
+from sieval.datasets.mmlu import MMLUDataset, MMLUDatasetSample
+from sieval.tasks.mmlu_0shot_gen import MMLUZeroShotGenTask
+
+
+class _StubChatModel(ChatModel):
+    def __init__(self):
+        super().__init__(model="mock-chat", api_key="fake")
+
+    async def _agenerate_impl(self, prompt, **kwargs) -> ModelOutput:
+        _ = (prompt, kwargs)
+        return ModelOutput(model=self.meta(), texts=["Answer: A"])
+
+    async def _alogprobs_impl(
+        self,
+        prompt,
+        *,
+        max_tokens: int = 1,
+        logprobs: int = 5,
+        echo: bool = True,
+        temperature: float = 0.0,
+        **kwargs,
+    ) -> ModelOutput:
+        _ = (prompt, max_tokens, logprobs, echo, temperature, kwargs)
+        return ModelOutput(model=self.meta(), texts=[""])
+
+
+def _sample(subject: str = "anatomy", answer: int = 0) -> MMLUDatasetSample:
+    return {
+        "question": "Q?",
+        "subject": subject,
+        "choices": ["a", "b", "c", "d"],
+        "answer": answer,
+    }
+
+
+def _task() -> MMLUZeroShotGenTask:
+    dataset = MMLUDataset(
+        _hf_dict=HFDatasetDict({"test": HFDataset.from_list([dict(_sample())])})
+    )
+    return MMLUZeroShotGenTask(dataset, _StubChatModel())
+
+
+def _fb(correct: bool, subject: str = "anatomy", category: str = "other"):
+    return {"correct": correct, "subject": subject, "category": category, "answer": "A"}
+
+
+@pytest.mark.anyio
+async def test_feedback_derives_letter_from_answer_index():
+    task = _task()
+    ctx = TaskContext(sample_id=0, raw_sample=_sample(subject="astronomy", answer=2))
+    finalize, fb = await task.feedback("C", ctx)
+    assert finalize is True
+    assert fb["answer"] == "C" and fb["correct"] is True
+    assert fb["subject"] == "astronomy"
+
+
+@pytest.mark.anyio
+async def test_report_counts_fails_in_denominator():
+    # 1 correct final + 1 pipeline failure → 50% over the full set (1/(1+1)),
+    # not 100%. A len(finals)-only denominator would wrongly report 100.0, so
+    # this pins the failure into both the score denominator and its category.
+    task = _task()
+    report = await task.report(
+        [TaskContext(sample_id=0, raw_sample=_sample(), feedback_result=_fb(True))],
+        [TaskContext(sample_id=1, raw_sample=_sample("anatomy", 1))],
+    )
+    assert report["fails"] == 1
+    assert report["score"] == 50.0  # 1/(1+1); old len(finals) denom gives 100.0
+    assert report["score_other"] == 50.0  # anatomy → "other"; fail buckets here too

--- a/tests/unit/tasks/test_mmlu_kshot_clp.py
+++ b/tests/unit/tasks/test_mmlu_kshot_clp.py
@@ -237,10 +237,10 @@ async def test_feedback_marks_wrong_prediction():
 
 
 @pytest.mark.anyio
-async def test_report_counts_fails_in_denominator():
-    # 1 correct final + 1 pipeline failure → 50% over the full set (1/(1+1)),
-    # not 100%. A len(finals)-only denominator would wrongly report 100.0, so
-    # this pins the failure into both the score denominator and its category.
+async def test_report_excludes_fails_from_denominator():
+    # CLP-family convention (cmmlu / mmmlu): 1 correct final + 1 pipeline failure
+    # → score 100.0 over the finalized set; the fail is reported separately, not
+    # scored wrong. A len(finals)+len(fails) denominator would give 50.0.
     good = _sample("anatomy", "Q", 0)  # gold "A"
     failed = _sample("anatomy", "Q2", 1)
     task = MMLUFewShotCLPTask(
@@ -259,8 +259,8 @@ async def test_report_counts_fails_in_denominator():
         [TaskContext(sample_id=1, raw_sample=failed)],
     )
     assert report["fails"] == 1
-    assert report["score"] == 50.0  # 1/(1+1); old len(finals) denom gives 100.0
-    assert report["score_other"] == 50.0  # anatomy → "other"; fail buckets here too
+    assert report["score"] == 100.0  # 1/1; a finals+fails denom would give 50.0
+    assert report["score_other"] == 100.0  # only the final buckets; fail excluded
 
 
 # --- Validation ---

--- a/tests/unit/tasks/test_mmlu_kshot_clp.py
+++ b/tests/unit/tasks/test_mmlu_kshot_clp.py
@@ -1,0 +1,284 @@
+"""Unit tests for the MMLU few-shot base-model clp task.
+
+AI-Generated Code - Claude Opus 4.8 (Anthropic)
+"""
+
+import pytest
+from datasets import Dataset as HFDataset
+from datasets import DatasetDict as HFDatasetDict
+
+from sieval.core.models import ModelOutput
+from sieval.core.models.gen_model import GenModel
+from sieval.core.tasks import TaskContext
+from sieval.datasets.mmlu import MMLUDataset, MMLUDatasetSample
+from sieval.tasks.mmlu_kshot_clp import (
+    CHOICES,
+    MMLUFewShotCLPTask,
+    _format_example,
+    _format_subject,
+)
+
+
+class _ScriptedGenModel(GenModel):
+    """Returns a top_logprobs distribution favouring ``winner``.
+
+    ``drop`` omits a letter from the top-k to exercise the missing-option path.
+    """
+
+    def __init__(self, winner: str = "A", drop: str | None = None):
+        super().__init__(model="mock-gen", api_key="fake")
+        self._winner = winner
+        self._drop = drop
+        self.prompts: list[str] = []
+        self.call_count = 0
+
+    async def _agenerate_impl(self, prompt: str, **kwargs) -> ModelOutput:
+        return ModelOutput(model=self.meta(), texts=[""])
+
+    async def _alogprobs_impl(
+        self,
+        prompt: str,
+        *,
+        max_tokens: int = 1,
+        logprobs: int = 5,
+        echo: bool = True,
+        temperature: float = 0.0,
+        **kwargs,
+    ) -> ModelOutput:
+        self.prompts.append(prompt)
+        self.call_count += 1
+        assert echo is False  # clp reads the next-token distribution, no echo
+        dist = {
+            f" {label}": (-0.1 if label == self._winner else -5.0)
+            for label in CHOICES
+            if label != self._drop
+        }
+        return ModelOutput(model=self.meta(), texts=[""], top_logprobs=[dist])
+
+
+def _sample(
+    subject: str = "abstract_algebra",
+    question: str = "Q?",
+    answer: int = 0,
+    choices: list[str] | None = None,
+) -> MMLUDatasetSample:
+    return {
+        "question": question,
+        "subject": subject,
+        "choices": choices or ["c0", "c1", "c2", "c3"],
+        "answer": answer,
+    }
+
+
+def _dataset(
+    dev_rows: list[MMLUDatasetSample], test_rows: list[MMLUDatasetSample]
+) -> MMLUDataset:
+    return MMLUDataset(
+        _hf_dict=HFDatasetDict(
+            {
+                "dev": HFDataset.from_list([dict(r) for r in dev_rows]),
+                "test": HFDataset.from_list([dict(r) for r in test_rows]),
+            }
+        )
+    )
+
+
+# --- Prompt format pinning (must match hendrycks/test evaluate_flan.py) ---
+
+
+def test_format_subject_matches_reference():
+    assert _format_subject("abstract_algebra") == " abstract algebra"
+    assert _format_subject("anatomy") == " anatomy"
+
+
+def test_format_example_with_and_without_answer():
+    sample = _sample(question="What?", answer=2, choices=["w", "x", "y", "z"])
+    assert (
+        _format_example(sample, include_answer=False)
+        == "What?\nA. w\nB. x\nC. y\nD. z\nAnswer:"
+    )
+    assert (
+        _format_example(sample, include_answer=True)
+        == "What?\nA. w\nB. x\nC. y\nD. z\nAnswer: C\n\n"
+    )
+
+
+@pytest.mark.anyio
+async def test_header_and_prompt_are_byte_exact():
+    dev = [_sample("anatomy", "S?", 0)]
+    test = _sample("anatomy", "TESTQ", 1)
+    task = MMLUFewShotCLPTask(_dataset(dev, [test]), _ScriptedGenModel(), k=1)
+    await task.setup()
+
+    pre = await task.preprocess(test, TaskContext(sample_id=0, raw_sample=test))
+    assert pre == (
+        "The following are multiple choice questions (with answers) about"
+        " anatomy.\n\n"
+        "S?\nA. c0\nB. c1\nC. c2\nD. c3\nAnswer: A\n\n"
+        "TESTQ\nA. c0\nB. c1\nC. c2\nD. c3\nAnswer:"
+    )
+
+
+# --- Few-shot: first k dev examples per subject, in order ---
+
+
+@pytest.mark.anyio
+async def test_fewshot_is_per_subject_fixed_order():
+    dev_rows = [_sample("anatomy", f"a{i}", 0) for i in range(7)] + [
+        _sample("astronomy", f"s{i}", 1) for i in range(7)
+    ]
+    task = MMLUFewShotCLPTask(
+        _dataset(dev_rows, [_sample("anatomy", "t", 0)]),
+        _ScriptedGenModel(),
+        k=5,
+    )
+    await task.setup()
+
+    anatomy = task._select_examples("anatomy")
+    astronomy = task._select_examples("astronomy")
+    assert [s["question"] for s in anatomy] == ["a0", "a1", "a2", "a3", "a4"]
+    assert [s["question"] for s in astronomy] == ["s0", "s1", "s2", "s3", "s4"]
+
+
+@pytest.mark.anyio
+async def test_preprocess_uses_only_matching_subject_shots():
+    dev_rows = [_sample("anatomy", f"a{i}", 0) for i in range(5)] + [
+        _sample("astronomy", f"s{i}", 1) for i in range(5)
+    ]
+    test = _sample("astronomy", "TESTQ", 2)
+    task = MMLUFewShotCLPTask(_dataset(dev_rows, [test]), _ScriptedGenModel(), k=5)
+    await task.setup()
+
+    pre = await task.preprocess(test, TaskContext(sample_id=0, raw_sample=test))
+    assert " astronomy." in pre and "anatomy" not in pre
+    assert pre.count("\nAnswer:") == 6  # 5 shots + test
+    assert pre.rstrip().endswith("Answer:")
+
+
+# --- Scoring: single echo=False call, argmax over top_logprobs ---
+
+
+@pytest.mark.anyio
+async def test_infer_issues_single_call_echo_false():
+    test = _sample("anatomy", "Q", 0)
+    model = _ScriptedGenModel(winner="C")
+    ds = _dataset([_sample("anatomy", "d", 0)], [test])
+    task = MMLUFewShotCLPTask(ds, model, k=1)
+    await task.setup()
+    ctx = TaskContext(sample_id=0, raw_sample=test)
+
+    pre = await task.preprocess(test, ctx)
+    await task.infer(pre, ctx)
+    assert model.call_count == 1  # ONE call, not 4
+
+
+@pytest.mark.anyio
+async def test_postprocess_argmax_and_missing_choice_raises():
+    test = _sample("anatomy", "Q", 0)
+    ds = _dataset([_sample("anatomy", "d", 0)], [test])
+    ctx = TaskContext(sample_id=0, raw_sample=test)
+
+    task = MMLUFewShotCLPTask(ds, _ScriptedGenModel(winner="C"), k=1)
+    await task.setup()
+    pre = await task.preprocess(test, ctx)
+    inf = await task.infer(pre, ctx)
+    assert await task.postprocess(inf, ctx) == "C"
+
+    dropped = MMLUFewShotCLPTask(ds, _ScriptedGenModel(winner="A", drop="D"), k=1)
+    await dropped.setup()
+    inf2 = await dropped.infer(await dropped.preprocess(test, ctx), ctx)
+    with pytest.raises(RuntimeError, match="missing option token"):
+        await dropped.postprocess(inf2, ctx)
+
+
+# --- Feedback + micro report (sibling-consistent with mmlu_0shot_gen) ---
+
+
+@pytest.mark.anyio
+async def test_feedback_and_report_micro_with_categories():
+    test = _sample("abstract_algebra", "Q", 2)  # gold "C"
+    task = MMLUFewShotCLPTask(
+        _dataset([_sample("abstract_algebra", "d", 0)], [test]),
+        _ScriptedGenModel(winner="C"),
+        k=1,
+    )
+    await task.setup()
+    ctx = TaskContext(sample_id=0, raw_sample=test)
+
+    inf = await task.infer(await task.preprocess(test, ctx), ctx)
+    post = await task.postprocess(inf, ctx)
+    finalize, fb = await task.feedback(post, ctx)
+    assert finalize is True
+    assert fb["correct"] is True
+    assert fb["answer"] == "C" and fb["prediction"] == "C"
+    assert fb["subject"] == "abstract_algebra" and fb["category"] == "stem"
+
+    report = await task.report(
+        [TaskContext(sample_id=0, raw_sample=test, feedback_result=fb)], []
+    )
+    assert report["score"] == 100.0
+    assert report["score_stem"] == 100.0
+    assert report["fails"] == 0
+
+
+@pytest.mark.anyio
+async def test_feedback_marks_wrong_prediction():
+    test = _sample("anatomy", "Q", 0)  # gold "A"
+    task = MMLUFewShotCLPTask(
+        _dataset([_sample("anatomy", "d", 0)], [test]),
+        _ScriptedGenModel(winner="D"),
+        k=1,
+    )
+    await task.setup()
+    ctx = TaskContext(sample_id=0, raw_sample=test)
+    inf = await task.infer(await task.preprocess(test, ctx), ctx)
+    _, fb = await task.feedback(await task.postprocess(inf, ctx), ctx)
+    assert fb["correct"] is False and fb["prediction"] == "D"
+
+
+@pytest.mark.anyio
+async def test_report_counts_fails_in_denominator():
+    # 1 correct final + 1 pipeline failure → 50% over the full set (1/(1+1)),
+    # not 100%. A len(finals)-only denominator would wrongly report 100.0, so
+    # this pins the failure into both the score denominator and its category.
+    good = _sample("anatomy", "Q", 0)  # gold "A"
+    failed = _sample("anatomy", "Q2", 1)
+    task = MMLUFewShotCLPTask(
+        _dataset([_sample("anatomy", "d", 0)], [good]),
+        _ScriptedGenModel(winner="A"),
+        k=1,
+    )
+    await task.setup()
+    ctx = TaskContext(sample_id=0, raw_sample=good)
+    inf = await task.infer(await task.preprocess(good, ctx), ctx)
+    _, fb = await task.feedback(await task.postprocess(inf, ctx), ctx)
+    assert fb["correct"] is True
+
+    report = await task.report(
+        [TaskContext(sample_id=0, raw_sample=good, feedback_result=fb)],
+        [TaskContext(sample_id=1, raw_sample=failed)],
+    )
+    assert report["fails"] == 1
+    assert report["score"] == 50.0  # 1/(1+1); old len(finals) denom gives 100.0
+    assert report["score_other"] == 50.0  # anatomy → "other"; fail buckets here too
+
+
+# --- Validation ---
+
+
+def test_invalid_k_and_logprobs_rejected():
+    ds = _dataset([_sample()], [_sample()])
+    with pytest.raises(ValueError, match="k must be >= 0"):
+        MMLUFewShotCLPTask(ds, _ScriptedGenModel(), k=-1)
+    with pytest.raises(ValueError, match="logprobs must be >= 1"):
+        MMLUFewShotCLPTask(ds, _ScriptedGenModel(), logprobs=0)
+
+
+@pytest.mark.anyio
+async def test_missing_fewshot_split_raises():
+    ds = MMLUDataset(
+        _hf_dict=HFDatasetDict({"test": HFDataset.from_list([dict(_sample())])})
+    )
+    task = MMLUFewShotCLPTask(ds, _ScriptedGenModel(), k=5)
+    with pytest.raises(ValueError, match="dev"):
+        await task.setup()


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Type

<!-- Choose ONE, delete the rest -->

- feature — new benchmark, task, or capability

## Summary
- Add **MMLUFewShotCLPTask** (`mmlu_kshot_clp`): 5-shot base-model MCQ scored by the next single token's log-prob over A/B/C/D, read from `top_logprobs` in one `alogprobs(echo=False)` call (OpenCompass clp). Aligned with [hendrycks/test `evaluate_flan.py`](https://github.com/hendrycks/test/blob/master/evaluate_flan.py). Missing any option token from top-k fails the sample loudly instead of guessing (`DEFAULT_LOGPROBS=100`; vLLM needs `--max-logprobs 100`).
- **Repoint MMLUDataset** from the simple-evals CSV URL to `hf:cais/mmlu@c30699e` with the native schema (`question`/`subject`/`choices`/`answer`); loader is now load-only (no coercion/rename). **Breaking** to `MMLUDatasetSample`.
- **`mmlu_0shot_gen` migrated to the new schema** (coupled change): prompt text and gold answer are unchanged (same MMLU test set, positional A/B/C/D + int→letter), so a clean 0-fail score is identical; it previously had no unit test, now covered.
- **Unify `report()` to the full-set denominator** `len(finals)+len(fails)` in both MMLU tasks (pipeline failures scored wrong), matching the `gsm8k_0shot_gen` family; only shifts a reported number when `fails>0`.
- core: extend the empty-infer anomaly rule to `clp`/`top_logprobs`; add `choice_scores_from_top_logprobs` to `core/utils/ppl`.
- Reference: hendrycks/test `evaluate_flan.py`; target = DeepSeek-V3 report Table 6 (Qwen2.5-72B Base, MMLU 5-shot = 85.0).


## Test Plan

### Automated

- [x] Lint/format clean (`ruff check && ruff format --check`)
- [x] Type check clean (`ty check` or `mypy --strict`)
- [x] Unit tests pass (`pdm run pytest`) <!-- delete if benchmark-only PR -->

### Manual

Model: Qwen2.5-72B (base) · sglang · tp=2 · 5-shot · logprobs=100

| Model | Expected  | Actual | Diff |
|---|---|---|---|
| Qwen2.5-72B-Base(5-shot) | 85.0(DeepSeek-V3 Report) | 86.11| +1.11(-1.11%) |

## Checklist

### Required (all PRs)

- [x] PR title follows conventional format (`type(scope): description`)
- [x] No internal paths, credentials, or personal info in committed files
- [x] AI-generated code has `AI-Generated Code - <model> (<provider>)` in module docstring
- [x] No new upper-layer dependencies added to `core/`
- [x] Deleted code verified — no remaining call sites depend on it

### If: New or Modified Benchmark

- [x] Reference paper/repo linked in Summary
- [x] Score comparison table included (model, expected, actual, diff)
- [x] Dataset loading tested (`sieval dataset download <name>` succeeds)
- [x] Task registered in package-level `__init__.py`

### If: Breaking Change

- [x] Described what breaks and migration path in Summary
- [x] Existing tests updated to reflect new behavior