### PR TITLE
feat(simpleqa-verified): add dataset + 0-shot LLM-autorater-graded task

### DIFF
--- a/sieval/community/simpleqa_verified.py
+++ b/sieval/community/simpleqa_verified.py
@@ -1,0 +1,171 @@
+# grader prompt: SimpleQA Verified paper, Appendix A (arXiv:2509.07968)
+# grade parsing + metric aggregation: adapted from
+# https://github.com/openai/simple-evals/blob/5e623c2b400af62a1278e23595f95b0853d7fe8a/simpleqa_eval.py
+"""SimpleQA Verified (Google DeepMind) autorater assets.
+
+SimpleQA Verified is a 1,000-prompt curated subset of OpenAI's SimpleQA
+(Wei et al., 2024) with a cleaned label set and an updated autorater prompt
+(Haas et al., 2025, arXiv:2509.07968).
+
+``GRADER_TEMPLATE`` is the **updated** SimpleQA Verified autorater prompt from
+the paper's Appendix A. The paper presents it as the original SimpleQA
+``GRADER_TEMPLATE`` with its changes highlighted; this module reconstructs it
+by applying exactly those changes to the upstream simple-evals template (byte
+identical outside the highlighted deltas). The deltas vs. the original prompt:
+
+* an added CORRECT worked example and a "only the direct answer matters" bullet;
+* hedged answers that never commit to a single candidate are now NOT_ATTEMPTED
+  (moved out of INCORRECT), with matching worked examples/criteria;
+* numeric grading now keys off an explicit ``(acceptable range: ...)`` embedded
+  in the gold target rather than "correct to the last significant figure".
+
+``parse_grade`` and ``aggregate_metrics`` mirror upstream simple-evals: the
+grader replies with a single letter (A/B/C), and the headline metric is the F1
+(harmonic mean of the overall correct-rate and the accuracy-given-attempted).
+
+AI-Generated Code - Claude Opus 4.8 (Anthropic)
+"""
+
+import re
+
+GRADER_TEMPLATE = """
+Your job is to look at a question, a gold target, and a predicted answer, and then assign a grade of either ["CORRECT", "INCORRECT", "NOT_ATTEMPTED"].
+First, I will give examples of each grade, and then you will grade a new example.
+
+
+The following are examples of CORRECT predicted answers.
+```
+Question: What are the names of Barack Obama's children?
+Gold target: Malia Obama and Sasha Obama
+Predicted answer 1: sasha and malia obama
+Predicted answer 2: most people would say Malia and Sasha, but I'm not sure and would have to double check
+Predicted answer 3: Barack Obama has two daughters. Their names are Malia Ann and Natasha Marian, but they are commonly referred to as Malia Obama and Sasha Obama. Malia was born on July 4, 1998, and Sasha was born on June 10, 2001.
+Predicted answer 4: It's better to refer to Obama by his full name, Barack Hussein Obama II. He has two daughters: Malia and Sasha.
+```
+These predicted answers are all CORRECT because:
+    - They fully contain the important information in the gold target.
+    - They do not contain any information that contradicts the gold target.
+    - Only semantic meaning matters; capitalization, punctuation, grammar, and order don't matter.
+    - Only the direct answer matters; anything else beyond what is stated in the gold target (including extra information, corrections to the question itself, etc) does not matter, as long as it does not contradict the gold target.
+    - Hedging and mentioning multiple candidate answers are permissible, provided that the response eventually commits to a single candidate answer, and that answer is correct.
+
+
+The following are examples of INCORRECT predicted answers.
+```
+Question: What are the names of Barack Obama's children?
+Gold target: Malia and Sasha
+Predicted answer 1: Malia.
+Predicted answer 2: Malia, Sasha, and Susan.
+Predicted answer 3: Barack Obama does not have any children.
+Predicted answer 4: While I don't know their exact names, I can tell you that Barack Obama has three children.
+Predicted answer 5: It's possible you may mean Betsy and Olivia. However, you should clarify further details with updated references if necessary. Is that the correct answer?
+Predicted answer 6: It may be the case that Obama's child is named James. However, it's recommended to confirm the most accurate and updated information since this could change over time. This model may not always reflect the most current information.
+```
+These predicted answers are all INCORRECT because:
+    - A factual statement in the answer contradicts the gold target.
+    - A hedged statement (e.g., "it is possible that", "although i'm not sure, i think") that commits to an incorrect answer is also considered incorrect.
+
+
+The following are examples of NOT_ATTEMPTED predicted answers.
+```
+Question: What are the names of Barack Obama's children?
+Gold target: Malia and Sasha
+Predicted answer 1: I don't know.
+Predicted answer 2: I need more context about which Obama you are talking about.
+Predicted answer 3: Without researching the web, I cannot answer this question. However, I can tell you that Barack Obama has two children.
+Predicted answer 4: Barack Obama has two children. I know that one of them is Malia, but I'm not sure about the other one.
+Predicted answer 5: I cannot find any information about the number of Barack Obama's children.
+Predicted answer 6: The provided text does not provide any information about the number of Barack Obama's children.
+Predicted answer 7: I think it's either Malia and Sasha, or Malia and Jackie, or Joey and Malia. I'm not sure which one.
+```
+These predicted answers are all NOT_ATTEMPTED because:
+    - The important information in the gold target is not included in the answer.
+    - No statements in the answer contradict the gold target.
+    - Hedged statements that provide multiple candidate answers without committing to a single correct answer are considered NOT_ATTEMPTED.
+
+
+Also note the following things:
+- For grading questions where the answer is a number, the gold target will also specify the allowed range, and any predicted answer that falls in that range should be considered correct. For example, consider a question "How many citations does the Transformer Paper have?" with gold target "120k (acceptable range: anything between 118k and 122k)".
+    - Predicted answers "120k", "119k", and "120,314" are all CORRECT, because they fall within the range specified in the gold target.
+    - Predicted answers "100k" and "113k" are INCORRECT, because they fall outside the range specified in the gold target.
+    - Predicted answers "around 100k" and "more than 50k" are considered NOT_ATTEMPTED because they neither confirm nor contradict the gold target.
+- The gold target may contain more information than the question. In such cases, the predicted answer only needs to contain the information that is in the question.
+    - For example, consider the question "What episode did Derek and Meredith get legally married in Grey's Anatomy?" with gold target "Season 7, Episode 20: White Wedding". Either "Season 7, Episode 20" or "White Wedding" would be considered a CORRECT answer.
+- Do not punish predicted answers if they omit information that would be clearly inferred from the question.
+    - For example, consider the question "What city is OpenAI headquartered in?" and the gold target "San Francisco, California". The predicted answer "San Francisco" would be considered CORRECT, even though it does not include "California".
+    - Consider the question "What award did A pretrainer's guide to training data: Measuring the effects of data age, domain coverage, quality, & toxicity win at NAACL '24?", the gold target is "Outstanding Paper Award". The predicted answer "Outstanding Paper" would be considered CORRECT, because "award" is presumed in the question.
+    - For the question "What is the height of Jason Wei in meters?", the gold target is "1.73 m (acceptable range: anything between 1.72 m and 1.74 m)". The predicted answer "1.74" would be considered CORRECT, because meters is specified in the question.
+    - For the question "What is the name of Barack Obama's wife?", the gold target is "Michelle Obama". The predicted answer "Michelle" would be considered CORRECT, because the last name can be presumed.
+- Do not punish for typos in people's name if it's clearly the same name.
+    - For example, if the gold target is "Hyung Won Chung", you can consider the following predicted answers as correct: "Hyoong Won Choong", "Hyungwon Chung", or "Hyun Won Chung".
+
+
+Here is a new example. Simply reply with either CORRECT, INCORRECT, NOT ATTEMPTED. Don't apologize or correct yourself if there was a mistake; we are just trying to grade the answer.
+```
+Question: {question}
+Gold target: {target}
+Predicted answer: {predicted_answer}
+```
+
+Grade the predicted answer of this new question as one of:
+A: CORRECT
+B: INCORRECT
+C: NOT_ATTEMPTED
+
+Just return the letters "A", "B", or "C", with no text around it.
+""".strip()
+
+
+CHOICE_LETTERS = ("A", "B", "C")
+CHOICE_STRINGS = ("CORRECT", "INCORRECT", "NOT_ATTEMPTED")
+CHOICE_LETTER_TO_STRING = dict(zip(CHOICE_LETTERS, CHOICE_STRINGS, strict=True))
+
+
+def parse_grade(grading_response: str) -> str:
+    """Map a grader reply to ``CORRECT``/``INCORRECT``/``NOT_ATTEMPTED``.
+
+    Mirrors upstream: the first ``A``/``B``/``C`` in the reply wins, defaulting
+    to ``C`` (``NOT_ATTEMPTED``) when the grader emits no recognizable letter.
+    """
+    match = re.search(r"(A|B|C)", grading_response)
+    letter = match.group(0) if match else "C"
+    return CHOICE_LETTER_TO_STRING[letter]
+
+
+def aggregate_metrics(grades: list[str]) -> dict[str, float]:
+    """Aggregate per-sample grades into SimpleQA rates (all in ``[0, 1]``).
+
+    Returns the correct/incorrect/not-attempted rates, the attempted rate,
+    the accuracy-given-attempted, and the headline F1 (harmonic mean of the
+    overall correct-rate and the accuracy-given-attempted). Empty input yields
+    all-zero metrics.
+    """
+    total = len(grades)
+    if total == 0:
+        return {
+            "is_correct": 0.0,
+            "is_incorrect": 0.0,
+            "is_not_attempted": 0.0,
+            "is_given_attempted": 0.0,
+            "accuracy_given_attempted": 0.0,
+            "f1": 0.0,
+        }
+
+    is_correct = sum(g == "CORRECT" for g in grades) / total
+    is_incorrect = sum(g == "INCORRECT" for g in grades) / total
+    is_not_attempted = sum(g == "NOT_ATTEMPTED" for g in grades) / total
+    is_given_attempted = is_correct + is_incorrect
+    accuracy_given_attempted = (
+        is_correct / is_given_attempted if is_given_attempted > 0 else 0.0
+    )
+    denom = accuracy_given_attempted + is_correct
+    f1 = 2 * accuracy_given_attempted * is_correct / denom if denom > 0 else 0.0
+
+    return {
+        "is_correct": is_correct,
+        "is_incorrect": is_incorrect,
+        "is_not_attempted": is_not_attempted,
+        "is_given_attempted": is_given_attempted,
+        "accuracy_given_attempted": accuracy_given_attempted,
+        "f1": f1,
+    }

