### PR TITLE
docs: sync README/CLAUDE.md with current registry (+ t-eval deps_group fix)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ Precise reproducibility is a product contract, not a nicety.
 * Package manager: `pdm` — see `.claude/rules/deps.md` for lock procedures
 * Formatting & lint: `ruff`; type checking: `ty` (primary), `mypy` (strict mode, secondary)
 * Tests: `pytest`
-* CLI: `typer` — top-level shortcuts `sieval run`, `sieval eval`; resource groups `infer`, `leaderboard` (e.g. `sieval leaderboard report`, `sieval infer start`)
+* CLI: `typer` — top-level shortcuts `sieval run`, `sieval eval`; resource groups `dataset`, `task`, `infer`, `leaderboard` (e.g. `sieval dataset list`, `sieval infer start`)
 
 ## Layer Boundaries & Dependencies
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ SiEval is a **model delivery quality verification system** with an asynchronous 
 - **Asynchronous streaming** — process samples concurrently without waiting for batch completion
 - **Iterative feedback loop** — multi-turn evaluation with feedback
 - **Resilient persistence** — sharded, append-only storage for crash recovery
-- **21 registered benchmark datasets** — AIME 2024, AIME 2025, AIME 2026, CMMLU, DROP, GPQA-Diamond, GSM8K, HMMT Feb 2025, HMMT Feb 2026, HumanEval, IFBench, IFEval, IMO-AnswerBench, LiveCodeBench, MATH-500, MBPP, MMLU, MMLU-Pro, OpenBookQA, TheoremQA, T-Eval (math, code, reasoning, knowledge, instruction-following, tool-use)
+- **Broad benchmark coverage** — mathematics (AIME, HMMT, MATH-500), knowledge & reasoning (MMLU, MMLU-Pro, GPQA-Diamond, CMMLU), code (HumanEval, MBPP, LiveCodeBench), instruction-following (IFEval, IFBench), and tool-use (T-Eval Before-Calling); run `sieval dataset list` for the full roster
 - **Type-safe pipelines** — fully typed task stages (preprocess → infer → postprocess → feedback)
 - **YAML-based configuration** — batch evaluation with model derivation and quota allocation
 - **Inference orchestration** — recipe-driven inference with auto-resolve and backend abstraction (vLLM, SGLang)
@@ -27,13 +27,16 @@ pdm install          # or: pip install -e .
 Optional extras (per-benchmark dependencies):
 
 ```bash
-pip install -e ".[math]"     # AIME 2024/2025/2026, HMMT Feb 2026, MATH-500 (math-verify)
+pip install -e ".[math]"     # AIME, GSM8K, HMMT, IMO-AnswerBench, MATH-500, TheoremQA (math-verify)
 pip install -e ".[drop]"     # DROP (numpy, scipy)
 pip install -e ".[ifbench]"  # IFBench (emoji, nltk, setuptools, syllapy)
 pip install -e ".[ifeval]"   # IFEval (absl, langdetect, nltk, immutabledict)
 pip install -e ".[t-eval]"   # T-Eval (numpy, sentence-transformers)
 pip install -e ".[math,drop,ifbench,ifeval,t-eval]"   # all extras at once
 ```
+
+> `sieval dataset list` includes a `DEPS_GROUP` column indicating which extra each
+> benchmark requires, and `sieval dataset show <name>` prints the exact install command.
 
 ## Quick Start
 
@@ -123,6 +126,7 @@ anyio.run(main)
 - [Concurrency Control](docs/guide/concurrency.md) — four-level concurrency model
 - [Profiling & Observability](docs/guide/profiling.md) — stage timing, I/O metrics, token tracking
 - [Inference Management](docs/guide/infer.md) — full infer subcommand reference
