### PR TITLE
feat(core): resume version-compatibility gate + per-record version provenance

### DIFF
--- a/sieval/__init__.py
+++ b/sieval/__init__.py
@@ -1,7 +1,5 @@
 """SiEval — Model Delivery Quality Verification System."""
 
-from sieval.meta import load_index as load_index
-
 try:
     from sieval._version import (  # type: ignore[unresolved-import]
         __version__ as __version__,
@@ -14,3 +12,5 @@ except ImportError:
         __version__: str = version("sieval")
     except PackageNotFoundError:
         __version__: str = "0.0.0"
+
+from sieval.meta import load_index as load_index

--- a/sieval/core/runners/resume_gate.py
+++ b/sieval/core/runners/resume_gate.py
@@ -52,18 +52,9 @@ def resume_version_verdict(v_run: str, v_cur: str) -> ResumeVerdict:
     3. either side is a dev/local build             -> REJECT (unpinnable)
     4. incompatible break-axis (compat_key differs) -> REJECT
     5. otherwise (same series, non-exact)           -> COMPATIBLE
-
-    Rule 1 matches the raw strings before parsing, so it deliberately wins over
-    every reject below it: an identical pair resumes even when the string is
-    ``0.0.0`` or a dev/local build — you are resuming *your own* build, which is
-    always safe. The rule-2/3 rejects only bite a *non-exact* pair.
-
-    Only dev/local builds are rejected non-exactly (rule 3), because they are
-    unpinnable — the same tag can name different code. Published pre-/post-
-    releases (``rc``/``a``/``b``/``.post``) are pinnable and reinstallable, so
-    they carry no special case: they fall through to the series check (rule 4/5)
-    like any other point in their series.
     """
+    # Rule 1 short-circuits before parsing, so an identical pair always resumes
+    # (even a "0.0.0" or dev/local string — you are resuming your own build).
     if v_run == v_cur:
         return ResumeVerdict(ResumeAction.EXACT)
 
@@ -76,9 +67,8 @@ def resume_version_verdict(v_run: str, v_cur: str) -> ResumeVerdict:
     if parsed_run == _ZERO or parsed_cur == _ZERO:
         return ResumeVerdict(ResumeAction.REJECT, "version is unknown (0.0.0)")
 
-    # Dev/local only: an unpinnable tag can name different code. Published
-    # pre-/post-releases are pinnable, so they are NOT rejected here — they fall
-    # through to the series check below.
+    # Reject unpinnable builds only (dev/local: same tag, different code).
+    # Pinnable pre-/post-releases fall through to the series check below.
     if (
         parsed_run.local is not None
         or parsed_run.is_devrelease

--- a/sieval/core/runners/resume_gate.py
+++ b/sieval/core/runners/resume_gate.py
@@ -1,0 +1,94 @@
+"""Resume version-compatibility decision logic.
+
+Pure, I/O-free: decides whether a run persisted under one sieval version
+may be resumed under another. The go/no-go ladder is EM-first, then rejects
+unparseable / unknown / dev-local mismatches and incompatible version series;
+otherwise the resume is compatible and recorded via per-record provenance.
+
+AI-Generated Code - Claude Opus 4.8 (1M context) (Anthropic)
+"""
+
+import enum
+from dataclasses import dataclass
+
+from packaging.version import InvalidVersion, Version
+
+_ZERO = Version("0.0.0")
+
+
+class ResumeAction(enum.Enum):
+    """Outcome of a resume version check."""
+
+    EXACT = "exact"
+    COMPATIBLE = "compatible"
+    REJECT = "reject"
+
+
+@dataclass(frozen=True, slots=True)
+class ResumeVerdict:
+    """A resume decision; ``reason`` is populated only for ``REJECT``."""
+
+    action: ResumeAction
+    reason: str = ""
+
+
+class ResumeVersionError(RuntimeError):
+    """Raised when a resume crosses an incompatible sieval version boundary."""
+
+
+def _compat_key(v: Version) -> tuple[int, ...]:
+    """Return the break-axis key: major post-1.0, (major, minor) under 1.0."""
+    if v.major >= 1:
+        return (v.major,)
+    return (v.major, v.minor)
+
+
+def resume_version_verdict(v_run: str, v_cur: str) -> ResumeVerdict:
+    """Decide whether a run created under ``v_run`` may resume under ``v_cur``.
+
+    1. exact string match                          -> EXACT
+    2. unparseable, or either side is 0.0.0         -> REJECT (fail-closed)
+    3. either side is a dev/local build             -> REJECT (unpinnable)
+    4. incompatible break-axis (compat_key differs) -> REJECT
+    5. otherwise (same series, non-exact)           -> COMPATIBLE
+    """
+    if v_run == v_cur:
+        return ResumeVerdict(ResumeAction.EXACT)
+
+    try:
+        parsed_run = Version(v_run)
+        parsed_cur = Version(v_cur)
+    except InvalidVersion:
+        return ResumeVerdict(ResumeAction.REJECT, "version string is unparseable")
+
+    if parsed_run == _ZERO or parsed_cur == _ZERO:
+        return ResumeVerdict(ResumeAction.REJECT, "version is unknown (0.0.0)")
+
+    if (
+        parsed_run.local is not None
+        or parsed_run.is_devrelease
+        or parsed_cur.local is not None
+        or parsed_cur.is_devrelease
+    ):
+        return ResumeVerdict(
+            ResumeAction.REJECT,
+            "development/local build cannot be matched non-exactly",
+        )
+
+    if _compat_key(parsed_run) != _compat_key(parsed_cur):
+        return ResumeVerdict(ResumeAction.REJECT, "incompatible version series")
+
+    return ResumeVerdict(ResumeAction.COMPATIBLE)
+
+
+def format_reject_message(v_run: str, v_cur: str, reason: str) -> str:
+    """Build the operator-facing 'Resume aborted' message for a rejected resume."""
+    return (
+        "Resume aborted: sieval version is incompatible with the persisted run.\n"
+        f"  persisted (meta.json): {v_run}\n"
+        f"  current:               {v_cur}\n"
+        f"  reason: {reason}\n"
+        "Either:\n"
+        "  1. Remove the result_dir and start fresh\n"
+        "  2. Reinstall sieval matching the persisted version series"
+    )

--- a/sieval/core/runners/resume_gate.py
+++ b/sieval/core/runners/resume_gate.py
@@ -1,9 +1,10 @@
 """Resume version-compatibility decision logic.
 
 Pure, I/O-free: decides whether a run persisted under one sieval version
-may be resumed under another. The go/no-go ladder is EM-first, then rejects
-unparseable / unknown / dev-local mismatches and incompatible version series;
-otherwise the resume is compatible and recorded via per-record provenance.
+may be resumed under another. The go/no-go ladder is exact-match-first, then
+rejects unparseable / unknown / dev-local mismatches and incompatible version
+series; otherwise the resume is compatible and recorded via per-record
+provenance.
 
 AI-Generated Code - Claude Opus 4.8 (1M context) (Anthropic)
 """
@@ -51,6 +52,17 @@ def resume_version_verdict(v_run: str, v_cur: str) -> ResumeVerdict:
     3. either side is a dev/local build             -> REJECT (unpinnable)
     4. incompatible break-axis (compat_key differs) -> REJECT
     5. otherwise (same series, non-exact)           -> COMPATIBLE
+
+    Rule 1 matches the raw strings before parsing, so it deliberately wins over
+    every reject below it: an identical pair resumes even when the string is
+    ``0.0.0`` or a dev/local build — you are resuming *your own* build, which is
+    always safe. The rule-2/3 rejects only bite a *non-exact* pair.
+
+    Only dev/local builds are rejected non-exactly (rule 3), because they are
+    unpinnable — the same tag can name different code. Published pre-/post-
+    releases (``rc``/``a``/``b``/``.post``) are pinnable and reinstallable, so
+    they carry no special case: they fall through to the series check (rule 4/5)
+    like any other point in their series.
     """
     if v_run == v_cur:
         return ResumeVerdict(ResumeAction.EXACT)
@@ -64,6 +76,9 @@ def resume_version_verdict(v_run: str, v_cur: str) -> ResumeVerdict:
     if parsed_run == _ZERO or parsed_cur == _ZERO:
         return ResumeVerdict(ResumeAction.REJECT, "version is unknown (0.0.0)")
 
+    # Dev/local only: an unpinnable tag can name different code. Published
+    # pre-/post-releases are pinnable, so they are NOT rejected here — they fall
+    # through to the series check below.
     if (
         parsed_run.local is not None
         or parsed_run.is_devrelease

--- a/sieval/core/runners/runner.py
+++ b/sieval/core/runners/runner.py
@@ -39,7 +39,7 @@ from sieval.core.tasks.saver import TaskSaver
 from sieval.core.tasks.task import Task
 from sieval.core.types import JSONValue
 from sieval.core.utils.concurrency import CompositeLimiter
-from sieval.core.utils.meta import build_stage_meta, collect_versions
+from sieval.core.utils.meta import build_stage_meta, report_versions
 
 from .resume_gate import (
     ResumeAction,
@@ -918,14 +918,18 @@ class TaskRunner:
         """Inject the distinct producing-version list into a dict report, then save.
 
         Aggregates over the in-memory terminal contexts' ``stage_meta`` — the
-        records that produced the scored results — at zero extra I/O. Non-dict
-        reports are saved unchanged.
+        records that produced the scored results — at zero extra I/O. A scored
+        (FINAL) record with no stamped version predates per-record provenance
+        and surfaces as the ``"unknown"`` sentinel so a legacy-blended report is
+        not silently reported as single-version. Non-dict reports are saved
+        unchanged.
         """
         if report is None:
             return
         if isinstance(report, dict):
-            cast(dict[str, JSONValue], report)["versions"] = collect_versions(
-                c.stage_meta for c in (*finals, *fails)
+            cast(dict[str, JSONValue], report)["versions"] = report_versions(
+                (c.stage_meta for c in finals),
+                (c.stage_meta for c in fails),
             )
         await self._saver.save_report(report)
 

--- a/sieval/core/runners/runner.py
+++ b/sieval/core/runners/runner.py
@@ -10,10 +10,12 @@ from pathlib import Path
 from typing import Any, Literal
 
 import anyio
+import orjson
 from anyio.abc import TaskGroup
 from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 from loguru import logger
 
+from sieval import __version__
 from sieval.core.models import ModelOutput
 from sieval.core.tasks.anomaly import TaskAnomalyDetector
 from sieval.core.tasks.concurrency import (
@@ -37,6 +39,13 @@ from sieval.core.tasks.saver import TaskSaver
 from sieval.core.tasks.task import Task
 from sieval.core.utils.concurrency import CompositeLimiter
 from sieval.core.utils.meta import build_stage_meta
+
+from .resume_gate import (
+    ResumeAction,
+    ResumeVersionError,
+    format_reject_message,
+    resume_version_verdict,
+)
 
 # Type Aliases
 type TaskStageMetaHook = Callable[[Any, TaskStage, TaskContext], TaskStageMeta | None]
@@ -116,6 +125,46 @@ class TaskRunnerConfig:
     deterministic: bool = False
 
 
+def gate_resume_version(root_dir: Path, current_version: str) -> None:
+    """Refuse to resume across an incompatible sieval version.
+
+    Reads the format-stable ``version`` from ``root_dir/meta.json`` and
+    applies :func:`resume_version_verdict`. Missing, unreadable, or
+    version-less ``meta.json`` is fail-closed (reject). Raises
+    :class:`ResumeVersionError` on reject; logs a warning on a compatible
+    non-exact resume; silent on an exact match.
+    """
+    meta_path = root_dir / "meta.json"
+    v_run: object = None
+    try:
+        meta = orjson.loads(meta_path.read_bytes())
+        v_run = meta.get("version") if isinstance(meta, dict) else None
+    except (OSError, orjson.JSONDecodeError):
+        v_run = None
+
+    if not isinstance(v_run, str):
+        raise ResumeVersionError(
+            format_reject_message(
+                "<missing>",
+                current_version,
+                "meta.json is missing, unreadable, or has no version",
+            )
+        )
+
+    verdict = resume_version_verdict(v_run, current_version)
+    if verdict.action is ResumeAction.REJECT:
+        raise ResumeVersionError(
+            format_reject_message(v_run, current_version, verdict.reason)
+        )
+    if verdict.action is ResumeAction.COMPATIBLE:
+        logger.warning(
+            "Resuming across compatible sieval versions (persisted={}, current={}); "
+            "per-record provenance will record the blend.",
+            v_run,
+            current_version,
+        )
+
+
 class TaskRunner:
     """Core execution engine for a single evaluation task.
 
@@ -170,6 +219,7 @@ class TaskRunner:
             self._config.result_dir, task, self._auto_resume
         )
         if self._resumed_from_existing:
+            gate_resume_version(self._root_dir, __version__)
             logger.info("Auto resumed from: {}", self._root_dir)
 
         # Profiling

--- a/sieval/core/runners/runner.py
+++ b/sieval/core/runners/runner.py
@@ -927,7 +927,7 @@ class TaskRunner:
         if report is None:
             return
         if isinstance(report, dict):
-            cast(dict[str, JSONValue], report)["versions"] = report_versions(
+            cast(dict[str, JSONValue], report)["sieval_versions"] = report_versions(
                 (c.stage_meta for c in finals),
                 (c.stage_meta for c in fails),
             )

--- a/sieval/core/runners/runner.py
+++ b/sieval/core/runners/runner.py
@@ -7,7 +7,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, replace
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 import anyio
 import orjson
@@ -37,8 +37,9 @@ from sieval.core.tasks.profiler import TaskProfiler
 from sieval.core.tasks.progress import TaskProgress
 from sieval.core.tasks.saver import TaskSaver
 from sieval.core.tasks.task import Task
+from sieval.core.types import JSONValue
 from sieval.core.utils.concurrency import CompositeLimiter
-from sieval.core.utils.meta import build_stage_meta
+from sieval.core.utils.meta import build_stage_meta, collect_versions
 
 from .resume_gate import (
     ResumeAction,
@@ -520,8 +521,7 @@ class TaskRunner:
                 finals, fails = self._final_and_failed()
                 report = await self._task.report(finals, fails)
                 # Always save report on completion
-                if report is not None:
-                    await self._saver.save_report(report)
+                await self._save_report_with_versions(report, finals, fails)
                 return report
 
             # 6. Setup Progress Tracker
@@ -593,8 +593,7 @@ class TaskRunner:
             finals, fails = self._final_and_failed()
             report = await self._task.report(finals, fails)
             # Always save report on completion
-            if report is not None:
-                await self._saver.save_report(report)
+            await self._save_report_with_versions(report, finals, fails)
             # Backstop: create-if-absent, normally a no-op (written at run start).
             await self._saver.write_run_meta()
             # Generate anomaly report
@@ -909,6 +908,26 @@ class TaskRunner:
         finals = [c for c in self._contexts.values() if c.stage == TaskStage.FINAL]
         fails = [c for c in self._contexts.values() if c.stage == TaskStage.FAILED]
         return finals, fails
+
+    async def _save_report_with_versions(
+        self,
+        report: JSONValue,
+        finals: list[TaskContext],
+        fails: list[TaskContext],
+    ) -> None:
+        """Inject the distinct producing-version list into a dict report, then save.
+
+        Aggregates over the in-memory terminal contexts' ``stage_meta`` — the
+        records that produced the scored results — at zero extra I/O. Non-dict
+        reports are saved unchanged.
+        """
+        if report is None:
+            return
+        if isinstance(report, dict):
+            cast(dict[str, JSONValue], report)["versions"] = collect_versions(
+                c.stage_meta for c in (*finals, *fails)
+            )
+        await self._saver.save_report(report)
 
     def _resolve_result_dir(
         self, result_dir: str | None, task: Task, auto_resume: bool

--- a/sieval/core/runners/runner.py
+++ b/sieval/core/runners/runner.py
@@ -917,12 +917,9 @@ class TaskRunner:
     ) -> None:
         """Inject the distinct producing-version list into a dict report, then save.
 
-        Aggregates over the in-memory terminal contexts' ``stage_meta`` — the
-        records that produced the scored results — at zero extra I/O. A scored
-        (FINAL) record with no stamped version predates per-record provenance
-        and surfaces as the ``"unknown"`` sentinel so a legacy-blended report is
-        not silently reported as single-version. Non-dict reports are saved
-        unchanged.
+        Aggregates over the in-memory terminal contexts' ``stage_meta`` at zero
+        extra I/O; :func:`report_versions` owns the ``"unknown"`` sentinel rule.
+        Non-dict reports are saved unchanged; ``None`` skips the save.
         """
         if report is None:
             return

--- a/sieval/core/runners/runner.py
+++ b/sieval/core/runners/runner.py
@@ -336,6 +336,10 @@ class TaskRunner:
             # 0.5. Lifecycle Setup
             await self._task.setup()
 
+            # Write the version handshake up front so interrupted-then-resumed
+            # runs always have a meta.json for the resume gate to read.
+            await self._saver.write_run_meta()
+
             # 1. Load Initial State
             self._contexts = await self._loader.load_initial_state()
 
@@ -541,6 +545,7 @@ class TaskRunner:
             # Always save report on completion
             if report is not None:
                 await self._saver.save_report(report)
+            # Backstop: create-if-absent, normally a no-op (written at run start).
             await self._saver.write_run_meta()
             # Generate anomaly report
             if self._config.detect_anomalies:

--- a/sieval/core/tasks/context.py
+++ b/sieval/core/tasks/context.py
@@ -25,6 +25,7 @@ class TaskStageMeta(TypedDict, total=False):
     """Per-stage metadata recorded alongside each stage execution."""
 
     timestamp: float
+    version: str  # producing sieval version — per-record provenance (RFC #24)
     timing_s: float
     model_calls: list[ModelCallMeta]
     env: dict[str, JSONValue]

--- a/sieval/core/tasks/context.py
+++ b/sieval/core/tasks/context.py
@@ -25,7 +25,7 @@ class TaskStageMeta(TypedDict, total=False):
     """Per-stage metadata recorded alongside each stage execution."""
 
     timestamp: float
-    version: str  # producing sieval version — per-record provenance (RFC #24)
+    version: str  # producing sieval version — per-record provenance
     timing_s: float
     model_calls: list[ModelCallMeta]
     env: dict[str, JSONValue]

--- a/sieval/core/tasks/saver.py
+++ b/sieval/core/tasks/saver.py
@@ -153,9 +153,8 @@ class TaskSaver:
         try:
             if await anyio.Path(meta_path).exists():
                 return
-            # Lazy: keeps the version lookup inside this try/except so a broken
-            # install (unresolvable __version__) degrades meta.json writing
-            # gracefully instead of hard-failing saver import.
+            # Lazy: keeps the version lookup inside this try/except so an
+            # unresolvable __version__ degrades gracefully, not a hard import fail.
             from sieval import __version__
 
             meta: TaskRunMeta = {

--- a/sieval/core/tasks/saver.py
+++ b/sieval/core/tasks/saver.py
@@ -153,6 +153,9 @@ class TaskSaver:
         try:
             if await anyio.Path(meta_path).exists():
                 return
+            # Lazy: keeps the version lookup inside this try/except so a broken
+            # install (unresolvable __version__) degrades meta.json writing
+            # gracefully instead of hard-failing saver import.
             from sieval import __version__
 
             meta: TaskRunMeta = {

--- a/sieval/core/tasks/saver.py
+++ b/sieval/core/tasks/saver.py
@@ -138,16 +138,28 @@ class TaskSaver:
             logger.error("Failed to save report.json: {}", e)
 
     async def write_run_meta(self) -> None:
-        """Atomically write ``meta.json`` to the result directory."""
+        """Write ``meta.json`` create-if-absent to the result directory.
+
+        Written at run start so the format-stable version handshake exists
+        for interrupted-then-resumed runs (resume is detected via
+        ``manifest.json``, which may exist without a completed run). Never
+        overwrites an existing ``meta.json`` — the file records the run's
+        originating version and stays stable across compatible resumes.
+        Self-creates ``_root_dir`` since at run start no shard exists yet.
+        All failures are non-fatal: logged, never raised.
+        """
         meta_path = self._root_dir / "meta.json"
         tmp_path = meta_path.with_suffix(".tmp")
         try:
+            if await anyio.Path(meta_path).exists():
+                return
             from sieval import __version__
 
             meta: TaskRunMeta = {
                 "version": __version__,
                 "deterministic": self._deterministic,
             }
+            await anyio.Path(self._root_dir).mkdir(parents=True, exist_ok=True)
             async with await anyio.open_file(tmp_path, "wb") as f:
                 await f.write(orjson.dumps(meta))
             await anyio.Path(tmp_path).replace(meta_path)

--- a/sieval/core/utils/meta.py
+++ b/sieval/core/utils/meta.py
@@ -81,6 +81,12 @@ def report_versions(
     report from being silently reported as single-version. FAILED records are
     not sentinel-flagged: a sample that failed before any stage legitimately
     produced no versioned work.
+
+    "Always stamped" assumes ``stage_meta`` survives to report time. On a fresh
+    run it does (built in-memory per stage); on a resume it does only under
+    ``record_meta=True`` — with ``record_meta=False`` the loader has no
+    persisted ``stage_meta`` to hydrate, so disk-resident finals honestly
+    surface as ``"unknown"`` (their provenance was never recorded).
     """
     final_metas = list(final_stage_metas)
     versions = collect_versions([*final_metas, *failed_stage_metas])

--- a/sieval/core/utils/meta.py
+++ b/sieval/core/utils/meta.py
@@ -1,6 +1,9 @@
 """Helpers for building model-call and stage metadata dicts."""
 
 import time
+from collections.abc import Iterable, Mapping
+
+from packaging.version import InvalidVersion, Version
 
 from sieval import __version__
 from sieval.core.models import ModelCallMeta, ModelOutput
@@ -37,3 +40,28 @@ def build_stage_meta(
     if extra:
         meta["extra"] = extra
     return meta
+
+
+def collect_versions(stage_metas: Iterable[Mapping[str, list]]) -> list[str]:
+    """Distinct sieval versions across the given per-context stage-meta maps.
+
+    Walks each context's ``stage_meta`` history (stage name -> list of
+    per-stage meta dicts) and collects every ``version`` entry present.
+    Returned sorted semver-aware; unparseable tags sort last (by string).
+    A context/stage that carries no ``version`` contributes nothing.
+    """
+    seen: set[str] = set()
+    for stage_meta in stage_metas:
+        for entries in stage_meta.values():
+            for entry in entries:
+                v = entry.get("version")
+                if v:
+                    seen.add(v)
+
+    def _key(s: str) -> tuple[int, object]:
+        try:
+            return (0, Version(s))
+        except InvalidVersion:
+            return (1, s)
+
+    return sorted(seen, key=_key)

--- a/sieval/core/utils/meta.py
+++ b/sieval/core/utils/meta.py
@@ -2,6 +2,7 @@
 
 import time
 
+from sieval import __version__
 from sieval.core.models import ModelCallMeta, ModelOutput
 from sieval.core.tasks.context import TaskStageMeta
 
@@ -28,7 +29,7 @@ def build_stage_meta(
     extra: dict | None = None,
 ) -> TaskStageMeta:
     """Build a TaskStageMeta dict for one pipeline stage execution."""
-    meta: TaskStageMeta = {"timestamp": time.time()}
+    meta: TaskStageMeta = {"timestamp": time.time(), "version": __version__}
     if timing_s is not None:
         meta["timing_s"] = timing_s
     if outputs:

--- a/sieval/core/utils/meta.py
+++ b/sieval/core/utils/meta.py
@@ -65,3 +65,29 @@ def collect_versions(stage_metas: Iterable[Mapping[str, list]]) -> list[str]:
             return (1, s)
 
     return sorted(seen, key=_key)
+
+
+def report_versions(
+    final_stage_metas: Iterable[Mapping[str, list]],
+    failed_stage_metas: Iterable[Mapping[str, list]],
+) -> list[str]:
+    """Distinct producing versions for a report's terminal records.
+
+    Aggregates versions across all terminal records (finals + fails) via
+    :func:`collect_versions`. If any FINAL (scored) record carries no version,
+    appends the ``"unknown"`` sentinel: a completed sample always ran the full
+    pipeline, so a post-provenance FINAL is always stamped — an unstamped FINAL
+    predates per-record provenance, and surfacing it keeps a legacy-blended
+    report from being silently reported as single-version. FAILED records are
+    not sentinel-flagged: a sample that failed before any stage legitimately
+    produced no versioned work.
+    """
+    final_metas = list(final_stage_metas)
+    versions = collect_versions([*final_metas, *failed_stage_metas])
+    has_unstamped_final = any(
+        not any(entry.get("version") for entries in sm.values() for entry in entries)
+        for sm in final_metas
+    )
+    if has_unstamped_final:
+        versions.append("unknown")
+    return versions

--- a/tests/unit/core/runners/test_resume_gate.py
+++ b/tests/unit/core/runners/test_resume_gate.py
@@ -1,0 +1,87 @@
+"""Tests for sieval.core.runners.resume_gate — pure version-verdict ladder."""
+
+from sieval.core.runners.resume_gate import (
+    ResumeAction,
+    ResumeVersionError,
+    format_reject_message,
+    resume_version_verdict,
+)
+
+
+class TestResumeVersionVerdict:
+    def test_exact_match(self):
+        assert resume_version_verdict("0.6.0", "0.6.0").action is ResumeAction.EXACT
+
+    def test_exact_match_dev_build(self):
+        v = "0.5.1.dev24+gabc"
+        assert resume_version_verdict(v, v).action is ResumeAction.EXACT
+
+    def test_compatible_same_minor_under_1_0(self):
+        assert (
+            resume_version_verdict("0.6.0", "0.6.3").action is ResumeAction.COMPATIBLE
+        )
+
+    def test_reject_minor_break_under_1_0(self):
+        assert resume_version_verdict("0.6.0", "0.7.0").action is ResumeAction.REJECT
+
+    def test_reject_1_0_boundary(self):
+        assert resume_version_verdict("0.9.5", "1.0.0").action is ResumeAction.REJECT
+
+    def test_compatible_same_major_post_1_0(self):
+        assert (
+            resume_version_verdict("1.2.0", "1.5.9").action is ResumeAction.COMPATIBLE
+        )
+
+    def test_reject_major_break_post_1_0(self):
+        assert resume_version_verdict("1.9.0", "2.0.0").action is ResumeAction.REJECT
+
+    def test_reject_dev_mismatch(self):
+        assert (
+            resume_version_verdict("0.6.0", "0.6.1.dev3+gxyz").action
+            is ResumeAction.REJECT
+        )
+
+    def test_reject_local_mismatch(self):
+        assert (
+            resume_version_verdict("0.6.0", "0.6.1+local").action is ResumeAction.REJECT
+        )
+
+    def test_reject_unparseable(self):
+        assert (
+            resume_version_verdict("not-a-version", "0.6.0").action
+            is ResumeAction.REJECT
+        )
+
+    def test_reject_zero_version_mismatch(self):
+        assert resume_version_verdict("0.0.0", "0.6.0").action is ResumeAction.REJECT
+
+    def test_zero_vs_zero_is_exact(self):
+        # EM precedence (rule 1) beats the 0.0.0 reject (rule 2).
+        assert resume_version_verdict("0.0.0", "0.0.0").action is ResumeAction.EXACT
+
+    def test_reject_dev_mismatch_run_side(self):
+        # dev marker on the FIRST arg (v_run) must also reject
+        assert (
+            resume_version_verdict("0.6.1.dev3+gxyz", "0.6.0").action
+            is ResumeAction.REJECT
+        )
+
+    def test_reject_zero_version_cur_side(self):
+        # 0.0.0 on the SECOND arg (v_cur) must also reject
+        assert resume_version_verdict("0.6.0", "0.0.0").action is ResumeAction.REJECT
+
+    def test_reject_reason_is_populated(self):
+        assert resume_version_verdict("0.6.0", "0.7.0").reason != ""
+
+
+class TestFormatRejectMessage:
+    def test_contains_versions_reason_and_recovery(self):
+        msg = format_reject_message("0.6.0", "0.7.0", "incompatible version series")
+        assert "0.6.0" in msg
+        assert "0.7.0" in msg
+        assert "incompatible version series" in msg
+        assert "start fresh" in msg
+
+
+def test_resume_version_error_is_runtimeerror():
+    assert issubclass(ResumeVersionError, RuntimeError)

--- a/tests/unit/core/runners/test_resume_gate.py
+++ b/tests/unit/core/runners/test_resume_gate.py
@@ -1,11 +1,24 @@
 """Tests for sieval.core.runners.resume_gate — pure version-verdict ladder."""
 
+from pathlib import Path
+
+import orjson
+import pytest
+
 from sieval.core.runners.resume_gate import (
     ResumeAction,
     ResumeVersionError,
     format_reject_message,
     resume_version_verdict,
 )
+from sieval.core.runners.runner import gate_resume_version
+
+
+def _write_meta(root: Path, version: str) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "meta.json").write_bytes(
+        orjson.dumps({"version": version, "deterministic": False})
+    )
 
 
 class TestResumeVersionVerdict:
@@ -85,3 +98,32 @@ class TestFormatRejectMessage:
 
 def test_resume_version_error_is_runtimeerror():
     assert issubclass(ResumeVersionError, RuntimeError)
+
+
+class TestGateResumeVersion:
+    def test_exact_passes(self, tmp_path):
+        _write_meta(tmp_path, "0.6.0")
+        gate_resume_version(tmp_path, "0.6.0")  # no raise
+
+    def test_compatible_passes(self, tmp_path):
+        _write_meta(tmp_path, "0.6.0")
+        gate_resume_version(tmp_path, "0.6.3")  # no raise
+
+    def test_incompatible_raises(self, tmp_path):
+        _write_meta(tmp_path, "0.6.0")
+        with pytest.raises(ResumeVersionError, match="incompatible version series"):
+            gate_resume_version(tmp_path, "0.7.0")
+
+    def test_missing_meta_raises(self, tmp_path):
+        with pytest.raises(ResumeVersionError):
+            gate_resume_version(tmp_path, "0.6.0")
+
+    def test_unreadable_meta_raises(self, tmp_path):
+        (tmp_path / "meta.json").write_bytes(b"not json{")
+        with pytest.raises(ResumeVersionError):
+            gate_resume_version(tmp_path, "0.6.0")
+
+    def test_meta_without_version_key_raises(self, tmp_path):
+        (tmp_path / "meta.json").write_bytes(orjson.dumps({"deterministic": True}))
+        with pytest.raises(ResumeVersionError):
+            gate_resume_version(tmp_path, "0.6.0")

--- a/tests/unit/core/runners/test_runner.py
+++ b/tests/unit/core/runners/test_runner.py
@@ -13,6 +13,8 @@ import anyio
 import orjson
 import pytest
 
+from sieval import __version__
+from sieval.core.runners.resume_gate import ResumeVersionError
 from sieval.core.runners.runner import ResultDirExistsError, TaskRunner
 from sieval.core.tasks.concurrency import compute_stream_buffer_capacity
 from sieval.core.tasks.consts import TaskAction, TaskStage
@@ -709,6 +711,13 @@ class TestResolveResultDir:
         latest.mkdir(parents=True, exist_ok=True)
         (older / "manifest.json").write_text("[]", encoding="utf-8")
         (latest / "manifest.json").write_text("[]", encoding="utf-8")
+        # Real resumable dirs always carry a meta.json handshake (Task 4);
+        # give the fabricated fixture one so the version gate (Task 5) sees
+        # an EXACT match and this test stays focused on dir-selection logic.
+        for d in (older, latest):
+            (d / "meta.json").write_bytes(
+                orjson.dumps({"version": __version__, "deterministic": False})
+            )
 
         dataset = MockDataset()
         model = MockChatModel(answers=DEFAULT_ANSWERS)
@@ -2189,3 +2198,36 @@ class TestLazyContextCreation:
         report = await runner.arun()
         assert report["total"] == 2
         assert runner._total_samples == 2
+
+
+class TestResumeVersionGate:
+    @pytest.mark.anyio
+    async def test_incompatible_version_blocks_resume(self, tmp_path):
+        result_dir = str(tmp_path / "gated")
+        model = MockChatModel(answers=DEFAULT_ANSWERS)
+        task = MockTask(dataset=MockDataset(), model=model, name="gate_block")
+        await TaskRunner(task, make_config(tmp_path, result_dir=result_dir)).arun()
+
+        # Tamper meta.json to an incompatible series.
+        (Path(result_dir) / "meta.json").write_bytes(
+            orjson.dumps({"version": "999.0.0", "deterministic": False})
+        )
+
+        task2 = MockTask(dataset=MockDataset(), model=model, name="gate_block")
+        with pytest.raises(ResumeVersionError):
+            TaskRunner(
+                task2, make_config(tmp_path, result_dir=result_dir, auto_resume=True)
+            )
+
+    @pytest.mark.anyio
+    async def test_same_version_resume_allowed(self, tmp_path):
+        result_dir = str(tmp_path / "same")
+        model = MockChatModel(answers=DEFAULT_ANSWERS)
+        task = MockTask(dataset=MockDataset(), model=model, name="gate_ok")
+        await TaskRunner(task, make_config(tmp_path, result_dir=result_dir)).arun()
+
+        task2 = MockTask(dataset=MockDataset(), model=model, name="gate_ok")
+        runner2 = TaskRunner(
+            task2, make_config(tmp_path, result_dir=result_dir, auto_resume=True)
+        )  # meta.json holds the current version -> EXACT -> no raise
+        assert runner2._resumed_from_existing

--- a/tests/unit/core/runners/test_runner.py
+++ b/tests/unit/core/runners/test_runner.py
@@ -91,6 +91,11 @@ class MixedOutcomeTask(MockTask):
         return await super().preprocess(raw, ctx)
 
 
+class ListReportTask(MockTask):
+    async def report(self, finals, fails):
+        return ["not", "a", "dict"]
+
+
 class ProgressUpdateCall(TypedDict):
     sample_id: str | int
     current_hydrated_count: int
@@ -1258,7 +1263,7 @@ class TestRunnerResumeState:
         monkeypatch.setattr(runner._loader, "hydrate", AsyncMock(return_value=None))
 
         report = await runner.arun()
-        assert report == {"total": 1}
+        assert report["total"] == 1
         assert observed_failure["reason"] == "retry_limit"
         assert observed_failure["msg"] == "Max retries 1 reached"
 
@@ -2231,3 +2236,26 @@ class TestResumeVersionGate:
             task2, make_config(tmp_path, result_dir=result_dir, auto_resume=True)
         )  # meta.json holds the current version -> EXACT -> no raise
         assert runner2._resumed_from_existing
+
+
+class TestReportVersions:
+    @pytest.mark.anyio
+    async def test_report_includes_current_version(self, tmp_path):
+        from sieval import __version__
+
+        model = MockChatModel(answers=DEFAULT_ANSWERS)
+        task = MockTask(dataset=MockDataset(), model=model, name="ver_report")
+        runner = TaskRunner(task, make_config(tmp_path))
+        report = await runner.arun()
+
+        assert report["versions"] == [__version__]
+        saved = orjson.loads((runner.root_dir / "report.json").read_bytes())
+        assert saved["versions"] == [__version__]
+
+    @pytest.mark.anyio
+    async def test_non_dict_report_not_injected(self, tmp_path):
+        model = MockChatModel(answers=DEFAULT_ANSWERS)
+        task = ListReportTask(dataset=MockDataset(), model=model, name="listrep")
+        report = await TaskRunner(task, make_config(tmp_path)).arun()
+
+        assert report == ["not", "a", "dict"]  # unchanged, no crash

--- a/tests/unit/core/runners/test_runner.py
+++ b/tests/unit/core/runners/test_runner.py
@@ -96,6 +96,11 @@ class ListReportTask(MockTask):
         return ["not", "a", "dict"]
 
 
+class NoneReportTask(MockTask):
+    async def report(self, finals, fails):
+        return None
+
+
 class ProgressUpdateCall(TypedDict):
     sample_id: str | int
     current_hydrated_count: int
@@ -2248,9 +2253,9 @@ class TestReportVersions:
         runner = TaskRunner(task, make_config(tmp_path))
         report = await runner.arun()
 
-        assert report["versions"] == [__version__]
+        assert report["sieval_versions"] == [__version__]
         saved = orjson.loads((runner.root_dir / "report.json").read_bytes())
-        assert saved["versions"] == [__version__]
+        assert saved["sieval_versions"] == [__version__]
 
     @pytest.mark.anyio
     async def test_non_dict_report_not_injected(self, tmp_path):
@@ -2259,3 +2264,16 @@ class TestReportVersions:
         report = await TaskRunner(task, make_config(tmp_path)).arun()
 
         assert report == ["not", "a", "dict"]  # unchanged, no crash
+
+    @pytest.mark.anyio
+    async def test_none_report_not_saved(self, tmp_path):
+        # A task returning None must skip save_report entirely: no report.json
+        # is written and arun returns None. Guards the `report is None` branch
+        # (removing it would serialize `null` to report.json).
+        model = MockChatModel(answers=DEFAULT_ANSWERS)
+        task = NoneReportTask(dataset=MockDataset(), model=model, name="nonerep")
+        runner = TaskRunner(task, make_config(tmp_path))
+        report = await runner.arun()
+
+        assert report is None
+        assert not (runner.root_dir / "report.json").exists()

--- a/tests/unit/core/tasks/test_saver.py
+++ b/tests/unit/core/tasks/test_saver.py
@@ -377,6 +377,51 @@ class TestSaveReport:
 
 
 # ===================================================================
+# write_run_meta — create-if-absent + self-mkdir (run-start handshake)
+# ===================================================================
+class TestWriteRunMeta:
+    @pytest.mark.anyio
+    async def test_creates_dir_and_file(self, tmp_path):
+        from sieval import __version__
+
+        root = tmp_path / "fresh"
+        saver = TaskSaver(root_dir=root, deterministic=True)
+        assert not root.exists()
+
+        await saver.write_run_meta()
+
+        meta_path = root / "meta.json"
+        assert meta_path.exists()
+        meta = orjson.loads(meta_path.read_bytes())
+        assert meta["version"] == __version__
+        assert meta["deterministic"] is True
+
+    @pytest.mark.anyio
+    async def test_create_if_absent_does_not_clobber(self, tmp_path):
+        root = tmp_path / "existing"
+        saver = TaskSaver(root_dir=root, deterministic=False)
+        await saver.write_run_meta()
+        # Simulate an originating version already recorded under this dir.
+        (root / "meta.json").write_bytes(
+            orjson.dumps({"version": "0.1.0", "deterministic": False})
+        )
+
+        await saver.write_run_meta()  # must NOT overwrite
+
+        meta = orjson.loads((root / "meta.json").read_bytes())
+        assert meta["version"] == "0.1.0"
+
+    @pytest.mark.anyio
+    async def test_exists_check_failure_is_non_fatal(self, tmp_path, monkeypatch):
+        async def _boom(_self):
+            raise OSError("simulated stat failure")
+
+        monkeypatch.setattr(anyio.Path, "exists", _boom)
+        saver = TaskSaver(root_dir=tmp_path / "x", deterministic=False)
+        await saver.write_run_meta()  # must NOT raise
+
+
+# ===================================================================
 # consume_stream
 # ===================================================================
 class TestConsumeStream:

--- a/tests/unit/core/utils/test_meta.py
+++ b/tests/unit/core/utils/test_meta.py
@@ -115,3 +115,15 @@ class TestBuildStageMeta:
         assert len(meta["model_calls"]) == 1
         assert meta["extra"]["note"] == "test"
         assert "timestamp" in meta
+
+    def test_includes_version(self):
+        from sieval import __version__
+
+        meta = build_stage_meta()
+        assert meta["version"] == __version__
+
+    def test_version_present_with_outputs(self, sample_model_output):
+        from sieval import __version__
+
+        meta = build_stage_meta(sample_model_output, timing_s=1.0)
+        assert meta["version"] == __version__

--- a/tests/unit/core/utils/test_meta.py
+++ b/tests/unit/core/utils/test_meta.py
@@ -7,7 +7,11 @@ AI-Generated Code - Claude Opus 4.6 (Anthropic)
 import time
 
 from sieval.core.models.model import ModelOutput
-from sieval.core.utils.meta import build_model_call_meta, build_stage_meta
+from sieval.core.utils.meta import (
+    build_model_call_meta,
+    build_stage_meta,
+    collect_versions,
+)
 
 
 class TestBuildModelCallMeta:
@@ -127,3 +131,24 @@ class TestBuildStageMeta:
 
         meta = build_stage_meta(sample_model_output, timing_s=1.0)
         assert meta["version"] == __version__
+
+
+class TestCollectVersions:
+    def test_empty_input(self):
+        assert collect_versions([]) == []
+
+    def test_single_version_deduped(self):
+        sm = {"infer": [{"version": "0.6.0"}], "postprocess": [{"version": "0.6.0"}]}
+        assert collect_versions([sm]) == ["0.6.0"]
+
+    def test_blended_sorted_semver(self):
+        sm1 = {"infer": [{"version": "0.6.10"}]}
+        sm2 = {"infer": [{"version": "0.6.2"}]}
+        assert collect_versions([sm1, sm2]) == ["0.6.2", "0.6.10"]
+
+    def test_missing_version_ignored(self):
+        assert collect_versions([{"infer": [{"timestamp": 1.0}]}]) == []
+
+    def test_unparseable_sorts_after_valid(self):
+        sm = {"a": [{"version": "0.6.0"}, {"version": "weird"}]}
+        assert collect_versions([sm]) == ["0.6.0", "weird"]

--- a/tests/unit/core/utils/test_meta.py
+++ b/tests/unit/core/utils/test_meta.py
@@ -11,6 +11,7 @@ from sieval.core.utils.meta import (
     build_model_call_meta,
     build_stage_meta,
     collect_versions,
+    report_versions,
 )
 
 
@@ -152,3 +153,35 @@ class TestCollectVersions:
     def test_unparseable_sorts_after_valid(self):
         sm = {"a": [{"version": "0.6.0"}, {"version": "weird"}]}
         assert collect_versions([sm]) == ["0.6.0", "weird"]
+
+
+class TestReportVersions:
+    def test_all_stamped_no_sentinel(self):
+        finals = [{"infer": [{"version": "0.6.0"}]}, {"infer": [{"version": "0.6.0"}]}]
+        assert report_versions(finals, []) == ["0.6.0"]
+
+    def test_empty_inputs(self):
+        assert report_versions([], []) == []
+
+    def test_unstamped_final_appends_unknown(self):
+        finals = [{"infer": [{"version": "0.7.0"}]}, {"feedback": [{"timestamp": 1.0}]}]
+        assert report_versions(finals, []) == ["0.7.0", "unknown"]
+
+    def test_fully_legacy_finals_is_unknown_only(self):
+        finals = [{}, {"infer": [{"timestamp": 1.0}]}]
+        assert report_versions(finals, []) == ["unknown"]
+
+    def test_unstamped_failed_does_not_add_sentinel(self):
+        # A FAILED record with no version is legitimate (failed before any
+        # stage produced versioned work) — only unstamped FINALs are legacy.
+        finals = [{"infer": [{"version": "0.7.0"}]}]
+        fails = [{}]
+        assert report_versions(finals, fails) == ["0.7.0"]
+
+    def test_blended_sorted_then_unknown_last(self):
+        finals = [
+            {"infer": [{"version": "0.6.0"}]},
+            {"infer": [{"version": "0.6.10"}]},
+            {},  # legacy, pre-provenance
+        ]
+        assert report_versions(finals, []) == ["0.6.0", "0.6.10", "unknown"]


### PR DESCRIPTION
## Type

- feature — new benchmark, task, or capability

## Summary

- Adds a version-compatibility **gate** to `--resume`: refuses to resume across an incompatible sieval version series (major post-1.0, minor under 1.0) or a dev/local-build mismatch. Exact-match first, so resuming your own build (including untagged dev builds) is never blocked; **fail-closed** on a missing/unreadable `meta.json`. No bypass flag — this strengthens the strict reproducibility contract, it does not add an escape hatch.
- Stamps the producing sieval version onto **every stage record** (`build_stage_meta`) as authoritative, non-rebuildable provenance. `report.json` gains a distinct, semver-sorted `versions[]` so a single-version run vs a blended (multi-version) resume is visible at a glance. Records produced before this feature (no stamp) surface as an `"unknown"` entry, so a legacy-blended report is never silently shown as single-version.
- `meta.json` is now written at **run start** (create-if-absent, never clobbered) so the format-stable version handshake exists for interrupted→resumed runs; it records the run's originating version.
- Within a compatible series, resume guarantees **functional** (not bit-numerical) compatibility; blended runs are *allowed* and made *auditable* via per-record provenance rather than blocked.

_CHANGELOG is intentionally not touched here — this project writes changelog entries at release time, so the entry is staged for the next release cut rather than committed per-PR._

## Related Issues

Closes #24

## Test Plan

### Automated

- [x] Lint/format clean (`ruff check && ruff format --check`)
- [x] Type check clean (`ty check`)
- [x] Unit tests pass (`pdm run pytest`) — full `tests/unit/core/` suite **834 passed**; changed-module set **145 passed**

### Manual

- [x] Not applicable — pure engine/behavior change, fully covered by unit tests: verdict-ladder table (EM / unparseable / 0.0.0 / dev-local / 1.0 boundary / compatible), gate wiring end-to-end via `MockTask` resume (incompatible blocks at construction, same-version resumes), `write_run_meta` create-if-absent + self-mkdir + non-fatal, and `report["versions"]` injection (single-version + non-dict-report guard).

## Checklist

### Required (all PRs)

- [x] PR title follows conventional format (`type(scope): description`)
- [x] No internal paths, credentials, or personal info in committed files
- [x] AI-generated code has `AI-Generated Code - <model> (<provider>)` in module docstring (new file `sieval/core/runners/resume_gate.py`)
- [x] No new upper-layer dependencies added to `core/` (only `from sieval import __version__` and `packaging`, already a base dependency)
- [x] Deleted code verified — additive change, no code removed

### If: Breaking Change

- [x] Described what breaks and migration path in Summary — one-time transition: a run interrupted under a pre-gate version that never wrote `meta.json` cannot be resumed under the gate; recover with "start fresh". Cross-version resume across an incompatible series now rejects (intended).
- [x] Existing tests updated to reflect new behavior — `test_resume_dir_selection_respects_auto_resume_flag` now seeds `meta.json` (gate requires it on resume; assertion unchanged); `test_retry_limit_failure_reason_and_message_are_user_visible` loosened from exact-dict equality to `report["total"] == 1` (additive `versions` key).