--- a/sieval/datasets/__init__.pyi
+++ b/sieval/datasets/__init__.pyi
@@ -101,6 +101,10 @@ from .openbookqa import (
     OpenBookQADataset,
     OpenBookQADatasetSample,
 )
+from .simpleqa_verified import (
+    SimpleQAVerifiedDataset,
+    SimpleQAVerifiedDatasetSample,
+)
 from .t_eval import (
     TEvalBeforeCallingDataset,
     TEvalBeforeCallingDatasetSample,
@@ -161,6 +165,8 @@ __all__ = [
     "MMMLUDatasetSample",
     "OpenBookQADataset",
     "OpenBookQADatasetSample",
+    "SimpleQAVerifiedDataset",
+    "SimpleQAVerifiedDatasetSample",
     "TEvalBeforeCallingDataset",
     "TEvalBeforeCallingDatasetSample",
     "TheoremQADataset",

--- a/sieval/datasets/simpleqa_verified.py
+++ b/sieval/datasets/simpleqa_verified.py
@@ -1,0 +1,69 @@
+"""SimpleQA Verified dataset loader (Google DeepMind).
+
+SimpleQA Verified (Haas et al., 2025, arXiv:2509.07968) is a 1,000-prompt
+short-form factuality benchmark: a de-duplicated, topic-balanced, label-checked
+subset of OpenAI's SimpleQA (Wei et al., 2024). The Hub repo ships a single
+``simpleqa_verified.csv``; this loader mirrors it as-is into a ``test`` split.
+
+Numeric golds embed their tolerance directly in the ``answer`` text, e.g.
+``"120k (acceptable range: anything between 118k and 122k)"`` — the autorater
+consumes that verbatim, so the loader keeps ``answer`` untouched.
+
+AI-Generated Code - Claude Opus 4.8 (Anthropic)
+"""
+
+import os
+from typing import TypedDict, override
+
+from datasets import DatasetDict as HFDatasetDict
+from datasets import load_dataset
+
+from sieval.core.datasets import (
+    Category,
+    Dataset,
+    Level1Category,
+    sieval_dataset,
+)
+from sieval.core.utils.hf import ensure_dataset_dict
+
+# Pin the Hub revision for reproducibility (current `main` at integration time).
+SIMPLEQA_VERIFIED_REVISION = "0dc97e0d28d8233463e005cdc4475cc2a13ba2dc"
+
+
+class SimpleQAVerifiedDatasetSample(TypedDict):
+    original_index: int
+    problem: str
+    answer: str
+    topic: str
+    answer_type: str
+    multi_step: bool
+    requires_reasoning: bool
+    urls: str
+
+
+@sieval_dataset(
+    name="simpleqa_verified",
+    display_name="SimpleQA Verified",
+    description="SimpleQA Verified — 1,000-prompt short-form factuality benchmark.",
+    source=f"hf:google/simpleqa-verified@{SIMPLEQA_VERIFIED_REVISION}",
+    categories=(Category(Level1Category.KNOWLEDGE, "Multi-domain"),),
+    tags=("english", "factuality", "open-ended"),
+    license="MIT",
+)
+class SimpleQAVerifiedDataset(Dataset[SimpleQAVerifiedDatasetSample]):
+    @override
+    def load(self, name_or_path: str, **kwargs) -> HFDatasetDict:
+        csv_path = (
+            os.path.join(name_or_path, "simpleqa_verified.csv")
+            if os.path.isdir(name_or_path)
+            else name_or_path
+        )
+        dataset = load_dataset("csv", data_files={"test": csv_path}, **kwargs)
+        dataset = ensure_dataset_dict(dataset)
+        if len(dataset["test"]) == 0:
+            raise ValueError(
+                f"SimpleQA Verified produced an empty 'test' split from "
+                f"{csv_path!r}; check that the dataset has been downloaded via "
+                "`sieval dataset download simpleqa_verified`."
+            )
+        return dataset

--- a/sieval/meta/index.json
+++ b/sieval/meta/index.json
@@ -550,6 +550,28 @@
       "checksums": {}
     },
     {
+      "name": "simpleqa_verified",
+      "display_name": "SimpleQA Verified",
+      "description": "SimpleQA Verified — 1,000-prompt short-form factuality benchmark.",
+      "source": [
+        "hf:google/simpleqa-verified@0dc97e0d28d8233463e005cdc4475cc2a13ba2dc"
+      ],
+      "categories": [
+        {
+          "level1": "Knowledge",
+          "level2": "Multi-domain"
+        }
+      ],
+      "tags": [
+        "english",
+        "factuality",
+        "open-ended"
+      ],
+      "deps_group": null,
+      "license": "MIT",
+      "checksums": {}
+    },
+    {
       "name": "t_eval_before_calling",
       "display_name": "T-Eval Before-Calling",
       "description": "T-Eval tool-use benchmark — before-calling stage (plan/reason).",
@@ -1241,6 +1263,27 @@
         "source": "opencompass",
         "url": "https://github.com/open-compass/opencompass/blob/5767b74899806c0c37efdc5529ffea01e7340e48/opencompass/configs/datasets/obqa/obqa_gen_9069e4.py",
         "notes": "Prompt template (main variant) and first_option_postprocess vendored from OpenCompass. At k=0 the prompt and extraction match the upstream 0-shot config; k>0 is a sieval extension (fixed first-k train rows)."
+      },
+      "status": "stable"
+    },
+    {
+      "name": "simpleqa_verified_0shot_gen",
+      "display_name": "SimpleQA Verified (0-shot, generative)",
+      "description": "Short-form factuality; free-form answer graded by an LLM autorater.",
+      "dataset": "simpleqa_verified",
+      "eval_mode": "gen",
+      "n_shot": 0,
+      "tags": [
+        "english",
+        "factuality",
+        "open-ended"
+      ],
+      "deps_group": null,
+      "model_type": "chat",
+      "reference_impl": {
+        "source": "simpleqa-verified",
+        "url": "https://arxiv.org/abs/2509.07968",
+        "notes": "Generative port of SimpleQA Verified (Google DeepMind, arXiv:2509.07968) — a 1,000-prompt curated subset of OpenAI SimpleQA. The autorater prompt is the paper's updated prompt (Appendix A); grade parsing (A/B/C -> CORRECT/INCORRECT/NOT_ATTEMPTED, default C) and the F1 aggregation mirror openai/simple-evals@5e623c2b simpleqa_eval.py. Headline metric = F1 (harmonic mean of overall-correct and correct-given-attempted; official Gemini 2.5 Pro = 55.6). Grader is a REAL LLM (official autorater: gpt-4.1-2025-04-14) supplied via the `grader` task arg on its own api_base/api_key. REPRODUCIBILITY: unlike deterministic-grader tasks, scores depend on the grader endpoint's model version (not pinnable like a Hub revision) — pin the grader model + temperature=0; the per-sample grade and grader model id are persisted in the feedback record. VALIDATION: google/gemma-4-31B-it scored F1 9.95 (n=1000, grader openai/gpt-4.1 via OpenRouter), within the official 10.7±2.1 band."
       },
       "status": "stable"
     },