+- [FAQ](docs/guide/faq.md) — common questions and troubleshooting
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ pip install -e ".[t-eval]"   # T-Eval (numpy, sentence-transformers)
 pip install -e ".[math,drop,ifbench,ifeval,t-eval]"   # all extras at once
 ```
 
-> `sieval dataset list` includes a `DEPS_GROUP` column indicating which extra each
-> benchmark requires, and `sieval dataset show <name>` prints the exact install command.
+> `sieval task list` includes a `DEPS_GROUP` column showing which extra each task
+> requires (`sieval task show <task>` prints it too), and `sieval dataset download <name>`
+> prints the exact install command when a required extra is missing.
 
 ## Quick Start
 

--- a/sieval/meta/index.json
+++ b/sieval/meta/index.json
@@ -1022,7 +1022,7 @@
         "english",
         "open-ended"
       ],
-      "deps_group": null,
+      "deps_group": "t-eval",
       "model_type": "chat",
       "reference_impl": {
         "source": "open-compass/T-Eval",

--- a/sieval/tasks/t_eval_before_calling_0shot_gen.py
+++ b/sieval/tasks/t_eval_before_calling_0shot_gen.py
@@ -25,6 +25,7 @@ from sieval.datasets import TEvalBeforeCallingDatasetSample
     eval_mode=EvalMode.GEN,
     n_shot=0,
     tags=("chinese", "english", "open-ended"),
+    deps_group="t-eval",
     model_type="chat",
     reference_impl=ReferenceImpl(
         source="open-compass/T-Eval",


### PR DESCRIPTION
## Type

Bundles a documentation sync with one related fix surfaced during the review:

- **docs** — README/CLAUDE.md accuracy sync (primary)
- **fix** — T-Eval `deps_group` metadata correction

## Summary

Reviewing README/CLAUDE.md against the current registry (post-0.6.0, after MMMLU #30
and HellaSwag #34 landed) turned up stale/incorrect claims plus one real metadata gap:

- **README benchmark list** — replaced the hardcoded "21 registered benchmark datasets"
  enumeration (already stale — omitted MMMLU/HellaSwag) with capability-area coverage and
  a pointer to `sieval dataset list` as the source of truth, so the roster stops drifting
  every release.
- **README `[math]` extras** — corrected the roster to match the tasks-registry
  `deps_group` (added GSM8K, HMMT Feb 2025, IMO-AnswerBench, TheoremQA), and noted the
  `DEPS_GROUP` column / `sieval dataset show` install hint. Added the FAQ doc link.
- **CLAUDE.md** — listed `dataset` and `task` alongside `infer`/`leaderboard` as CLI
  resource groups.
- **fix(t-eval)** — the T-Eval Before-Calling task top-level imports `numpy` and lazily
  imports `sentence_transformers` (both in the `t-eval` extra) but left `deps_group=None`
  in its `@sieval_task` metadata. So `sieval task list` showed `DEPS_GROUP=-` and the
  pre-run readiness check never warned about the missing extra — a user without
  `sieval[t-eval]` hit a raw `ImportError` at run time. Set `deps_group="t-eval"` and
  regenerated `sieval/meta/index.json`. Metadata-only; no scoring impact.

## Test Plan

### Automated

- [x] Lint/format clean (`ruff check && ruff format` — via pre-commit)
- [x] Type check clean (`ty check` on the changed task file)
- [x] Unit tests pass (`test_t_eval_before_calling_0shot_gen.py` + `test_eval.py` — 3 passed)
- [x] Preflight: `check_meta_index_sync`, `check_tasks`, `check_dep_coverage`, `check_links` — all PASS

### Manual

- [x] `sieval task list` now shows `DEPS_GROUP = t-eval` for `t_eval_before_calling_0shot_gen` (was `-`)

## Checklist

### Required (all PRs)

- [x] PR title follows conventional format
- [x] No internal paths, credentials, or personal info in committed files
- [x] AI-generated code marker — N/A (no new source files; one-line metadata edit + doc edits)
- [x] No new upper-layer dependencies added to `core/` (core not touched)
- [x] Deleted code verified — N/A (only a stale README enumeration removed; no code deleted)
