### PR TITLE
feat(hellaswag): add dataset and few-shot ppl task

### DIFF
--- a/sieval/community/hellaswag.py
+++ b/sieval/community/hellaswag.py
@@ -1,0 +1,29 @@
+# adapted from https://github.com/EleutherAI/lm-evaluation-harness/blob/1dd931087362abba74e0375c8c631295559f48b2/lm_eval/tasks/hellaswag/utils.py
+
+import re
+from collections.abc import Mapping
+from typing import Any, TypedDict
+
+
+class ProcessedDoc(TypedDict):
+    query: str
+    choices: list[str]
+    gold: int
+
+
+def preprocess(text: str) -> str:
+    text = text.strip()
+    # NOTE: Brackets are artifacts of the WikiHow dataset portion of HellaSwag.
+    text = text.replace(" [title]", ". ")
+    text = re.sub(r"\[.*?\]", "", text)
+    text = text.replace("  ", " ")
+    return text
+
+
+def process_doc(doc: Mapping[str, Any]) -> ProcessedDoc:
+    ctx = doc["ctx_a"] + " " + doc["ctx_b"].capitalize()
+    return {
+        "query": preprocess(doc["activity_label"] + ": " + ctx),
+        "choices": [preprocess(ending) for ending in doc["endings"]],
+        "gold": int(doc["label"]),
+    }

--- a/sieval/datasets/__init__.pyi
+++ b/sieval/datasets/__init__.pyi
@@ -29,6 +29,10 @@ from .gsm8k import (
     GSM8KDataset,
     GSM8KDatasetSample,
 )
+from .hellaswag import (
+    HellaSwagDataset,
+    HellaSwagDatasetSample,
+)
 from .hmmt_feb_2025 import (
     HMMTFeb2025Dataset,
     HMMTFeb2025DatasetSample,
@@ -109,6 +113,8 @@ __all__ = [
     "HMMTFeb2025DatasetSample",
     "HMMTFeb2026Dataset",
     "HMMTFeb2026DatasetSample",
+    "HellaSwagDataset",
+    "HellaSwagDatasetSample",
     "HumanEvalDataset",
     "HumanEvalDatasetSample",
     "IFBenchDataset",

--- a/sieval/datasets/hellaswag.py
+++ b/sieval/datasets/hellaswag.py
@@ -1,0 +1,65 @@
+"""
+HellaSwag dataset — commonsense sentence completion (4-way multiple choice).
+
+Mirrors the native ``Rowan/hellaswag`` parquet schema as-is. The lm-eval-harness
+query/choice text construction lives in the task layer
+(``sieval.community.hellaswag``), not here, so the loader stays a faithful source
+mirror (per the dataset-layer rule "load() must mirror the source as-is").
+
+Default eval split is ``validation``: HellaSwag withholds the ``test`` labels
+(the native ``test`` split ships with empty ``label`` strings), so ``test`` cannot
+be scored. Override via the ``eval_split`` load kwarg.
+
+AI-Generated Code - Claude Opus 4.8 (Anthropic)
+"""
+
+from typing import TypedDict, override
+
+from datasets import DatasetDict as HFDatasetDict
+from datasets import load_dataset
+
+from sieval.core.datasets import (
+    Category,
+    Dataset,
+    Level1Category,
+    sieval_dataset,
+)
+from sieval.core.utils.hf import apply_eval_split, ensure_dataset_dict
+
+HELLASWAG_REVISION = "218ec52e09a7e7462a5400043bb9a69a41d06b76"
+
+
+class HellaSwagDatasetSample(TypedDict):
+    ind: int
+    activity_label: str
+    ctx_a: str
+    ctx_b: str
+    ctx: str
+    endings: list[str]
+    source_id: str
+    split: str
+    split_type: str
+    label: str
+
+
+@sieval_dataset(
+    name="hellaswag",
+    display_name="HellaSwag",
+    description="Commonsense sentence completion — pick the most plausible ending.",
+    source=f"hf:Rowan/hellaswag@{HELLASWAG_REVISION}",
+    categories=(Category(Level1Category.KNOWLEDGE, "CommonSense"),),
+    tags=("english", "multiple-choice", "commonsense"),
+    license="MIT",
+)
+class HellaSwagDataset(Dataset[HellaSwagDatasetSample]):
+    @override
+    def load(
+        self,
+        name_or_path: str,
+        *,
+        eval_split: str | None = "validation",
+        **kwargs,
+    ) -> HFDatasetDict:
+        dataset = load_dataset(name_or_path, **kwargs)
+        dataset = ensure_dataset_dict(dataset)
+        return apply_eval_split(dataset, eval_split)

--- a/sieval/meta/index.json
+++ b/sieval/meta/index.json
@@ -163,6 +163,28 @@
       "checksums": {}
     },
     {
+      "name": "hellaswag",
+      "display_name": "HellaSwag",
+      "description": "Commonsense sentence completion — pick the most plausible ending.",
+      "source": [
+        "hf:Rowan/hellaswag@218ec52e09a7e7462a5400043bb9a69a41d06b76"
+      ],
+      "categories": [
+        {
+          "level1": "Knowledge",
+          "level2": "CommonSense"
+        }
+      ],
+      "tags": [
+        "english",
+        "multiple-choice",
+        "commonsense"
+      ],
+      "deps_group": null,
+      "license": "MIT",
+      "checksums": {}
+    },
+    {
       "name": "hmmt_feb_2025",
       "display_name": "HMMT Feb 2025",
       "description": "Harvard-MIT Mathematics Tournament, February 2025, 30 problems.",
@@ -655,6 +677,27 @@
         "source": "lm-evaluation-harness",
         "url": "https://github.com/EleutherAI/lm-evaluation-harness/blob/1dd931087362abba74e0375c8c631295559f48b2/lm_eval/tasks/gsm8k/gsm8k.yaml",
         "notes": "Uses lm-eval-harness strict-match extraction, aligned with the original GSM8K dataset.py #### answer delimiter. Also reports lm-eval-harness flexible-extract as a secondary metric, not as the original GSM8K official metric. Default k=8 follows the DeepSeek-V3 Table 3 comparison target (Qwen2.5-72B-Base GSM8K 8-shot EM = 88.3); DeepSeek-V3 does not specify strict vs flexible extraction."
+      },
+      "status": "stable"
+    },
+    {
+      "name": "hellaswag_kshot_ppl",
+      "display_name": "HellaSwag (k-shot, log-likelihood)",
+      "description": "Commonsense sentence completion via per-ending log-likelihood.",
+      "dataset": "hellaswag",
+      "eval_mode": "ppl",
+      "n_shot": 10,
+      "tags": [
+        "english",
+        "multiple-choice",
+        "commonsense"
+      ],
+      "deps_group": null,
+      "model_type": "gen",
+      "reference_impl": {
+        "source": "lm-evaluation-harness",
+        "url": "https://github.com/EleutherAI/lm-evaluation-harness/blob/1dd931087362abba74e0375c8c631295559f48b2/lm_eval/tasks/hellaswag/hellaswag.yaml",
+        "notes": "multiple_choice log-likelihood; acc + acc_norm (character-length normalized, reported as score). Few-shot exemplars (k, default 10) sampled from train, rendered 'query gold_ending' and joined by blank lines per lm-eval; k=0 is 0-shot. Continuation log-probs read via echoed alogprobs; context/continuation split by char offset (no tokenizer at this layer)."
       },
       "status": "stable"
     },