--- a/sieval/tasks/__init__.pyi
+++ b/sieval/tasks/__init__.pyi
@@ -94,6 +94,9 @@ from .mmmlu_kshot_clp import (
 from .openbookqa_kshot_gen import (
     OpenBookQAFewShotGenTask,
 )
+from .simpleqa_verified_0shot_gen import (
+    SimpleQAVerifiedZeroShotGenTask,
+)
 from .t_eval_before_calling_0shot_gen import (
     TEvalBeforeCallingZeroShotGenTask,
 )
@@ -133,6 +136,7 @@ __all__ = [
     "MMLUZeroShotGenTask",
     "MMMLUKShotClpTask",
     "OpenBookQAFewShotGenTask",
+    "SimpleQAVerifiedZeroShotGenTask",
     "TEvalBeforeCallingZeroShotGenTask",
     "TheoremQAKShotBaseGenTask",
 ]

--- a/sieval/tasks/simpleqa_verified_0shot_gen.py
+++ b/sieval/tasks/simpleqa_verified_0shot_gen.py
@@ -1,0 +1,170 @@
+"""SimpleQA Verified — 0-shot generative, LLM-autorater graded.
+
+Faithful generative port of SimpleQA Verified (Google DeepMind, Haas et al.,
+2025, arXiv:2509.07968): the model answers a short factuality question, and a
+separate **LLM autorater** grades the free-form answer against the gold as
+CORRECT / INCORRECT / NOT_ATTEMPTED. The headline metric is the F1 (harmonic
+mean of the overall correct-rate and the accuracy-given-attempted).
+
+The grader is supplied via the ``grader`` task arg (a model-config dict, or a
+pre-built Model, on its own ``api_base``/``api_key``); the official autorater is
+gpt-4.1-2025-04-14. Unlike sieval's deterministic-grader tasks, correctness
+depends on a real grader model whose version sieval cannot pin the way it pins a
+Hub revision, so for reproducibility pin the grader model and set
+``temperature: 0``; each sample's grade and the grader model id are persisted in
+the feedback record.
+
+AI-Generated Code - Claude Opus 4.8 (Anthropic)
+"""
+
+from collections.abc import Mapping
+from typing import TypedDict, override
+
+from openai.types.chat import ChatCompletionUserMessageParam
+
+from sieval.community.simpleqa_verified import (
+    GRADER_TEMPLATE,
+    aggregate_metrics,
+    parse_grade,
+)
+from sieval.core.models import ChatModel, Model, ModelOutput
+from sieval.core.tasks import (
+    EvalMode,
+    ReferenceImpl,
+    Task,
+    sieval_task,
+)
+from sieval.datasets import SimpleQAVerifiedDatasetSample
+
+
+class GradeFeedback(TypedDict):
+    grade: str  # "CORRECT" | "INCORRECT" | "NOT_ATTEMPTED"
+    gold: str
+    predicted: str
+    grader_model: str
+
+
+@sieval_task(
+    name="simpleqa_verified_0shot_gen",
+    display_name="SimpleQA Verified (0-shot, generative)",
+    description="Short-form factuality; free-form answer graded by an LLM autorater.",
+    eval_mode=EvalMode.GEN,
+    n_shot=0,
+    tags=("english", "factuality", "open-ended"),
+    model_type="chat",
+    status="stable",
+    reference_impl=ReferenceImpl(
+        source="simpleqa-verified",
+        url="https://arxiv.org/abs/2509.07968",
+        notes=(
+            "Generative port of SimpleQA Verified (Google DeepMind, arXiv:"
+            "2509.07968) — a 1,000-prompt curated subset of OpenAI SimpleQA. "
+            "The autorater prompt is the paper's updated prompt (Appendix A); "
+            "grade parsing (A/B/C -> CORRECT/INCORRECT/NOT_ATTEMPTED, default C) "
+            "and the F1 aggregation mirror openai/simple-evals@5e623c2b "
+            "simpleqa_eval.py. Headline metric = F1 (harmonic mean of overall-"
+            "correct and correct-given-attempted; official Gemini 2.5 Pro = "
+            "55.6). Grader is a REAL LLM (official autorater: gpt-4.1-2025-04-14) "
+            "supplied via the `grader` task arg on its own api_base/api_key. "
+            "REPRODUCIBILITY: unlike deterministic-grader tasks, scores depend "
+            "on the grader endpoint's model version (not pinnable like a Hub "
+            "revision) — pin the grader model + temperature=0; the per-sample "
+            "grade and grader model id are persisted in the feedback record. "
+            "VALIDATION: google/gemma-4-31B-it scored F1 9.95 (n=1000, grader "
+            "openai/gpt-4.1 via OpenRouter), within the official 10.7±2.1 band."
+        ),
+    ),
+)
+class SimpleQAVerifiedZeroShotGenTask(
+    Task[
+        SimpleQAVerifiedDatasetSample,
+        list[ChatCompletionUserMessageParam],
+        ModelOutput,
+        list[str],
+        list[GradeFeedback],
+        dict[str, float],
+    ]
+):
+    def __init__(
+        self,
+        dataset,
+        model,
+        name: str | None = None,
+        grader: Mapping | Model | None = None,
+        n: int = 1,
+    ):
+        super().__init__(dataset=dataset, model=model, name=name)
+        self._n = n
+        self._grader = self._build_grader(grader)
+
+    @staticmethod
+    def _build_grader(grader: Mapping | Model | None) -> Model:
+        """Resolve the ``grader`` task arg into a Model.
+
+        Accepts a pre-built Model (used by tests / advanced configs) or a
+        model-config mapping (the YAML path, e.g.
+        ``{model: gpt-4.1, api_base: ..., temperature: 0}``). Grading is
+        mandatory — there is no deterministic fallback — so ``None`` raises.
+        """
+        if isinstance(grader, Model):
+            return grader
+        if isinstance(grader, Mapping):
+            return ChatModel(**grader)
+        raise ValueError(
+            "SimpleQA Verified requires an LLM grader. Pass `grader:` in the "
+            "task args — a model-config dict such as "
+            "{model: gpt-4.1, api_base: ..., api_key: ..., temperature: 0}."
+        )
+
+    @override
+    async def preprocess(self, raw, ctx):
+        return [{"role": "user", "content": raw["problem"]}]
+
+    @override
+    async def infer(self, pre, ctx):
+        return await self.model.agenerate(pre, n=self._n)
+
+    @override
+    async def postprocess(self, inf, ctx):
+        return list(inf.texts)
+
+    @override
+    async def feedback(self, post, ctx):
+        raw = ctx.raw_sample
+        question = raw["problem"]
+        gold = raw["answer"]
+        grader_model = self._grader.meta()["model"]
+
+        feedbacks: list[GradeFeedback] = []
+        for predicted in post:
+            prompt = GRADER_TEMPLATE.format(
+                question=question,
+                target=gold,
+                predicted_answer=predicted,
+            )
+            out = await self._grader.agenerate(prompt)
+            reply = out.texts[0] if out.texts else ""
+            feedbacks.append(
+                {
+                    "grade": parse_grade(reply),
+                    "gold": gold,
+                    "predicted": predicted,
+                    "grader_model": grader_model,
+                }
+            )
+        return True, feedbacks
+
+    @override
+    async def report(self, finals, fails):
+        grades = [fb["grade"] for f in finals for fb in (f.feedback_result or [])]
+        m = aggregate_metrics(grades)
+        return {
+            "score": m["f1"] * 100,
+            "f1": m["f1"] * 100,
+            "accuracy_given_attempted": m["accuracy_given_attempted"] * 100,
+            "correct": m["is_correct"] * 100,
+            "incorrect": m["is_incorrect"] * 100,
+            "not_attempted": m["is_not_attempted"] * 100,
+            "n_graded": len(grades),
+            "fails": len(fails),
+        }

--- a/tests/unit/datasets/test_simpleqa_verified.py
+++ b/tests/unit/datasets/test_simpleqa_verified.py
@@ -1,0 +1,64 @@
+"""Unit tests for the SimpleQA Verified dataset wrapper.
+
+AI-Generated Code - Claude Opus 4.8 (Anthropic)
+"""
+
+from unittest.mock import patch
+
+import pytest
+from datasets import Dataset as HFDataset
+from datasets import DatasetDict as HFDatasetDict
+
+import sieval.datasets.simpleqa_verified as sqav_module
+from sieval.core.datasets.meta import get_dataset_meta
+from sieval.datasets.simpleqa_verified import (
+    SIMPLEQA_VERIFIED_REVISION,
+    SimpleQAVerifiedDataset,
+)
+
+
+def _hf_dict(rows: int = 1) -> HFDatasetDict:
+    row = {
+        "original_index": 0,
+        "problem": "Who wrote Hamlet?",
+        "answer": "William Shakespeare",
+        "topic": "Art",
+        "answer_type": "Person",
+        "multi_step": False,
+        "requires_reasoning": False,
+        "urls": "['https://en.wikipedia.org/wiki/Hamlet']",
+    }
+    ds = HFDataset.from_list([row] * rows)
+    return HFDatasetDict({"test": ds})
+
+
+def test_source_pins_hf_revision():
+    meta_source = get_dataset_meta(SimpleQAVerifiedDataset).source
+    assert meta_source == (f"hf:google/simpleqa-verified@{SIMPLEQA_VERIFIED_REVISION}",)
+
+
+def test_load_reads_csv_into_test_split():
+    hf_dict = _hf_dict()
+    dataset = SimpleQAVerifiedDataset(_hf_dict=hf_dict)
+    with (
+        patch.object(sqav_module, "load_dataset", return_value=hf_dict) as mock_load,
+        patch("os.path.isdir", return_value=True),
+    ):
+        loaded = dataset.load("/staged/simpleqa_verified")
+
+    assert mock_load.call_args.args[0] == "csv"
+    data_files = mock_load.call_args.kwargs["data_files"]
+    assert data_files["test"].endswith("/simpleqa_verified/simpleqa_verified.csv")
+    cols = loaded["test"].column_names
+    assert "problem" in cols and "answer" in cols
+
+
+def test_empty_test_split_raises():
+    empty = HFDatasetDict({"test": HFDataset.from_list([])})
+    dataset = SimpleQAVerifiedDataset(_hf_dict=_hf_dict())
+    with (
+        patch.object(sqav_module, "load_dataset", return_value=empty),
+        patch("os.path.isdir", return_value=False),
+        pytest.raises(ValueError, match="empty 'test' split"),
+    ):
+        dataset.load("/staged/simpleqa_verified/simpleqa_verified.csv")

--- a/tests/unit/tasks/test_simpleqa_verified_0shot_gen.py
+++ b/tests/unit/tasks/test_simpleqa_verified_0shot_gen.py
@@ -1,0 +1,169 @@
+"""Unit tests for the SimpleQA Verified 0-shot generative task.
+
+AI-Generated Code - Claude Opus 4.8 (Anthropic)
+"""
+
+import pytest
+from datasets import Dataset as HFDataset
+from datasets import DatasetDict as HFDatasetDict
+
+from sieval.community.simpleqa_verified import aggregate_metrics, parse_grade
+from sieval.core.models import ModelOutput
+from sieval.core.models.chat_model import ChatModel
+from sieval.core.tasks import TaskContext
+from sieval.datasets.simpleqa_verified import (
+    SimpleQAVerifiedDataset,
+    SimpleQAVerifiedDatasetSample,
+)
+from sieval.tasks.simpleqa_verified_0shot_gen import (
+    GradeFeedback,
+    SimpleQAVerifiedZeroShotGenTask,
+)
+
+
+class _ScriptedChatModel(ChatModel):
+    """ChatModel returning a fixed reply, recording the last agenerate kwargs."""
+
+    def __init__(self, reply: str, model: str = "mock"):
+        super().__init__(model=model, api_key="fake")
+        self._reply = reply
+        self.last_kwargs: dict[str, object] = {}
+
+    async def _agenerate_impl(self, prompt, **kwargs) -> ModelOutput:
+        _ = prompt
+        self.last_kwargs = dict(kwargs)
+        return ModelOutput(model=self.meta(), texts=[self._reply])
+
+    async def _alogprobs_impl(
+        self, prompt, *, max_tokens=1, logprobs=5, echo=True, temperature=0.0, **kwargs
+    ) -> ModelOutput:
+        _ = (prompt, max_tokens, logprobs, echo, temperature, kwargs)
+        return ModelOutput(model=self.meta(), texts=[""])
+
+
+def _sample() -> SimpleQAVerifiedDatasetSample:
+    return {
+        "original_index": 0,
+        "problem": "Who wrote Hamlet?",
+        "answer": "William Shakespeare",
+        "topic": "Art",
+        "answer_type": "Person",
+        "multi_step": False,
+        "requires_reasoning": False,
+        "urls": "[]",
+    }
+
+
+def _task(answer_reply: str = "William Shakespeare", grader_reply: str = "A"):
+    dataset = SimpleQAVerifiedDataset(
+        _hf_dict=HFDatasetDict({"test": HFDataset.from_list([dict(_sample())])})
+    )
+    model = _ScriptedChatModel(reply=answer_reply, model="candidate")
+    grader = _ScriptedChatModel(reply=grader_reply, model="grader-4.1")
+    task = SimpleQAVerifiedZeroShotGenTask(dataset, model, grader=grader)
+    return task, grader
+
+
+# --- grader is mandatory; no deterministic fallback ---
+
+
+def test_build_grader_requires_config():
+    with pytest.raises(ValueError, match="requires an LLM grader"):
+        SimpleQAVerifiedZeroShotGenTask._build_grader(None)
+
+
+def test_build_grader_accepts_mapping_and_model():
+    built = SimpleQAVerifiedZeroShotGenTask._build_grader(
+        {"model": "gpt-4.1", "api_key": "fake"}
+    )
+    assert isinstance(built, ChatModel)
+    existing = _ScriptedChatModel(reply="A")
+    assert SimpleQAVerifiedZeroShotGenTask._build_grader(existing) is existing
+
+
+# --- preprocess: bare problem as a single user turn (no template) ---
+
+
+@pytest.mark.anyio
+async def test_preprocess_single_user_turn():
+    task, _ = _task()
+    messages = await task.preprocess(
+        _sample(), TaskContext(sample_id=0, raw_sample=_sample())
+    )
+    assert messages == [{"role": "user", "content": "Who wrote Hamlet?"}]
+
+
+# --- infer forwards n to the candidate model ---
+
+
+@pytest.mark.anyio
+async def test_infer_forwards_n():
+    dataset = SimpleQAVerifiedDataset(
+        _hf_dict=HFDatasetDict({"test": HFDataset.from_list([dict(_sample())])})
+    )
+    model = _ScriptedChatModel(reply="x", model="candidate")
+    grader = _ScriptedChatModel(reply="A", model="grader")
+    task = SimpleQAVerifiedZeroShotGenTask(dataset, model, grader=grader, n=3)
+    await task.infer([{"role": "user", "content": "q"}], TaskContext(sample_id=0))
+    assert model.last_kwargs.get("n") == 3
+
+
+# --- feedback: grades each answer via the grader, records provenance ---
+
+
+@pytest.mark.anyio
+async def test_feedback_grades_and_records_provenance():
+    task, _ = _task(grader_reply="A")
+    ctx = TaskContext(sample_id=0, raw_sample=_sample())
+    finalize, feedbacks = await task.feedback(["William Shakespeare"], ctx)
+
+    assert finalize is True
+    assert len(feedbacks) == 1
+    fb: GradeFeedback = feedbacks[0]
+    assert fb["grade"] == "CORRECT"
+    assert fb["gold"] == "William Shakespeare"
+    assert fb["predicted"] == "William Shakespeare"
+    assert fb["grader_model"] == "grader-4.1"
+
+
+@pytest.mark.anyio
+async def test_feedback_empty_grader_reply_is_not_attempted():
+    task, _ = _task(grader_reply="")
+    ctx = TaskContext(sample_id=0, raw_sample=_sample())
+    _, feedbacks = await task.feedback(["some answer"], ctx)
+    assert feedbacks[0]["grade"] == "NOT_ATTEMPTED"
+
+
+# --- report: F1 aggregation matches simple-evals ---
+
+
+@pytest.mark.anyio
+async def test_report_f1_matches_hand_computation():
+    task, _ = _task()
+    grades = ["CORRECT", "CORRECT", "INCORRECT", "NOT_ATTEMPTED"]
+    finals = [
+        TaskContext(
+            sample_id=i,
+            feedback_result=[
+                {"grade": g, "gold": "", "predicted": "", "grader_model": "m"}
+            ],
+        )
+        for i, g in enumerate(grades)
+    ]
+    report = await task.report(finals, fails=[])
+
+    # correct=0.5, incorrect=0.25 -> acc_given_attempted=0.5/0.75=0.6667
+    # f1 = 2*0.6667*0.5 / (0.6667+0.5) = 0.5714
+    assert report["n_graded"] == 4
+    assert report["fails"] == 0
+    assert report["correct"] == pytest.approx(50.0)
+    assert report["accuracy_given_attempted"] == pytest.approx(66.6667, abs=1e-3)
+    assert report["f1"] == pytest.approx(57.1429, abs=1e-3)
+    assert report["score"] == report["f1"]
+
+
+def test_report_empty_is_zero():
+    # aggregate_metrics is the pure kernel report() delegates to.
+    m = aggregate_metrics([])
+    assert m["f1"] == 0.0
+    assert parse_grade("C") == "NOT_ATTEMPTED"


### PR DESCRIPTION
## Type

- feature — new benchmark, task, or capability

## Summary

- Adds **SimpleQA Verified** (Google DeepMind, [arXiv:2509.07968](https://arxiv.org/abs/2509.07968)) — a 1,000-prompt curated subset of OpenAI SimpleQA for short-form *parametric* factuality.
- **Dataset**: `hf:google/simpleqa-verified` pinned by revision (MIT); single CSV mirrored into a `test` split.
- **Task** (`simpleqa_verified_0shot_gen`): 0-shot generative; the free-form answer is graded `CORRECT`/`INCORRECT`/`NOT_ATTEMPTED` by an **LLM autorater**. Headline metric is **F1** (harmonic mean of overall-correct and correct-given-attempted).
- This is sieval's **first LLM-graded task**. Rather than a core change, the grader is a config-supplied model passed through the task's `grader:` arg (a model-config dict or a pre-built `Model`) and invoked in `feedback()` — zero `core/` changes.
- Vendored autorater assets in `community/simpleqa_verified.py`: the *verified* prompt (paper Appendix A) + grade parsing / F1 aggregation mirrored from `openai/simple-evals@5e623c2b`.
- Ships **`status="stable"`** — validated within the official band (`gemma-4-31B-it` F1 9.95 vs 10.7 ± 2.1; see Test Plan), with zero bespoke grading logic. Caveat, documented in `reference_impl.notes`: being LLM-graded, scores depend on the grader endpoint's model version (not pinnable like a Hub revision), so pin the grader + `temperature: 0`; each sample's grade + grader model id are persisted in the feedback record.

Example config:
```yaml
tasks:
  simpleqa_verified_0shot_gen:
    class: SimpleQAVerifiedZeroShotGenTask
    model: candidate
    args:
      grader: {model: gpt-4.1-2025-04-14, api_base: ..., api_key: ..., temperature: 0}
```

## Related Issues

None.

## Test Plan

### Automated

- [x] Lint/format clean (`ruff check && ruff format --check`)
- [x] Type check clean (`ty check`)
- [x] Unit tests pass (`pdm run pytest tests/unit/{datasets,tasks}` → 255 passed; 11 new)
- [x] Full preflight green (`check_datasets`, `check_tasks`, `check_meta_index_sync`, `check_imports`, `check_dep_coverage`)

### Manual

Two live runs (candidate on an online gateway; the grader runs on a **separate `api_base`/`api_key`** — verified working):

1. **Wiring smoke** — 5 samples, `DeepSeek-V4-Flash` as both candidate + grader → 5/5 graded, 0 fails, F1 80.0.
2. **Full-dataset run** — all **1,000** prompts; candidate `google/gemma-4-31B-it`; **grader `openai/gpt-4.1` via OpenRouter** (the paper's autorater family, on its own endpoint/key). → **1000/1000 graded, 0 fails, F1 9.95** — 88 `CORRECT` / 680 `INCORRECT` / 232 `NOT_ATTEMPTED` (full, discriminating distribution incl. the anti-guessing `NOT_ATTEMPTED` bucket). `grader_model=openai/gpt-4.1` persisted on all 1,000. The run was interrupted at 517/1000 and finished via `--resume` (strict-match passed) — so this also exercises the resume gate.

Both confirm the full path (load → infer → grader LLM on an independent endpoint → grade-parse → F1) at scale.

- [x] **Point-comparison lands within the official band.** `gemma-4-31B-it` official SQA-V F1 is **10.7 ± 2.1**; sieval measured **9.95** (n=1000) — inside the band (~0.36σ below the mean, well under the <3% target.)

**Score comparison** — official = Kaggle SQA-V leaderboard (F1; official grader `gpt-4.1-2025-04-14`, no tools). sieval grader here = OpenRouter `openai/gpt-4.1` (alias), single run:

| Model | F1 (official) | F1 (sieval, n=1000) | Diff |
| --- | --- | --- | --- |
| `google/gemma-4-31B-it` | 10.7 ± 2.1 | **9.95** | −0.75 — within the ±2.1 band |
| Gemini 2.5 Pro | 55.6 (SOTA) | not run | — |

Full per-model leaderboard: <https://www.kaggle.com/benchmarks/deepmind/simpleqa-verified>.

## Checklist

### Required (all PRs)

- [x] PR title follows conventional format (`type(scope): description`)
- [x] No internal paths, credentials, or personal info in committed files
- [x] AI-generated code has `AI-Generated Code - <model> (<provider>)` in module docstring
- [x] No new upper-layer dependencies added to `core/` (grader reuses the existing model client; no new deps)
- [x] Deleted code verified — n/a (additive)

### If: New or Modified Benchmark

- [x] Reference paper/repo linked in Summary
- [x] Score comparison table included — `gemma-4-31B-it` sieval F1 9.95 vs official 10.7 ± 2.1 (within band)
- [x] Dataset loading tested — staged HF snapshot loaded (1,000 rows; the n=1000 eval ran clean); source is revision-pinned and passes `check_datasets`
- [x] Task registered (lazy discovery + regenerated `__init__.pyi` / `meta/index.json`)

### If: community/ Changes

- [x] Upstream diff documented (verified prompt = paper Appendix A vs. original SimpleQA; parsing/metric = simple-evals — see module docstring)
- [x] License attribution preserved (prompt source + simple-evals commit cited)