--- a/sieval/meta/index.json
+++ b/sieval/meta/index.json
@@ -697,7 +697,7 @@
       "reference_impl": {
         "source": "lm-evaluation-harness",
         "url": "https://github.com/EleutherAI/lm-evaluation-harness/blob/1dd931087362abba74e0375c8c631295559f48b2/lm_eval/tasks/hellaswag/hellaswag.yaml",
-        "notes": "multiple_choice log-likelihood; acc + acc_norm (character-length normalized, reported as score). Few-shot exemplars (k, default 10) sampled from train, rendered 'query gold_ending' and joined by blank lines per lm-eval; k=0 is 0-shot. Continuation log-probs read via echoed alogprobs; context/continuation split by char offset (no tokenizer at this layer)."
+        "notes": "multiple_choice log-likelihood; acc + acc_norm (character-length normalized, reported as score). Few-shot exemplars (k, default 10) sampled from train, rendered 'query gold_ending' and joined by blank lines per lm-eval; k=0 is 0-shot. Continuation log-probs read via echoed alogprobs; context/continuation split by char offset (no tokenizer at this layer). Infra requirement: echo scoring reads the prompt's input logprobs, so the serving backend's prefix caching must be disabled (cached positions are not recomputed -> truncated logprobs); the backend layer owns the specific flag."
       },
       "status": "stable"
     },

--- a/sieval/tasks/__init__.pyi
+++ b/sieval/tasks/__init__.pyi
@@ -25,6 +25,9 @@ from .gsm8k_0shot_gen import (
 from .gsm8k_kshot_base_gen import (
     GSM8KFewShotBaseGenTask,
 )
+from .hellaswag_kshot_ppl import (
+    HellaSwagFewShotPPLTask,
+)
 from .hmmt_feb_2025_0shot_gen import (
     HMMTFeb2025ZeroShotGenTask,
 )
@@ -88,6 +91,7 @@ __all__ = [
     "GSM8KZeroShotGenTask",
     "HMMTFeb2025ZeroShotGenTask",
     "HMMTFeb2026ZeroShotGenTask",
+    "HellaSwagFewShotPPLTask",
     "HumanEvalZeroShotBaseGenTask",
     "HumanEvalZeroShotGenTask",
     "IFBenchZeroShotGenTask",

--- a/sieval/tasks/hellaswag_kshot_ppl.py
+++ b/sieval/tasks/hellaswag_kshot_ppl.py
@@ -21,12 +21,13 @@ maps the digit ``label`` to an int (``ast.literal_eval`` when ``isdigit()`` and
 ending text), not the index; ``labeled_examples`` carries the trailing delimiter.
 The exact assembled context is byte-pinned by the ``k=1``/``k=2`` tests.
 
-Comparison target: the DeepSeek-V3 report (Table 6) lists Qwen2.5-72B-Base
-HellaSwag = 84.8. That number comes from DeepSeek's internal harness and its
-exact protocol (prompt / acc-vs-acc_norm / shot count) is not fully specified,
-so this lm-eval-aligned ``acc_norm`` (10-shot) task is expected to land *near*
-84.8 rather than match it exactly — a few-point, different-harness gap is not a
-reproduction failure.
+Validated: Qwen2.5-72B-Base, 10-shot, ``acc_norm`` 87.4 over the full
+10042-sample validation split, ``fails=0``, deterministic (two byte-identical
+runs). Comparison target (cross-check only): the DeepSeek-V3 report (Table 6)
+lists Qwen2.5-72B-Base HellaSwag = 84.8 — from DeepSeek's internal harness with
+an underspecified protocol (prompt / acc-vs-``acc_norm`` / shot count), so the
+~2.6-pt gap is a different-harness delta, not a reproduction failure. The
+reproduced method is lm-eval ``hellaswag`` (``acc_norm``).
 
 Query/choice construction is the lm-eval ``process_docs`` logic, factored into
 ``sieval.community.hellaswag`` (``preprocess`` + ``process_doc``), applied to both
@@ -168,7 +169,10 @@ def _argmax(values: list[float]) -> int:
             "sampled from train, rendered 'query gold_ending' and joined by "
             "blank lines per lm-eval; k=0 is 0-shot. Continuation log-probs read "
             "via echoed alogprobs; context/continuation split by char offset "
-            "(no tokenizer at this layer)."
+            "(no tokenizer at this layer). Infra requirement: echo scoring reads "
+            "the prompt's input logprobs, so the serving backend's prefix caching "
+            "must be disabled (cached positions are not recomputed -> truncated "
+            "logprobs); the backend layer owns the specific flag."
         ),
     ),
 )
@@ -264,7 +268,9 @@ class HellaSwagFewShotPPLTask(
     @override
     async def report(self, finals, fails):
         # Denominator counts pipeline failures as wrong (full-set accuracy),
-        # matching the sibling family and upstream — a regression test locks it.
+        # matching the `mbpp` sibling. (The MCQ siblings openbookqa/cmmlu instead
+        # exclude fails, and lm-eval has no pipeline-failure concept — this is a
+        # deliberate choice, moot here since fails=0.) A regression test locks it.
         total = len(finals) + len(fails)
         if total == 0:
             return {"score": 0.0, "acc": 0.0, "acc_norm": 0.0, "fails": 0}

--- a/sieval/tasks/hellaswag_kshot_ppl.py
+++ b/sieval/tasks/hellaswag_kshot_ppl.py
@@ -1,0 +1,308 @@
+"""
+HellaSwag k-shot log-likelihood (PPL) task — commonsense sentence completion.
+
+Aligned with the EleutherAI lm-evaluation-harness ``hellaswag`` task
+(``output_type: multiple_choice``): for each of the 4 endings the conditional
+log-probability of the ending given the context is scored, then ``acc`` is the
+argmax over the raw log-prob sums and ``acc_norm`` is the argmax over the
+character-length-normalized sums (the headline HellaSwag metric, reported as
+``score``).
+
+Few-shot (``k`` > 0) replicates lm-eval's ``ConfigurableTask`` few-shot assembly
+for multiple-choice: ``k`` labeled examples sampled from the ``train`` split,
+each rendered as ``query + " " + gold_ending`` (``target_delimiter`` = " "; the
+few-shot target is the gold *choice text*, not the label index), joined by
+``"\\n\\n"`` (``fewshot_delimiter``) with a trailing ``"\\n\\n"``, then the target
+query, with no leading description. ``k=0`` reproduces the 0-shot form. This
+assembly is byte-verified against the reference-commit source: hellaswag
+overrides neither delimiter (defaults ``" "`` / ``"\n\n"``); ``doc_to_target``
+maps the digit ``label`` to an int (``ast.literal_eval`` when ``isdigit()`` and
+``doc_to_choice`` is set), so the rendered answer is ``choices[label]`` (the gold
+ending text), not the index; ``labeled_examples`` carries the trailing delimiter.
+The exact assembled context is byte-pinned by the ``k=1``/``k=2`` tests.
+
+Comparison target: the DeepSeek-V3 report (Table 6) lists Qwen2.5-72B-Base
+HellaSwag = 84.8. That number comes from DeepSeek's internal harness and its
+exact protocol (prompt / acc-vs-acc_norm / shot count) is not fully specified,
+so this lm-eval-aligned ``acc_norm`` (10-shot) task is expected to land *near*
+84.8 rather than match it exactly — a few-point, different-harness gap is not a
+reproduction failure.
+
+Query/choice construction is the lm-eval ``process_docs`` logic, factored into
+``sieval.community.hellaswag`` (``preprocess`` + ``process_doc``), applied to both
+the exemplars and the target doc. Per choice the continuation log-prob is read
+from an echoed ``alogprobs`` call on ``context + " " + ending``.
+
+Deviations from lm-eval-harness:
+- lm-eval splits context/continuation at the token-id level
+  (``len(tok_encode(context))``); this layer has no tokenizer, so the continuation
+  tokens are isolated by reconstructing character offsets over the echoed token
+  texts (``_continuation_logprob``). Equivalent under faithful detokenization
+  with the space delimiter (clean token boundary).
+- ``alogprobs`` scores with ``max_tokens=1`` (lm-eval uses 0, pure echo), so the
+  echoed response carries one trailing generated token; it is dropped by bounding
+  the continuation char span at ``len(prompt)``.
+- Exemplar *selection* differs: we draw one fixed set via
+  ``Dataset.retrieve_samples`` (seed 1234), computed once in ``setup()`` and
+  reused for every eval doc (repo convention); lm-eval draws via its own
+  ``ContextSampler`` RNG. Both are ``k`` random train exemplars and the assembly
+  *format* is identical (verified above), so the aggregate ``acc_norm`` is robust
+  to the draw — only the specific exemplars chosen differ.
+
+Repro decoding: deterministic log-prob scoring — ``alogprobs`` uses
+``temperature=0`` and ``echo=True``; no sampling params apply.
+
+AI-Generated Code - Claude Opus 4.8 (Anthropic)
+"""
+
+from typing import TypedDict, override
+
+from sieval.community.hellaswag import process_doc
+from sieval.core.models import ModelOutput
+from sieval.core.tasks import (
+    EvalMode,
+    ReferenceImpl,
+    Task,
+    sieval_task,
+)
+from sieval.core.utils.ppl import total_logprob
+from sieval.datasets import HellaSwagDatasetSample
+
+N_SHOT = 10
+DEFAULT_FEWSHOT_SEED = 1234
+FEWSHOT_SPLIT = "train"
+FEWSHOT_DELIMITER = "\n\n"
+
+
+class Preprocessed(TypedDict):
+    context: str  # few-shot prefix + target query
+    choices: list[str]
+    gold: int
+
+
+class Prediction(TypedDict):
+    pred_acc: int
+    pred_acc_norm: int
+    logprobs: list[float]
+    norm_logprobs: list[float]
+
+
+class Feedback(TypedDict):
+    acc: bool
+    acc_norm: bool
+    gold: int
+    pred_acc: int
+    pred_acc_norm: int
+
+
+def _continuation_logprob(
+    tokens: list[str] | None,
+    token_logprobs: list[float | None] | None,
+    *,
+    prompt: str,
+    context_char_len: int,
+) -> float:
+    """Sum the echoed log-probs of the continuation tokens of *prompt*.
+
+    The continuation is ``prompt[context_char_len:]`` (the ``" " + ending``).
+    Tokens are located by reconstructing cumulative character offsets over the
+    echoed token texts, in prompt-relative coordinates: any BOS prefix or
+    trailing generated token is handled by anchoring on where *prompt* appears
+    in the detokenized stream and bounding the span at ``len(prompt)``.
+
+    Raises ``RuntimeError`` if the continuation cannot be isolated (empty
+    logprobs, prompt not found in the detokenized stream, or no continuation
+    token in range) — echo scoring must fail loud rather than score a
+    mislocated/partial span silently.
+    """
+    if not tokens or not token_logprobs:
+        raise RuntimeError("sglang returned empty echoed logprobs; cannot score.")
+    size = min(len(tokens), len(token_logprobs))
+    tokens = tokens[:size]
+    token_logprobs = token_logprobs[:size]
+
+    base = "".join(tokens).find(prompt)
+    if base < 0:
+        raise RuntimeError(
+            "cannot locate the prompt in the echoed token stream "
+            "(detokenization mismatch); continuation cannot be isolated."
+        )
+
+    cont_tokens: list[str] = []
+    cont_logprobs: list[float | None] = []
+    offset = 0
+    for tok, logprob in zip(tokens, token_logprobs, strict=True):
+        start = offset - base
+        end = start + len(tok)
+        offset += len(tok)
+        if start >= context_char_len and end <= len(prompt):
+            cont_tokens.append(tok)
+            cont_logprobs.append(logprob)
+
+    total, count = total_logprob(cont_tokens, cont_logprobs, skip_first=False)
+    if count == 0:
+        raise RuntimeError("no continuation tokens isolated; cannot score.")
+    return total
+
+
+def _argmax(values: list[float]) -> int:
+    return max(range(len(values)), key=lambda i: values[i])
+
+
+@sieval_task(
+    name="hellaswag_kshot_ppl",
+    display_name="HellaSwag (k-shot, log-likelihood)",
+    description="Commonsense sentence completion via per-ending log-likelihood.",
+    eval_mode=EvalMode.PPL,
+    n_shot=N_SHOT,
+    tags=("english", "multiple-choice", "commonsense"),
+    model_type="gen",
+    reference_impl=ReferenceImpl(
+        source="lm-evaluation-harness",
+        url=(
+            "https://github.com/EleutherAI/lm-evaluation-harness/blob/1dd931087362abba74e0375c8c631295559f48b2/lm_eval/tasks/hellaswag/hellaswag.yaml"
+        ),
+        notes=(
+            "multiple_choice log-likelihood; acc + acc_norm (character-length "
+            "normalized, reported as score). Few-shot exemplars (k, default 10) "
+            "sampled from train, rendered 'query gold_ending' and joined by "
+            "blank lines per lm-eval; k=0 is 0-shot. Continuation log-probs read "
+            "via echoed alogprobs; context/continuation split by char offset "
+            "(no tokenizer at this layer)."
+        ),
+    ),
+)
+class HellaSwagFewShotPPLTask(
+    Task[
+        HellaSwagDatasetSample,
+        Preprocessed,
+        list[ModelOutput],
+        Prediction,
+        Feedback,
+        dict[str, float],
+    ]
+):
+    def __init__(
+        self,
+        dataset,
+        model,
+        name: str | None = None,
+        *,
+        k: int = N_SHOT,
+        fewshot_split: str = FEWSHOT_SPLIT,
+        fewshot_seed: int = DEFAULT_FEWSHOT_SEED,
+    ):
+        if k < 0:
+            raise ValueError(f"k must be >= 0, got {k}")
+        super().__init__(dataset=dataset, model=model, name=name)
+        self._k = k
+        self._fewshot_split = fewshot_split
+        self._fewshot_seed = fewshot_seed
+        # Built once in setup() (framework contract: runs before any sample);
+        # "" is the k=0 prefix and a typed placeholder never observed post-setup.
+        self._fewshot_prefix: str = ""
+
+    @override
+    async def setup(self) -> None:
+        self._fewshot_prefix = self._build_fewshot_prefix()
+
+    @override
+    async def preprocess(self, raw, ctx):
+        doc = process_doc(raw)
+        context = self._fewshot_prefix + doc["query"]
+        return {"context": context, "choices": doc["choices"], "gold": doc["gold"]}
+
+    @override
+    async def infer(self, pre, ctx):
+        context = pre["context"]
+        # echo=True is structural to PPL scoring: it returns the conditional
+        # log-prob of every echoed continuation token (one call per ending).
+        # logprobs=0: we only read each token's own log-prob, never the top-k
+        # alternatives, so skip that extraction/payload over the whole prompt
+        # (sglang: top_logprobs_num=0; input_token_logprobs are still returned).
+        return [
+            await self.model.alogprobs(f"{context} {choice}", echo=True, logprobs=0)
+            for choice in pre["choices"]
+        ]
+
+    @override
+    async def postprocess(self, inf, ctx):
+        pre = ctx.preprocess_result
+        context = pre["context"]
+
+        logprobs: list[float] = []
+        norm_logprobs: list[float] = []
+        for choice, out in zip(pre["choices"], inf, strict=True):
+            ll = _continuation_logprob(
+                out.logprobs_tokens,
+                out.logprobs,
+                prompt=f"{context} {choice}",
+                context_char_len=len(context),
+            )
+            logprobs.append(ll)
+            # lm-eval acc_norm divides by the choice character length (no delimiter)
+            norm_logprobs.append(ll / len(choice) if choice else ll)
+
+        return {
+            "pred_acc": _argmax(logprobs),
+            "pred_acc_norm": _argmax(norm_logprobs),
+            "logprobs": logprobs,
+            "norm_logprobs": norm_logprobs,
+        }
+
+    @override
+    async def feedback(self, post, ctx):
+        gold = ctx.preprocess_result["gold"]
+        return True, {
+            "acc": post["pred_acc"] == gold,
+            "acc_norm": post["pred_acc_norm"] == gold,
+            "gold": gold,
+            "pred_acc": post["pred_acc"],
+            "pred_acc_norm": post["pred_acc_norm"],
+        }
+
+    @override
+    async def report(self, finals, fails):
+        # Denominator counts pipeline failures as wrong (full-set accuracy),
+        # matching the sibling family and upstream — a regression test locks it.
+        total = len(finals) + len(fails)
+        if total == 0:
+            return {"score": 0.0, "acc": 0.0, "acc_norm": 0.0, "fails": 0}
+        acc_num = sum(1 for ctx in finals if ctx.feedback_result["acc"])
+        acc_norm_num = sum(1 for ctx in finals if ctx.feedback_result["acc_norm"])
+        acc = 100 * acc_num / total
+        acc_norm = 100 * acc_norm_num / total
+        return {
+            "score": acc_norm,
+            "acc": acc,
+            "acc_norm": acc_norm,
+            "fails": len(fails),
+        }
+
+    def _build_fewshot_prefix(self) -> str:
+        if self._k == 0:
+            return ""
+        split = self.dataset.dataset_dict.get(self._fewshot_split)
+        if split is None:
+            raise ValueError(
+                "HellaSwag k-shot PPL task requires a "
+                f"{self._fewshot_split!r} split for few-shot exemplars."
+            )
+        if len(split) < self._k:
+            raise ValueError(
+                "HellaSwag k-shot PPL task requires at least "
+                f"{self._k} examples in split {self._fewshot_split!r}; "
+                f"found {len(split)}."
+            )
+        examples = self.dataset.retrieve_samples(
+            self._k,
+            split=self._fewshot_split,
+            mode="random",
+            seed=self._fewshot_seed,
+        )
+        rendered = []
+        for example in examples:
+            doc = process_doc(example)
+            gold_ending = doc["choices"][doc["gold"]]
+            rendered.append(f"{doc['query']} {gold_ending}")
+        return FEWSHOT_DELIMITER.join(rendered) + FEWSHOT_DELIMITER

--- a/tests/unit/community/test_hellaswag.py
+++ b/tests/unit/community/test_hellaswag.py
@@ -1,0 +1,55 @@
+"""Pinning tests for the HellaSwag lm-eval preprocessing adaptation.
+
+AI-Generated Code - Claude Opus 4.8 (Anthropic)
+"""
+
+from sieval.community.hellaswag import preprocess, process_doc
+
+
+def test_preprocess_strip_and_title_marker():
+    # " [title]" -> ". "  (and surrounding whitespace stripped)
+    assert preprocess("  Climbing [title] the wall  ") == "Climbing. the wall"
+
+
+def test_preprocess_removes_bracketed_artifacts():
+    assert preprocess("clean [substeps] this") == "clean this"
+    # bracket at the very start: strip() runs BEFORE removal, so the resulting
+    # leading space is NOT re-stripped (faithful to lm-eval; no "  " to collapse).
+    assert preprocess("[header] lead") == " lead"
+
+
+def test_preprocess_double_space_collapse_is_single_pass():
+    # lm-eval applies ONE replace("  ", " "); 4 spaces collapse to 2, not 1.
+    assert preprocess("a    b") == "a  b"
+
+
+def test_process_doc_builds_query_choices_gold():
+    doc = {
+        "activity_label": "Roof shingle removal",
+        "ctx_a": "A man is sitting on a roof.",
+        "ctx_b": "he starts pulling up roofing on a roof.",
+        "endings": [
+            "is ripping [title] up the shingles.",
+            "holds a stick.",
+        ],
+        "label": "1",
+    }
+    out = process_doc(doc)
+    assert out["query"] == (
+        "Roof shingle removal: A man is sitting on a roof. "
+        "He starts pulling up roofing on a roof."
+    )
+    assert out["choices"] == ["is ripping. up the shingles.", "holds a stick."]
+    assert out["gold"] == 1
+
+
+def test_process_doc_capitalize_lowercases_rest_of_ctx_b():
+    # str.capitalize() upper-cases the first char and LOWER-cases the rest.
+    doc = {
+        "activity_label": "X",
+        "ctx_a": "A.",
+        "ctx_b": "iPhone IS here",
+        "endings": ["e"],
+        "label": "0",
+    }
+    assert process_doc(doc)["query"] == "X: A. Iphone is here"

--- a/tests/unit/datasets/test_hellaswag.py
+++ b/tests/unit/datasets/test_hellaswag.py
@@ -1,0 +1,73 @@
+"""Unit tests for the HellaSwag dataset loader.
+
+AI-Generated Code - Claude Opus 4.8 (Anthropic)
+"""
+
+from datasets import Dataset as HFDataset
+from datasets import DatasetDict as HFDatasetDict
+
+from sieval.datasets import hellaswag as hs
+from sieval.datasets.hellaswag import HellaSwagDataset
+
+_COLUMNS = {
+    "ind",
+    "activity_label",
+    "ctx_a",
+    "ctx_b",
+    "ctx",
+    "endings",
+    "source_id",
+    "split",
+    "split_type",
+    "label",
+}
+
+
+def _row(label: str) -> dict:
+    return {
+        "ind": 0,
+        "activity_label": "Removing ice from car",
+        "ctx_a": "A woman is outside.",
+        "ctx_b": "she",
+        "ctx": "A woman is outside. she",
+        "endings": ["a", "b", "c", "d"],
+        "source_id": "activitynet~v_x",
+        "split": "val",
+        "split_type": "indomain",
+        "label": label,
+    }
+
+
+def _fake_dict() -> HFDatasetDict:
+    return HFDatasetDict(
+        {
+            "train": HFDataset.from_list([_row("0")]),
+            "validation": HFDataset.from_list([_row("2")]),
+            "test": HFDataset.from_list([_row("")]),  # HellaSwag withholds test labels
+        }
+    )
+
+
+def test_load_defaults_eval_split_to_validation(monkeypatch):
+    monkeypatch.setattr(hs, "load_dataset", lambda *a, **k: _fake_dict())
+    ds = HellaSwagDataset(name_or_path="Rowan/hellaswag")
+    test_split = ds.dataset_dict["test"]
+    # the eval split ("test") now carries the LABELED validation rows
+    assert test_split[0]["label"] == "2"
+    # mirror: native schema preserved exactly (no columns added/removed)
+    assert set(test_split.column_names) == _COLUMNS
+
+
+def test_load_respects_explicit_eval_split_test(monkeypatch):
+    monkeypatch.setattr(hs, "load_dataset", lambda *a, **k: _fake_dict())
+    ds = HellaSwagDataset(name_or_path="Rowan/hellaswag", eval_split="test")
+    # native (label-less) test split kept unchanged — no remap when eval_split == "test"
+    assert ds.dataset_dict["test"][0]["label"] == ""
+
+
+def test_load_mirrors_source_without_preprocessing(monkeypatch):
+    monkeypatch.setattr(hs, "load_dataset", lambda *a, **k: _fake_dict())
+    ds = HellaSwagDataset(name_or_path="Rowan/hellaswag")
+    # ctx_b stays raw ("she"), NOT capitalized — query construction is task-side
+    assert ds.dataset_dict["test"][0]["ctx_b"] == "she"
+    assert ds.dataset_dict["train"][0]["label"] == "0"

--- a/tests/unit/tasks/test_hellaswag_kshot_ppl.py
+++ b/tests/unit/tasks/test_hellaswag_kshot_ppl.py
@@ -1,0 +1,299 @@
+"""Unit tests for the HellaSwag k-shot log-likelihood (PPL) task.
+
+AI-Generated Code - Claude Opus 4.8 (Anthropic)
+"""
+
+import pytest
+from datasets import Dataset as HFDataset
+from datasets import DatasetDict as HFDatasetDict
+
+from sieval.core.models import ModelOutput
+from sieval.core.models.gen_model import GenModel
+from sieval.core.tasks import TaskContext
+from sieval.datasets.hellaswag import HellaSwagDataset
+from sieval.tasks.hellaswag_kshot_ppl import (
+    HellaSwagFewShotPPLTask,
+    _argmax,
+    _continuation_logprob,
+)
+
+QUERY = "Activity label: a person"
+# Chosen so raw-LL argmax (acc) and length-normalized argmax (acc_norm) DIVERGE.
+CHOICES = ["ab", "cdcde", "x" * 30, "y" * 10]  # char lengths 2, 5, 30, 10
+LLS = [-1.0, -5.0, -3.0, -4.0]  # norms: -0.50, -1.00, -0.10, -0.40
+# acc -> argmax(LL) = 0 ; acc_norm -> argmax(LL / len) = 2
+GOLD = 2
+
+
+def _doc(activity: str, ctx_a: str, ctx_b: str, endings: list[str], label: str) -> dict:
+    return {
+        "ind": 0,
+        "activity_label": activity,
+        "ctx_a": ctx_a,
+        "ctx_b": ctx_b,
+        "ctx": f"{ctx_a} {ctx_b}",
+        "endings": endings,
+        "source_id": "s",
+        "split": "train",
+        "split_type": "t",
+        "label": label,
+    }
+
+
+TRAIN_A = _doc(
+    "Cooking", "She cracks an egg.", "the woman", ["pours it in.", "x", "y", "z"], "0"
+)
+TRAIN_B = _doc(
+    "Driving", "He starts the car.", "the man", ["drives away.", "x", "y", "z"], "0"
+)
+RENDERED_A = "Cooking: She cracks an egg. The woman pours it in."
+RENDERED_B = "Driving: He starts the car. The man drives away."
+
+
+def _crafted_output(
+    model: GenModel, prompt: str, choice: str, ll: float
+) -> ModelOutput:
+    """Echoed logprobs for *prompt* (= context + ' ' + choice) summing to *ll*.
+
+    Layout stresses the helper: a non-empty leading BOS token, the (arbitrary,
+    possibly few-shot-prefixed) context as one token, the continuation split
+    across two tokens, and a trailing generated token (``max_tokens=1``).
+    """
+    context = prompt[: len(prompt) - len(choice) - 1]  # strip trailing " " + choice
+    cont = " " + choice
+    mid = max(1, len(cont) // 2)
+    part1, part2 = cont[:mid], cont[mid:]
+    tokens = ["<s>", context, part1, part2, "<gen>"]
+    logprobs = [None, -42.0, ll / 2, ll / 2, -99.0]
+    return ModelOutput(
+        model=model.meta(),
+        texts=["<gen>"],
+        logprobs_tokens=tokens,
+        logprobs=logprobs,
+    )
+
+
+class _PPLMockModel(GenModel):
+    def __init__(self, choices: list[str], lls: list[float]):
+        super().__init__(model="mock-gen", api_key="fake")
+        self._ll_by_choice: dict[str, float] = dict(zip(choices, lls, strict=True))
+        self.calls: list[str] = []
+        self.echos: list[bool] = []
+        self.logprobs_args: list[int] = []
+
+    async def _agenerate_impl(self, prompt: str, **kwargs) -> ModelOutput:
+        _ = (prompt, kwargs)
+        return ModelOutput(model=self.meta(), texts=[""])
+
+    async def _alogprobs_impl(
+        self,
+        prompt: str,
+        *,
+        max_tokens: int = 1,
+        logprobs: int = 5,
+        echo: bool = True,
+        temperature: float = 0.0,
+        **kwargs,
+    ) -> ModelOutput:
+        _ = (max_tokens, temperature, kwargs)
+        self.calls.append(prompt)
+        self.echos.append(echo)
+        self.logprobs_args.append(logprobs)
+        # CHOICES are mutually non-suffix, so exactly one endswith-matches.
+        choice = next(c for c in self._ll_by_choice if prompt.endswith(c))
+        return _crafted_output(self, prompt, choice, self._ll_by_choice[choice])
+
+
+def _make_task(
+    k: int = 0, train_docs: list[dict] | None = None
+) -> tuple[HellaSwagFewShotPPLTask, _PPLMockModel]:
+    splits = {
+        "test": HFDataset.from_list([_doc("T", "A.", "he", ["a", "b", "c", "d"], "0")])
+    }
+    if train_docs is not None:
+        splits["train"] = HFDataset.from_list(train_docs)
+    dataset = HellaSwagDataset(_hf_dict=HFDatasetDict(splits))
+    model = _PPLMockModel(CHOICES, LLS)
+    return HellaSwagFewShotPPLTask(dataset, model, k=k), model
+
+
+def _pre(context: str = QUERY) -> dict:
+    return {"context": context, "choices": CHOICES, "gold": GOLD}
+
+
+# ---------------------------------------------------------------- helper units
+
+
+def test_continuation_logprob_isolates_continuation_with_bos_and_gen_tail():
+    prompt = f"{QUERY} {CHOICES[0]}"
+    tokens = ["<s>", QUERY, " ", CHOICES[0], "<gen>"]
+    logprobs = [None, -42.0, -0.4, -0.6, -99.0]
+    ll = _continuation_logprob(
+        tokens, logprobs, prompt=prompt, context_char_len=len(QUERY)
+    )
+    assert ll == pytest.approx(-1.0)
+
+
+def test_continuation_logprob_clean_stream_no_bos():
+    prompt = "abc de"
+    tokens = ["abc", " de", "Z"]
+    logprobs = [-1.0, -2.0, -7.0]
+    ll = _continuation_logprob(tokens, logprobs, prompt=prompt, context_char_len=3)
+    assert ll == pytest.approx(-2.0)
+
+
+def test_continuation_logprob_empty_raises():
+    # empty echoed logprobs → loud fail, never a silent -inf that mis-scores
+    with pytest.raises(RuntimeError):
+        _continuation_logprob(None, None, prompt="x", context_char_len=0)
+
+
+def test_continuation_logprob_raises_when_prompt_not_located():
+    # tokens don't reconstruct the prompt → cannot isolate continuation → raise
+    with pytest.raises(RuntimeError):
+        _continuation_logprob(
+            ["foo", "bar"], [-1.0, -2.0], prompt="unrelated text", context_char_len=3
+        )
+
+
+def test_argmax_returns_first_index_on_ties():
+    assert _argmax([-1.0, -1.0, -2.0]) == 0
+    assert _argmax([-3.0, -0.5, -0.5]) == 1
+
+
+# ----------------------------------------------------------- few-shot prefix
+
+
+def test_k_negative_rejected():
+    dataset = HellaSwagDataset(
+        _hf_dict=HFDatasetDict(
+            {
+                "test": HFDataset.from_list(
+                    [_doc("T", "A.", "h", ["a", "b", "c", "d"], "0")]
+                )
+            }
+        )
+    )
+    with pytest.raises(ValueError, match="k must be >= 0"):
+        HellaSwagFewShotPPLTask(dataset, _PPLMockModel(CHOICES, LLS), k=-1)
+
+
+@pytest.mark.anyio
+async def test_k0_context_is_just_the_query():
+    task, _ = _make_task(k=0)
+    await task.setup()
+    raw = _doc("X", "A.", "he", ["one", "two", "three", "four"], "2")
+    pre = await task.preprocess(raw, TaskContext(sample_id=0, raw_sample=raw))
+    assert pre["context"] == "X: A. He"  # no prefix
+    assert pre["gold"] == 2
+
+
+@pytest.mark.anyio
+async def test_k1_fewshot_prefix_rendered_query_space_gold_ending():
+    task, _ = _make_task(k=1, train_docs=[TRAIN_A])
+    await task.setup()
+    assert task._fewshot_prefix == f"{RENDERED_A}\n\n"
+
+    raw = _doc("X", "A.", "he", ["one", "two", "three", "four"], "2")
+    pre = await task.preprocess(raw, TaskContext(sample_id=0, raw_sample=raw))
+    # byte-identical to lm-eval's few-shot assembly: `query + " " + gold_ending`,
+    # "\n\n"-joined with trailing "\n\n", then the target query (no description).
+    assert pre["context"] == f"{RENDERED_A}\n\nX: A. He"
+
+
+@pytest.mark.anyio
+async def test_k2_prefix_joins_two_exemplars_with_blank_lines():
+    task, _ = _make_task(k=2, train_docs=[TRAIN_A, TRAIN_B])
+    await task.setup()
+    prefix = task._fewshot_prefix
+    parts = prefix.split("\n\n")
+    assert prefix.endswith("\n\n")
+    assert parts[-1] == ""  # trailing delimiter
+    assert set(parts[:-1]) == {RENDERED_A, RENDERED_B}  # order-independent
+
+
+def test_build_fewshot_prefix_raises_when_train_too_small():
+    task, _ = _make_task(k=3, train_docs=[TRAIN_A])  # only 1 < 3
+    with pytest.raises(ValueError, match="at least 3 examples"):
+        task._build_fewshot_prefix()
+
+
+# ----------------------------------------------------------------- pipeline
+
+
+@pytest.mark.anyio
+async def test_infer_prepends_prefix_and_issues_one_echo_call_per_choice():
+    task, model = _make_task(k=1, train_docs=[TRAIN_A])
+    await task.setup()
+    prefix = task._fewshot_prefix
+    pre = _pre(context=f"{prefix}{QUERY}")
+    out = await task.infer(pre, TaskContext(sample_id=0, preprocess_result=pre))
+    assert len(out) == len(CHOICES)
+    assert all(call.startswith(prefix) for call in model.calls)
+    assert model.calls == [f"{prefix}{QUERY} {c}" for c in CHOICES]
+    assert model.echos == [True] * len(CHOICES)
+    # top-k logprobs are never read → not requested (cheaper over a long prompt)
+    assert model.logprobs_args == [0] * len(CHOICES)
+
+
+@pytest.mark.anyio
+async def test_acc_and_acc_norm_diverge_and_score_is_acc_norm():
+    task, _ = _make_task(k=0)
+    pre = _pre()
+    inf = await task.infer(pre, TaskContext(sample_id=0, preprocess_result=pre))
+    ctx = TaskContext(sample_id=0, preprocess_result=pre, infer_result=inf)
+
+    post = await task.postprocess(inf, ctx)
+    assert post["pred_acc"] == 0  # argmax raw log-likelihood
+    assert post["pred_acc_norm"] == 2  # argmax length-normalized log-likelihood
+
+    finalize, fb = await task.feedback(post, ctx)
+    assert finalize is True
+    assert fb["acc"] is False  # 0 != gold(2)
+    assert fb["acc_norm"] is True  # 2 == gold(2)
+
+    report = await task.report(
+        [TaskContext(sample_id=0, preprocess_result=pre, feedback_result=fb)], []
+    )
+    assert report["acc"] == 0.0
+    assert report["acc_norm"] == 100.0
+    assert report["score"] == report["acc_norm"]  # headline metric is acc_norm
+    assert report["fails"] == 0
+
+
+@pytest.mark.anyio
+async def test_fewshot_scoring_unaffected_by_prefix():
+    # With a k=1 prefix, continuation isolation still scores only the ending,
+    # so the acc/acc_norm predictions match the k=0 case.
+    task, _ = _make_task(k=1, train_docs=[TRAIN_A])
+    await task.setup()
+    prefix = task._fewshot_prefix
+    pre = _pre(context=f"{prefix}{QUERY}")
+    inf = await task.infer(pre, TaskContext(sample_id=0, preprocess_result=pre))
+    post = await task.postprocess(
+        inf, TaskContext(sample_id=0, preprocess_result=pre, infer_result=inf)
+    )
+    assert post["pred_acc"] == 0
+    assert post["pred_acc_norm"] == 2
+
+
+@pytest.mark.anyio
+async def test_report_handles_empty_finals():
+    task, _ = _make_task(k=0)
+    report = await task.report([], [TaskContext(sample_id=0)])
+    assert report == {"score": 0.0, "acc": 0.0, "acc_norm": 0.0, "fails": 1}
+
+
+@pytest.mark.anyio
+async def test_report_counts_fails_in_denominator():
+    # 1 correct final + 1 pipeline fail → 50% (fails in denominator), not 100%.
+    # Locks against reverting to the old len(finals)-only denominator.
+    task, _ = _make_task(k=0)
+    fb = {"acc": True, "acc_norm": True, "gold": 0, "pred_acc": 0, "pred_acc_norm": 0}
+    finals = [TaskContext(sample_id=0, feedback_result=fb)]
+    fails = [TaskContext(sample_id=1)]
+    report = await task.report(finals, fails)
+    assert report["acc"] == 50.0
+    assert report["acc_norm"] == 50.0
+    assert report["score"] == 50.0
+    assert report["fails"] == 1


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Type

- feature — new benchmark, task, or capability

## Summary

- Add **HellaSwag** as a k-shot log-likelihood (PPL) task + dataset, aligned with
  EleutherAI **lm-evaluation-harness** `hellaswag` (https://github.com/EleutherAI/lm-evaluation-harness/tree/main/lm_eval/tasks/hellaswag): `multiple_choice` scoring — per-ending conditional log-prob, `acc` + `acc_norm` (headline = `acc_norm`), 0-shot..k-shot, validation split.
- Few-shot assembly is **byte-verified against lm-eval source** (delimiters `" "`/`"\n\n"`, gold *choice-text* answer via label→int→`choices[label]`, trailing delimiter, no description); only exemplar *selection* differs (our `retrieve_samples` vs lm-eval's `ContextSampler`) — documented as a deviation.
- Runs on the sglang backend via the official `SglangGenModel` (`engine: sglang`, #21); requires `--disable-radix-cache` for echo-logprob correctness.
- Continuation is isolated by char-offset (no tokenizer at this layer) and fails loud if it can't be located; report denominator counts pipeline failures (`len(finals)+len(fails)`).

## Test Plan

### Automated

- [x] Lint/format clean (`ruff check && ruff format --check`)
- [x] Type check clean (`ty check` or `mypy --strict`)
- [x] Unit tests pass (`pdm run pytest`) <!-- delete if benchmark-only PR -->

### Manual

- [x] Live run — Qwen2.5-72B-Base, 10-shot, sglang (`engine: sglang`, `--disable-radix-cache`):

  | Model  | Expected | Actual | Diff |
  |---|---|---|---|
  | Qwen2.5-72B-Base | 84.8 (DeepSeek-V3 report, Table 6) | 87.39| +2.59 (+2.59%) |

Target is from DeepSeek-V3's internal harness (protocol unspecified); this task follows lm-eval `acc_norm`, so a small different-harness gap is expected, not a repro miss.

## Checklist

### Required (all PRs)

- [x] PR title follows conventional format (`type(scope): description`)
- [x] No internal paths, credentials, or personal info in committed files
- [x] AI-generated code has `AI-Generated Code - <model> (<provider>)` in module docstring
- [x] No new upper-layer dependencies added to `core/`
- [x] Deleted code verified — no remaining call sites depend on it

### If: New or Modified Benchmark

- [x] Reference paper/repo linked in Summary
- [x] Score comparison table included (model, expected, actual, diff)
- [x] Dataset loading tested (`sieval dataset download <name>` succeeds)
- [x] Task registered in package-level `__init__.py`

### If: community/ Changes

- [x] Upstream diff documented (what differs and why)
- [x] License attribution preserved