### PR TITLE
feat(hmmt): add MathArena-aligned HMMT Nov 2025 benchmark

### DIFF
--- a/.claude/rules/datasets.md
+++ b/.claude/rules/datasets.md
@@ -10,6 +10,25 @@ paths:
 - New datasets must be downloadable via `sieval dataset download <name>`; the `source` field is the authoritative origin.
 - Verify with `python scripts/check_preflight.py --check check_datasets` after adding new datasets
 
+## Upstream Sample Shape
+
+There is no shared cross-benchmark sample schema — every Task binds 1:1 to its own sample
+`TypedDict`, so nothing downstream benefits from two loaders agreeing on a field name or a
+dtype. Both rules below therefore start from "what does the pinned revision actually ship",
+not "what does the sibling loader do".
+
+- **Keep upstream field names.** Rename only when the upstream name is unusable as-is (not a
+  valid identifier, e.g. `Short Answer`; or it collides). Never rename for uniformity with a
+  sibling loader — a rename is a permanent divergence from the upstream card that every future
+  reader has to reconcile.
+- **Cast a column's dtype only when the pinned revision requires it.** Measure the pinned
+  snapshot (HF datasets-server, or just load it) instead of copying a sibling: a cast that
+  matches the dtype upstream already ships is a no-op that reads as a guarantee. Content-inferred
+  dtypes (CSV/JSON parsing) and mismatched dtypes are the load-bearing cases.
+- Either way, say **which case it is** in a comment — including when the answer is "no cast
+  needed, upstream already ships this dtype". Otherwise the next edit that restores uniformity
+  looks like a cleanup.
+
 ## Dataset Metadata: `@sieval_dataset`
 
 - Every concrete `Dataset[TSample]` subclass must be decorated with `@sieval_dataset(...)` from `sieval.core.datasets`.

--- a/.claude/rules/datasets.md
+++ b/.claude/rules/datasets.md
@@ -13,21 +13,15 @@ paths:
 ## Upstream Sample Shape
 
 There is no shared cross-benchmark sample schema — every Task binds 1:1 to its own sample
-`TypedDict`, so nothing downstream benefits from two loaders agreeing on a field name or a
-dtype. Both rules below therefore start from "what does the pinned revision actually ship",
-not "what does the sibling loader do".
+`TypedDict`, so nothing downstream gains from two loaders agreeing on a field name or dtype.
 
 - **Keep upstream field names.** Rename only when the upstream name is unusable as-is (not a
-  valid identifier, e.g. `Short Answer`; or it collides). Never rename for uniformity with a
-  sibling loader — a rename is a permanent divergence from the upstream card that every future
-  reader has to reconcile.
-- **Cast a column's dtype only when the pinned revision requires it.** Measure the pinned
-  snapshot (HF datasets-server, or just load it) instead of copying a sibling: a cast that
-  matches the dtype upstream already ships is a no-op that reads as a guarantee. Content-inferred
-  dtypes (CSV/JSON parsing) and mismatched dtypes are the load-bearing cases.
-- Either way, say **which case it is** in a comment — including when the answer is "no cast
-  needed, upstream already ships this dtype". Otherwise the next edit that restores uniformity
-  looks like a cleanup.
+  valid identifier, e.g. `Short Answer`, or it collides) — never for uniformity with a sibling.
+- **Cast a column's dtype only when the pinned revision requires it.** Measure the snapshot
+  instead of copying a sibling; a cast matching the dtype upstream already ships is a no-op that
+  reads as a guarantee. CSV/JSON content-inferred dtypes are the load-bearing case.
+- Say **which case it is** in a comment, including "no cast needed, upstream ships this dtype" —
+  otherwise restoring uniformity looks like a cleanup.
 
 ## Dataset Metadata: `@sieval_dataset`
 

--- a/.claude/rules/tasks.md
+++ b/.claude/rules/tasks.md
@@ -19,7 +19,9 @@ paths:
 
 - Add benchmark-specific dependencies to `pyproject.toml` optional dependency groups (e.g., `[project.optional-dependencies.benchmark_name]`)
 - New datasets must be downloadable via `sieval dataset download <name>` — verify the `source` field (`hf:` / `url:` / `local:`) resolves.
-- Stub sync (`scripts/sync_package_stubs.py`), meta index (`scripts/sync_meta_index.py`), ruff check, and ty check are now automated via PostToolUse hooks — no need to run manually
+- Record the upstream **repeat/sampling protocol** in `reference_impl.notes` whenever it differs from this task's default `n` (e.g. matharena's runner default `--n 4`; simple-evals' `n_repeats`), and say how to match it. A default that silently diverges makes scores look comparable to the reference when they are not. Nothing enforces this — it needs upstream knowledge.
+- Stub sync (`scripts/sync_package_stubs.py`) and meta index (`scripts/sync_meta_index.py`) are wired to a PostToolUse hook in `.claude/settings.json`, so a Write/Edit under `sieval/tasks/` or `sieval/datasets/` inside a Claude Code session regenerates both — in the checkout that owns the edited file, worktrees included. Convenience, not a guarantee: the hook does not fire for `sed -i`, `git apply`, a rebase, or any edit made outside the session. Verify before committing with `python scripts/sync_meta_index.py --check` and `python scripts/sync_package_stubs.py --check` — preflight's `check_meta_index_sync` fails CI on index drift, and stub drift has no automated enforcer at all.
+- ruff and ty also run from that hook on each edited `.py`/`.pyi`, but they only report — run the full `ruff check` / `ty check` before committing.
 - Run `python scripts/check_preflight.py --check check_tasks` to verify naming, tags, and imports
 
 ## Code Quality

--- a/.claude/rules/tasks.md
+++ b/.claude/rules/tasks.md
@@ -19,9 +19,9 @@ paths:
 
 - Add benchmark-specific dependencies to `pyproject.toml` optional dependency groups (e.g., `[project.optional-dependencies.benchmark_name]`)
 - New datasets must be downloadable via `sieval dataset download <name>` — verify the `source` field (`hf:` / `url:` / `local:`) resolves.
-- Record the upstream **repeat/sampling protocol** in `reference_impl.notes` whenever it differs from this task's default `n` (e.g. matharena's runner default `--n 4`; simple-evals' `n_repeats`), and say how to match it. A default that silently diverges makes scores look comparable to the reference when they are not. Nothing enforces this — it needs upstream knowledge.
-- Stub sync (`scripts/sync_package_stubs.py`) and meta index (`scripts/sync_meta_index.py`) are wired to a PostToolUse hook in `.claude/settings.json`, so a Write/Edit under `sieval/tasks/` or `sieval/datasets/` inside a Claude Code session regenerates both — in the checkout that owns the edited file, worktrees included. Convenience, not a guarantee: the hook does not fire for `sed -i`, `git apply`, a rebase, or any edit made outside the session. Verify before committing with `python scripts/sync_meta_index.py --check` and `python scripts/sync_package_stubs.py --check` — preflight's `check_meta_index_sync` fails CI on index drift, and stub drift has no automated enforcer at all.
-- ruff and ty also run from that hook on each edited `.py`/`.pyi`, but they only report — run the full `ruff check` / `ty check` before committing.
+- Record the upstream **repeat/sampling protocol** in `reference_impl.notes` when it differs from this task's default `n` (matharena's runner default `--n 4`; simple-evals' `n_repeats`), and say how to match it. Nothing enforces this — it needs upstream knowledge.
+- The PostToolUse hooks in `.claude/settings.json` regenerate stubs + `meta/index.json` on a Write/Edit under `sieval/tasks/` or `sieval/datasets/`, in the checkout that owns the file. They do not fire for `sed -i`, `git apply`, or a rebase, so `--check` both sync scripts before committing: CI fails on a stale `meta/index.json`, and stub drift has no enforcer at all.
+- ruff and ty run from the same hooks but only report — run the full `ruff check` / `ty check` before committing.
 - Run `python scripts/check_preflight.py --check check_tasks` to verify naming, tags, and imports
 
 ## Code Quality

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,13 +6,13 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python -c \"import json,sys; d=json.load(sys.stdin); print(d.get('tool_input',{}).get('file_path','') or d.get('tool_response',{}).get('filePath',''))\" | { read -r f; echo \"$f\" | grep -qE '\\.pyi?$' && echo \"$f\" | grep -qE '^sieval/(tasks|datasets)/' && python scripts/sync_package_stubs.py || true; }",
+            "command": "python -c \"import json,sys; d=json.load(sys.stdin); print(d.get('tool_input',{}).get('file_path','') or d.get('tool_response',{}).get('filePath',''))\" | { read -r f; echo \"$f\" | grep -qE '\\.pyi?$' && echo \"$f\" | grep -qE '(^|/)sieval/(tasks|datasets)/' || exit 0; r=$(git -C \"$(dirname \"$f\")\" rev-parse --show-toplevel 2>/dev/null) && [ -f \"$r/scripts/sync_package_stubs.py\" ] && python \"$r/scripts/sync_package_stubs.py\" || true; }",
             "timeout": 30,
             "statusMessage": "Post-edit checks..."
           },
           {
             "type": "command",
-            "command": "python -c \"import json,sys; d=json.load(sys.stdin); print(d.get('tool_input',{}).get('file_path','') or d.get('tool_response',{}).get('filePath',''))\" | { read -r f; echo \"$f\" | grep -qE '^sieval/(tasks|datasets)/.*\\.py$' && python scripts/sync_meta_index.py || true; }",
+            "command": "python -c \"import json,sys; d=json.load(sys.stdin); print(d.get('tool_input',{}).get('file_path','') or d.get('tool_response',{}).get('filePath',''))\" | { read -r f; echo \"$f\" | grep -qE '(^|/)sieval/(tasks|datasets)/.*\\.py$' || exit 0; r=$(git -C \"$(dirname \"$f\")\" rev-parse --show-toplevel 2>/dev/null) && [ -f \"$r/scripts/sync_meta_index.py\" ] && python \"$r/scripts/sync_meta_index.py\" || true; }",
             "timeout": 30,
             "statusMessage": "Post-edit checks..."
           },

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,18 +75,15 @@ See [tests/README.md](tests/README.md) for mock infrastructure and full command 
 
 ## Adding a New Benchmark
 
-1. Create dataset in `sieval/datasets/` — keep the upstream field names and only cast a column's
-   dtype if the pinned revision actually requires it; renaming or casting for uniformity with a
-   sibling loader is divergence, not consistency (each Task binds 1:1 to its own sample `TypedDict`,
-   so no consumer needs a shared shape)
+1. Create dataset in `sieval/datasets/` — keep upstream field names, and cast a column's dtype
+   only if the pinned revision requires it (each Task binds 1:1 to its own sample `TypedDict`, so
+   uniformity with a sibling loader buys nothing)
 2. Create task in `sieval/tasks/` — file naming: `<task>_<N>shot_<mode>.py` (see `sieval/tasks/CLAUDE.md`)
-3. If the reference implementation repeats sampling (e.g. `n_repeats`, `--n 4`) and your task's
-   default `n` differs, record that in `reference_impl.notes` along with how to match it — otherwise
-   scores look comparable to the reference when they are not
+3. If the reference implementation repeats sampling (`n_repeats`, `--n 4`) and your task's default
+   `n` differs, record that in `reference_impl.notes` with how to match it
 4. Add unit tests under `tests/unit/datasets/` and `tests/unit/tasks/` mirroring the source layout
 5. Run `python scripts/sync_package_stubs.py` and `python scripts/sync_meta_index.py` to regenerate
-   type stubs and the registry, then `--check` both to confirm nothing is left dirty — CI fails on a
-   stale `meta/index.json`
+   type stubs and the registry, then `--check` both — CI fails on a stale `meta/index.json`
 6. Third-party evaluation code goes in `sieval/community/` with proper attribution
 
 ## Submitting Changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,11 +75,19 @@ See [tests/README.md](tests/README.md) for mock infrastructure and full command 
 
 ## Adding a New Benchmark
 
-1. Create dataset in `sieval/datasets/`
+1. Create dataset in `sieval/datasets/` — keep the upstream field names and only cast a column's
+   dtype if the pinned revision actually requires it; renaming or casting for uniformity with a
+   sibling loader is divergence, not consistency (each Task binds 1:1 to its own sample `TypedDict`,
+   so no consumer needs a shared shape)
 2. Create task in `sieval/tasks/` — file naming: `<task>_<N>shot_<mode>.py` (see `sieval/tasks/CLAUDE.md`)
-3. Add unit tests under `tests/unit/datasets/` and `tests/unit/tasks/` mirroring the source layout
-4. Run `python scripts/sync_package_stubs.py` and `python scripts/sync_meta_index.py` to regenerate type stubs and the registry
-5. Third-party evaluation code goes in `sieval/community/` with proper attribution
+3. If the reference implementation repeats sampling (e.g. `n_repeats`, `--n 4`) and your task's
+   default `n` differs, record that in `reference_impl.notes` along with how to match it — otherwise
+   scores look comparable to the reference when they are not
+4. Add unit tests under `tests/unit/datasets/` and `tests/unit/tasks/` mirroring the source layout
+5. Run `python scripts/sync_package_stubs.py` and `python scripts/sync_meta_index.py` to regenerate
+   type stubs and the registry, then `--check` both to confirm nothing is left dirty — CI fails on a
+   stale `meta/index.json`
+6. Third-party evaluation code goes in `sieval/community/` with proper attribution
 
 ## Submitting Changes
 

--- a/scripts/check_preflight.py
+++ b/scripts/check_preflight.py
@@ -24,10 +24,9 @@ if TYPE_CHECKING:
     from sieval.core.datasets.meta import DatasetMeta
 
 # Check THIS checkout, which is also the tree the path-based checks walk.
-# `python scripts/check_preflight.py` puts scripts/ on sys.path[0] and never adds
-# the repo root, so the registry imports below otherwise resolve through the
-# editable install — in a git worktree that is a different checkout, and the run
-# would validate the other branch's code while reporting on this one.
+# `python scripts/x.py` puts scripts/ on sys.path[0] but never the repo root, so
+# the registry imports below otherwise resolve through the editable install —
+# from a worktree, that validates another branch while reporting on this one.
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 # Known import-name → package-name mismatches

--- a/scripts/check_preflight.py
+++ b/scripts/check_preflight.py
@@ -23,6 +23,13 @@ from typing import TYPE_CHECKING, Literal
 if TYPE_CHECKING:
     from sieval.core.datasets.meta import DatasetMeta
 
+# Check THIS checkout, which is also the tree the path-based checks walk.
+# `python scripts/check_preflight.py` puts scripts/ on sys.path[0] and never adds
+# the repo root, so the registry imports below otherwise resolve through the
+# editable install — in a git worktree that is a different checkout, and the run
+# would validate the other branch's code while reporting on this one.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
 # Known import-name → package-name mismatches
 _IMPORT_TO_PACKAGE: dict[str, str] = {
     "sklearn": "scikit-learn",

--- a/scripts/sync_meta_index.py
+++ b/scripts/sync_meta_index.py
@@ -8,10 +8,9 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 # Import sieval from THIS checkout, which is also where the index is written.
-# `python scripts/sync_meta_index.py` puts scripts/ on sys.path[0] and never adds
-# the repo root, so `import sieval` otherwise resolves through the editable
-# install — in a git worktree that is a different checkout, and the script would
-# happily write the other branch's registry here.
+# `python scripts/x.py` puts scripts/ on sys.path[0] but never the repo root, so
+# `import sieval` otherwise resolves through the editable install — from a
+# worktree that is a different checkout, whose registry would be written here.
 sys.path.insert(0, str(ROOT))
 
 from sieval.core.datasets.meta import (  # noqa: E402

--- a/scripts/sync_meta_index.py
+++ b/scripts/sync_meta_index.py
@@ -3,20 +3,28 @@
 import argparse
 import json
 import os
+import sys
 from pathlib import Path
 
-from sieval.core.datasets.meta import (
+ROOT = Path(__file__).resolve().parents[1]
+# Import sieval from THIS checkout, which is also where the index is written.
+# `python scripts/sync_meta_index.py` puts scripts/ on sys.path[0] and never adds
+# the repo root, so `import sieval` otherwise resolves through the editable
+# install — in a git worktree that is a different checkout, and the script would
+# happily write the other branch's registry here.
+sys.path.insert(0, str(ROOT))
+
+from sieval.core.datasets.meta import (  # noqa: E402
     dataset_meta_to_dict,
     import_all_datasets,
     iter_dataset_metas,
 )
-from sieval.core.tasks.meta import (
+from sieval.core.tasks.meta import (  # noqa: E402
     import_all_tasks,
     iter_task_metas,
     task_meta_to_dict,
 )
 
-ROOT = Path(__file__).resolve().parents[1]
 INDEX_PATH = ROOT / "sieval" / "meta" / "index.json"
 
 

--- a/sieval/community/matharena.py
+++ b/sieval/community/matharena.py
@@ -1,7 +1,7 @@
 """MathArena-aligned prompting and answer extraction.
 
 Mirrors the eth-sri/matharena (MIT) reference implementation so sieval's
-AIME/HMMT 2026 tasks elicit and parse answers the same way matharena.ai does:
+AIME/HMMT tasks elicit and parse answers the same way matharena.ai does:
 
 * the per-competition ``instruction`` strings from
   ``configs/competitions/{aime,hmmt}/*.yaml`` (final answer in ``\\boxed{}``;
@@ -183,8 +183,8 @@ def extract_answer(text: str, strict_parsing: bool = False) -> str | None:
     """matharena-aligned extraction.
 
     Take the last ``\\boxed{}``; if absent and ``strict_parsing`` is false,
-    fall back to the last integer (both AIME 2026 and HMMT Feb 2026 set
-    ``strict_parsing: false``).
+    fall back to the last integer (every AIME/HMMT competition config sieval
+    ports sets ``strict_parsing: false``).
     """
     boxed = extract_boxed_answer(text)
     if boxed is not None:

--- a/sieval/datasets/__init__.pyi
+++ b/sieval/datasets/__init__.pyi
@@ -69,6 +69,10 @@ from .hmmt_feb_2026 import (
     HMMTFeb2026Dataset,
     HMMTFeb2026DatasetSample,
 )
+from .hmmt_nov_2025 import (
+    HMMTNov2025Dataset,
+    HMMTNov2025DatasetSample,
+)
 from .human_eval import (
     HumanEvalDataset,
     HumanEvalDatasetSample,
@@ -157,6 +161,8 @@ __all__ = [
     "HMMTFeb2025DatasetSample",
     "HMMTFeb2026Dataset",
     "HMMTFeb2026DatasetSample",
+    "HMMTNov2025Dataset",
+    "HMMTNov2025DatasetSample",
     "HellaSwagDataset",
     "HellaSwagDatasetSample",
     "HendrycksMathDataset",

--- a/sieval/datasets/aime_2026.py
+++ b/sieval/datasets/aime_2026.py
@@ -38,12 +38,10 @@ class AIME2026DatasetSample(TypedDict):
 )
 class AIME2026Dataset(Dataset[AIME2026DatasetSample]):
     def _strip_sample(self, sample: AIME2026DatasetSample) -> AIME2026DatasetSample:
-        # Normalize the gold answer only; the problem text stays verbatim.
-        # strip_string is an answer normalizer (it rewrites \frac/\sqrt, drops
-        # \left/\right) and mangles full problem LaTeX — e.g. \sqrt[20]{x} becomes
-        # \sqrt{[}20]{x} and \tfrac pq becomes \frac{ }{p}q. DEVIATION: matharena
-        # does not normalize golds at all; sieval does so math-verify compares
-        # canonical forms.
+        # Gold answer only; problem text stays verbatim — strip_string normalizes
+        # answers (rewrites \frac/\sqrt, drops \left/\right) and mangles problem
+        # LaTeX (\sqrt[20]{x} -> \sqrt{[}20]{x}). DEVIATION: matharena does not
+        # normalize golds; sieval does, so math-verify compares canonical forms.
         sample["answer"] = strip_string(sample["answer"])
         return sample
 

--- a/sieval/datasets/aime_2026.py
+++ b/sieval/datasets/aime_2026.py
@@ -23,7 +23,7 @@ AIME_2026_REVISION = "d2de22f3c656b4f56cf8981212186377d1e23bc3"
 
 
 class AIME2026DatasetSample(TypedDict):
-    question: str
+    problem: str
     answer: str
 
 
@@ -38,21 +38,20 @@ class AIME2026DatasetSample(TypedDict):
 )
 class AIME2026Dataset(Dataset[AIME2026DatasetSample]):
     def _strip_sample(self, sample: AIME2026DatasetSample) -> AIME2026DatasetSample:
-        # Normalize the answer only; leave the problem text verbatim. strip_string
-        # is an answer normalizer (it rewrites \frac/\sqrt, drops \left/\right) and
-        # mangles full problem LaTeX if applied to the question — e.g. \sqrt[20]{x}
-        # becomes \sqrt{[}20]{x} and \tfrac pq becomes \frac{ }{p}q. Matches the
-        # aime_2024 / math_500 loaders.
+        # Normalize the gold answer only; the problem text stays verbatim.
+        # strip_string is an answer normalizer (it rewrites \frac/\sqrt, drops
+        # \left/\right) and mangles full problem LaTeX — e.g. \sqrt[20]{x} becomes
+        # \sqrt{[}20]{x} and \tfrac pq becomes \frac{ }{p}q. DEVIATION: matharena
+        # does not normalize golds at all; sieval does so math-verify compares
+        # canonical forms.
         sample["answer"] = strip_string(sample["answer"])
         return sample
 
     @override
     def load(self, name_or_path: str, **kwargs) -> HFDatasetDict:
         # MathArena exposes a single `default` config under the `train` split with
-        # columns problem / answer / problem_idx. Rename `problem` -> `question` to
-        # match the shared AIME sample schema.
+        # columns problem / answer / problem_idx, kept under their upstream names.
         dataset = ensure_dataset(load_dataset(name_or_path, split="train", **kwargs))
-        dataset = dataset.rename_column("problem", "question")
         # MathArena ships AIME answers as int64; cast to string up front so the
         # `answer: str` contract holds (otherwise `.map` re-infers against the
         # existing int64 feature and silently casts the stripped string back).

--- a/sieval/datasets/hmmt_feb_2025.py
+++ b/sieval/datasets/hmmt_feb_2025.py
@@ -40,11 +40,10 @@ class HMMTFeb2025Dataset(Dataset[HMMTFeb2025DatasetSample]):
     def _strip_sample(
         self, sample: HMMTFeb2025DatasetSample
     ) -> HMMTFeb2025DatasetSample:
-        # Normalize the gold answer only; the problem text stays verbatim.
-        # strip_string is an answer normalizer (rewrites \frac/\sqrt, drops
-        # \left/\right) and mangles full problem LaTeX — e.g. \sqrt[20]{x} becomes
-        # \sqrt{[}20]{x}. DEVIATION: matharena does not normalize golds at all;
-        # sieval does so math-verify compares canonical forms.
+        # Gold answer only; problem text stays verbatim — strip_string normalizes
+        # answers (rewrites \frac/\sqrt, drops \left/\right) and mangles problem
+        # LaTeX (\sqrt[20]{x} -> \sqrt{[}20]{x}). DEVIATION: matharena does not
+        # normalize golds; sieval does, so math-verify compares canonical forms.
         sample["answer"] = strip_string(sample["answer"])
         return sample
 
@@ -54,10 +53,9 @@ class HMMTFeb2025Dataset(Dataset[HMMTFeb2025DatasetSample]):
         # columns problem_idx / problem / answer / problem_type, kept under their
         # upstream names.
         dataset = ensure_dataset(load_dataset(name_or_path, split="train", **kwargs))
-        # No dtype cast: `answer` is `string` in the pinned snapshot, so the
-        # `answer: str` contract holds from upstream and `.map` preserves it across
-        # _strip_sample. MathArena's answer dtype varies per competition, so a
-        # sibling loader casting is a fact about its own pin, not a family rule.
+        # No dtype cast: `answer` is already `string` in the pinned snapshot and
+        # `.map` preserves it. MathArena's answer dtype varies per competition, so a
+        # sibling loader's cast is a fact about its own pin, not a family rule.
         dataset = dataset.map(self._strip_sample, num_proc=os.cpu_count())
         # the test split is the same as the train split
         return HFDatasetDict(

--- a/sieval/datasets/hmmt_feb_2025.py
+++ b/sieval/datasets/hmmt_feb_2025.py
@@ -7,7 +7,7 @@ import os
 from typing import TypedDict, override
 
 from datasets import DatasetDict as HFDatasetDict
-from datasets import Value, load_dataset
+from datasets import load_dataset
 
 from sieval.community.math import strip_string
 from sieval.core.datasets import (
@@ -54,11 +54,10 @@ class HMMTFeb2025Dataset(Dataset[HMMTFeb2025DatasetSample]):
         # columns problem_idx / problem / answer / problem_type, kept under their
         # upstream names.
         dataset = ensure_dataset(load_dataset(name_or_path, split="train", **kwargs))
-        # MathArena varies the answer dtype across competitions (aime_2026 ships
-        # int64, the HMMT sets ship string), so cast up front: it makes the
-        # `answer: str` contract hold by construction and stops `.map` re-inferring
-        # against an int64 feature and casting the stripped string straight back.
-        dataset = dataset.cast_column("answer", Value("string"))
+        # No dtype cast: `answer` is `string` in the pinned snapshot, so the
+        # `answer: str` contract holds from upstream and `.map` preserves it across
+        # _strip_sample. MathArena's answer dtype varies per competition, so a
+        # sibling loader casting is a fact about its own pin, not a family rule.
         dataset = dataset.map(self._strip_sample, num_proc=os.cpu_count())
         # the test split is the same as the train split
         return HFDatasetDict(

--- a/sieval/datasets/hmmt_feb_2025.py
+++ b/sieval/datasets/hmmt_feb_2025.py
@@ -23,7 +23,7 @@ HMMT_FEB_2025_REVISION = "6fdc4277120810ff75aa22d2d5489b91f7a262a1"
 
 
 class HMMTFeb2025DatasetSample(TypedDict):
-    question: str
+    problem: str
     answer: str
 
 
@@ -40,22 +40,24 @@ class HMMTFeb2025Dataset(Dataset[HMMTFeb2025DatasetSample]):
     def _strip_sample(
         self, sample: HMMTFeb2025DatasetSample
     ) -> HMMTFeb2025DatasetSample:
-        # Normalize the answer only; leave the problem text verbatim. strip_string
-        # is an answer normalizer and mangles full problem LaTeX if applied to the
-        # question. Matches the aime_2024 / hmmt_feb_2026 loaders.
+        # Normalize the gold answer only; the problem text stays verbatim.
+        # strip_string is an answer normalizer (rewrites \frac/\sqrt, drops
+        # \left/\right) and mangles full problem LaTeX — e.g. \sqrt[20]{x} becomes
+        # \sqrt{[}20]{x}. DEVIATION: matharena does not normalize golds at all;
+        # sieval does so math-verify compares canonical forms.
         sample["answer"] = strip_string(sample["answer"])
         return sample
 
     @override
     def load(self, name_or_path: str, **kwargs) -> HFDatasetDict:
         # MathArena exposes a single `default` config under the `train` split with
-        # columns problem_idx / problem / answer / problem_type. Rename `problem`
-        # -> `question` to match the shared math sample schema.
+        # columns problem_idx / problem / answer / problem_type, kept under their
+        # upstream names.
         dataset = ensure_dataset(load_dataset(name_or_path, split="train", **kwargs))
-        dataset = dataset.rename_column("problem", "question")
-        # HMMT answers are already strings (symbolic + some plain integers); the
-        # cast is a harmless no-op that keeps both math loaders uniform and the
-        # `answer: str` contract explicit.
+        # MathArena varies the answer dtype across competitions (aime_2026 ships
+        # int64, the HMMT sets ship string), so cast up front: it makes the
+        # `answer: str` contract hold by construction and stops `.map` re-inferring
+        # against an int64 feature and casting the stripped string straight back.
         dataset = dataset.cast_column("answer", Value("string"))
         dataset = dataset.map(self._strip_sample, num_proc=os.cpu_count())
         # the test split is the same as the train split

--- a/sieval/datasets/hmmt_feb_2026.py
+++ b/sieval/datasets/hmmt_feb_2026.py
@@ -40,11 +40,10 @@ class HMMTFeb2026Dataset(Dataset[HMMTFeb2026DatasetSample]):
     def _strip_sample(
         self, sample: HMMTFeb2026DatasetSample
     ) -> HMMTFeb2026DatasetSample:
-        # Normalize the gold answer only; the problem text stays verbatim.
-        # strip_string is an answer normalizer (rewrites \frac/\sqrt, drops
-        # \left/\right) and mangles full problem LaTeX — e.g. "1, 2, ..., n" becomes
-        # "1, 2, 0..., n". DEVIATION: matharena does not normalize golds at all;
-        # sieval does so math-verify compares canonical forms.
+        # Gold answer only; problem text stays verbatim — strip_string normalizes
+        # answers (rewrites \frac/\sqrt, drops \left/\right) and mangles problem
+        # LaTeX ("1, 2, ..., n" -> "1, 2, 0..., n"). DEVIATION: matharena does
+        # not normalize golds; sieval does, so math-verify compares canonical forms.
         sample["answer"] = strip_string(sample["answer"])
         return sample
 
@@ -53,10 +52,9 @@ class HMMTFeb2026Dataset(Dataset[HMMTFeb2026DatasetSample]):
         # MathArena exposes a single `default` config under the `train` split with
         # columns problem / answer / problem_idx, kept under their upstream names.
         dataset = ensure_dataset(load_dataset(name_or_path, split="train", **kwargs))
-        # No dtype cast: `answer` is `string` in the pinned snapshot, so the
-        # `answer: str` contract holds from upstream and `.map` preserves it across
-        # _strip_sample. MathArena's answer dtype varies per competition, so a
-        # sibling loader casting is a fact about its own pin, not a family rule.
+        # No dtype cast: `answer` is already `string` in the pinned snapshot and
+        # `.map` preserves it. MathArena's answer dtype varies per competition, so a
+        # sibling loader's cast is a fact about its own pin, not a family rule.
         dataset = dataset.map(self._strip_sample, num_proc=os.cpu_count())
         # the test split is the same as the train split
         return HFDatasetDict(

--- a/sieval/datasets/hmmt_feb_2026.py
+++ b/sieval/datasets/hmmt_feb_2026.py
@@ -7,7 +7,7 @@ import os
 from typing import TypedDict, override
 
 from datasets import DatasetDict as HFDatasetDict
-from datasets import Value, load_dataset
+from datasets import load_dataset
 
 from sieval.community.math import strip_string
 from sieval.core.datasets import (
@@ -53,11 +53,10 @@ class HMMTFeb2026Dataset(Dataset[HMMTFeb2026DatasetSample]):
         # MathArena exposes a single `default` config under the `train` split with
         # columns problem / answer / problem_idx, kept under their upstream names.
         dataset = ensure_dataset(load_dataset(name_or_path, split="train", **kwargs))
-        # MathArena varies the answer dtype across competitions (aime_2026 ships
-        # int64, the HMMT sets ship string), so cast up front: it makes the
-        # `answer: str` contract hold by construction and stops `.map` re-inferring
-        # against an int64 feature and casting the stripped string straight back.
-        dataset = dataset.cast_column("answer", Value("string"))
+        # No dtype cast: `answer` is `string` in the pinned snapshot, so the
+        # `answer: str` contract holds from upstream and `.map` preserves it across
+        # _strip_sample. MathArena's answer dtype varies per competition, so a
+        # sibling loader casting is a fact about its own pin, not a family rule.
         dataset = dataset.map(self._strip_sample, num_proc=os.cpu_count())
         # the test split is the same as the train split
         return HFDatasetDict(

--- a/sieval/datasets/hmmt_feb_2026.py
+++ b/sieval/datasets/hmmt_feb_2026.py
@@ -23,7 +23,7 @@ HMMT_FEB_2026_REVISION = "02fba4f74d8e68e73e66a02d540fd979c05c274c"
 
 
 class HMMTFeb2026DatasetSample(TypedDict):
-    question: str
+    problem: str
     answer: str
 
 
@@ -40,23 +40,23 @@ class HMMTFeb2026Dataset(Dataset[HMMTFeb2026DatasetSample]):
     def _strip_sample(
         self, sample: HMMTFeb2026DatasetSample
     ) -> HMMTFeb2026DatasetSample:
-        # Normalize the answer only; leave the problem text verbatim. strip_string
-        # is an answer normalizer and mangles full problem LaTeX if applied to the
-        # question — e.g. "1, 2, ..., n" becomes "1, 2, 0..., n". Matches the
-        # aime_2024 / math_500 loaders.
+        # Normalize the gold answer only; the problem text stays verbatim.
+        # strip_string is an answer normalizer (rewrites \frac/\sqrt, drops
+        # \left/\right) and mangles full problem LaTeX — e.g. "1, 2, ..., n" becomes
+        # "1, 2, 0..., n". DEVIATION: matharena does not normalize golds at all;
+        # sieval does so math-verify compares canonical forms.
         sample["answer"] = strip_string(sample["answer"])
         return sample
 
     @override
     def load(self, name_or_path: str, **kwargs) -> HFDatasetDict:
         # MathArena exposes a single `default` config under the `train` split with
-        # columns problem / answer / problem_idx. Rename `problem` -> `question` to
-        # match the shared math sample schema.
+        # columns problem / answer / problem_idx, kept under their upstream names.
         dataset = ensure_dataset(load_dataset(name_or_path, split="train", **kwargs))
-        dataset = dataset.rename_column("problem", "question")
-        # HMMT answers are already strings (symbolic + some plain integers); the
-        # cast is a harmless no-op that keeps both math loaders uniform and the
-        # `answer: str` contract explicit.
+        # MathArena varies the answer dtype across competitions (aime_2026 ships
+        # int64, the HMMT sets ship string), so cast up front: it makes the
+        # `answer: str` contract hold by construction and stops `.map` re-inferring
+        # against an int64 feature and casting the stripped string straight back.
         dataset = dataset.cast_column("answer", Value("string"))
         dataset = dataset.map(self._strip_sample, num_proc=os.cpu_count())
         # the test split is the same as the train split

--- a/sieval/datasets/hmmt_nov_2025.py
+++ b/sieval/datasets/hmmt_nov_2025.py
@@ -1,0 +1,67 @@
+"""HMMT November 2025 dataset loader (MathArena source).
+
+AI-Generated Code - Claude Opus 4.8 (Anthropic)
+"""
+
+import os
+from typing import TypedDict, override
+
+from datasets import DatasetDict as HFDatasetDict
+from datasets import Value, load_dataset
+
+from sieval.community.math import strip_string
+from sieval.core.datasets import (
+    Category,
+    Dataset,
+    Level1Category,
+    sieval_dataset,
+)
+from sieval.core.utils.hf import ensure_dataset
+
+# Pin the MathArena HF snapshot for reproducibility (see check_datasets / #8).
+HMMT_NOV_2025_REVISION = "118dbfb45c4c9467c672268ed55166642897aa46"
+
+
+class HMMTNov2025DatasetSample(TypedDict):
+    question: str
+    answer: str
+
+
+@sieval_dataset(
+    name="hmmt_nov_2025",
+    display_name="HMMT Nov 2025",
+    description="Harvard-MIT Mathematics Tournament, November 2025, 30 problems.",
+    source=f"hf:MathArena/hmmt_nov_2025@{HMMT_NOV_2025_REVISION}",
+    categories=(Category(Level1Category.MATHEMATICS, "CompetitionMath"),),
+    tags=("english", "open-ended"),
+    license="CC-BY-NC-SA-4.0",
+)
+class HMMTNov2025Dataset(Dataset[HMMTNov2025DatasetSample]):
+    def _strip_sample(
+        self, sample: HMMTNov2025DatasetSample
+    ) -> HMMTNov2025DatasetSample:
+        # Normalize the answer only; leave the problem text verbatim. strip_string
+        # is an answer normalizer and mangles full problem LaTeX if applied to the
+        # question. Matches the aime_2026 / hmmt_feb_2025 loaders.
+        sample["answer"] = strip_string(sample["answer"])
+        return sample
+
+    @override
+    def load(self, name_or_path: str, **kwargs) -> HFDatasetDict:
+        # MathArena exposes a single `default` config under the `train` split with
+        # columns problem_idx / problem / answer. Rename `problem` -> `question` to
+        # match the shared math sample schema.
+        dataset = ensure_dataset(load_dataset(name_or_path, split="train", **kwargs))
+        dataset = dataset.rename_column("problem", "question")
+        # HMMT answers are already strings (symbolic + some plain integers); the
+        # cast is a harmless no-op that keeps both math loaders uniform and the
+        # `answer: str` contract explicit.
+        dataset = dataset.cast_column("answer", Value("string"))
+        dataset = dataset.map(self._strip_sample, num_proc=os.cpu_count())
+        # the test split is the same as the train split
+        return HFDatasetDict(
+            {
+                "train": dataset,
+                "test": dataset,
+            }
+        )

--- a/sieval/datasets/hmmt_nov_2025.py
+++ b/sieval/datasets/hmmt_nov_2025.py
@@ -7,7 +7,7 @@ import os
 from typing import TypedDict, override
 
 from datasets import DatasetDict as HFDatasetDict
-from datasets import Value, load_dataset
+from datasets import load_dataset
 
 from sieval.community.math import strip_string
 from sieval.core.datasets import (
@@ -55,11 +55,10 @@ class HMMTNov2025Dataset(Dataset[HMMTNov2025DatasetSample]):
         # MathArena exposes a single `default` config under the `train` split with
         # columns problem_idx / problem / answer, kept under their upstream names.
         dataset = ensure_dataset(load_dataset(name_or_path, split="train", **kwargs))
-        # MathArena varies the answer dtype across competitions (aime_2026 ships
-        # int64, the HMMT sets ship string), so cast up front: it makes the
-        # `answer: str` contract hold by construction and stops `.map` re-inferring
-        # against an int64 feature and casting the stripped string straight back.
-        dataset = dataset.cast_column("answer", Value("string"))
+        # No dtype cast: `answer` is `string` in the pinned snapshot, so the
+        # `answer: str` contract holds from upstream and `.map` preserves it across
+        # _strip_sample. MathArena's answer dtype varies per competition, so a
+        # sibling loader casting is a fact about its own pin, not a family rule.
         dataset = dataset.map(self._strip_sample, num_proc=os.cpu_count())
         # the test split is the same as the train split
         return HFDatasetDict(

--- a/sieval/datasets/hmmt_nov_2025.py
+++ b/sieval/datasets/hmmt_nov_2025.py
@@ -40,13 +40,12 @@ class HMMTNov2025Dataset(Dataset[HMMTNov2025DatasetSample]):
     def _strip_sample(
         self, sample: HMMTNov2025DatasetSample
     ) -> HMMTNov2025DatasetSample:
-        # Normalize the gold answer only; the problem text stays verbatim.
-        # strip_string is an answer normalizer (rewrites \frac/\sqrt, drops
-        # \left/\right) and mangles full problem LaTeX — e.g. \sqrt[20]{x} becomes
-        # \sqrt{[}20]{x}. DEVIATION: matharena does not normalize golds at all;
-        # sieval does so math-verify compares canonical forms. Score-neutral on this
-        # snapshot — it rewrites 3 of 30 golds (1/91 -> \frac{1}{91}, 91/6, 199/8),
-        # all of which math-verify already treats as equivalent.
+        # Gold answer only; problem text stays verbatim — strip_string normalizes
+        # answers (rewrites \frac/\sqrt, drops \left/\right) and mangles problem
+        # LaTeX (\sqrt[20]{x} -> \sqrt{[}20]{x}). DEVIATION: matharena does not
+        # normalize golds; sieval does, so math-verify compares canonical forms.
+        # Score-neutral here: 3 of 30 golds change (1/91 -> \frac{1}{91}, 91/6,
+        # 199/8), all already equivalent under math-verify.
         sample["answer"] = strip_string(sample["answer"])
         return sample
 
@@ -55,10 +54,9 @@ class HMMTNov2025Dataset(Dataset[HMMTNov2025DatasetSample]):
         # MathArena exposes a single `default` config under the `train` split with
         # columns problem_idx / problem / answer, kept under their upstream names.
         dataset = ensure_dataset(load_dataset(name_or_path, split="train", **kwargs))
-        # No dtype cast: `answer` is `string` in the pinned snapshot, so the
-        # `answer: str` contract holds from upstream and `.map` preserves it across
-        # _strip_sample. MathArena's answer dtype varies per competition, so a
-        # sibling loader casting is a fact about its own pin, not a family rule.
+        # No dtype cast: `answer` is already `string` in the pinned snapshot and
+        # `.map` preserves it. MathArena's answer dtype varies per competition, so a
+        # sibling loader's cast is a fact about its own pin, not a family rule.
         dataset = dataset.map(self._strip_sample, num_proc=os.cpu_count())
         # the test split is the same as the train split
         return HFDatasetDict(

--- a/sieval/datasets/hmmt_nov_2025.py
+++ b/sieval/datasets/hmmt_nov_2025.py
@@ -23,7 +23,7 @@ HMMT_NOV_2025_REVISION = "118dbfb45c4c9467c672268ed55166642897aa46"
 
 
 class HMMTNov2025DatasetSample(TypedDict):
-    question: str
+    problem: str
     answer: str
 
 
@@ -40,22 +40,25 @@ class HMMTNov2025Dataset(Dataset[HMMTNov2025DatasetSample]):
     def _strip_sample(
         self, sample: HMMTNov2025DatasetSample
     ) -> HMMTNov2025DatasetSample:
-        # Normalize the answer only; leave the problem text verbatim. strip_string
-        # is an answer normalizer and mangles full problem LaTeX if applied to the
-        # question. Matches the aime_2026 / hmmt_feb_2025 loaders.
+        # Normalize the gold answer only; the problem text stays verbatim.
+        # strip_string is an answer normalizer (rewrites \frac/\sqrt, drops
+        # \left/\right) and mangles full problem LaTeX — e.g. \sqrt[20]{x} becomes
+        # \sqrt{[}20]{x}. DEVIATION: matharena does not normalize golds at all;
+        # sieval does so math-verify compares canonical forms. Score-neutral on this
+        # snapshot — it rewrites 3 of 30 golds (1/91 -> \frac{1}{91}, 91/6, 199/8),
+        # all of which math-verify already treats as equivalent.
         sample["answer"] = strip_string(sample["answer"])
         return sample
 
     @override
     def load(self, name_or_path: str, **kwargs) -> HFDatasetDict:
         # MathArena exposes a single `default` config under the `train` split with
-        # columns problem_idx / problem / answer. Rename `problem` -> `question` to
-        # match the shared math sample schema.
+        # columns problem_idx / problem / answer, kept under their upstream names.
         dataset = ensure_dataset(load_dataset(name_or_path, split="train", **kwargs))
-        dataset = dataset.rename_column("problem", "question")
-        # HMMT answers are already strings (symbolic + some plain integers); the
-        # cast is a harmless no-op that keeps both math loaders uniform and the
-        # `answer: str` contract explicit.
+        # MathArena varies the answer dtype across competitions (aime_2026 ships
+        # int64, the HMMT sets ship string), so cast up front: it makes the
+        # `answer: str` contract hold by construction and stops `.map` re-inferring
+        # against an int64 feature and casting the stripped string straight back.
         dataset = dataset.cast_column("answer", Value("string"))
         dataset = dataset.map(self._strip_sample, num_proc=os.cpu_count())
         # the test split is the same as the train split

--- a/sieval/datasets/imo_answer_bench.py
+++ b/sieval/datasets/imo_answer_bench.py
@@ -35,7 +35,7 @@ IMO_ANSWER_BENCH_URL = (
 
 
 class IMOAnswerBenchDatasetSample(TypedDict):
-    question: str
+    problem: str
     answer: str
 
 
@@ -74,10 +74,16 @@ class IMOAnswerBenchDataset(Dataset[IMOAnswerBenchDatasetSample]):
             "csv", data_files={"train": csv_path, "test": csv_path}, **kwargs
         )
         dataset = ensure_dataset_dict(dataset)
-        dataset = dataset.rename_column("Problem", "question")
+        # Upstream ships `Problem` / `Short Answer`; lower-case and de-space them so
+        # the columns are addressable as ordinary keys (not a schema reshape — the
+        # upstream names are simply not usable as-is).
+        dataset = dataset.rename_column("Problem", "problem")
         dataset = dataset.rename_column("Short Answer", "answer")
         # Golds are short answers (integers, LaTeX expressions, small answer sets);
         # kept verbatim — IMO-Bench grades via math-verify, not string normalization.
+        # The cast is load-bearing here: this is a CSV, so the answer dtype is
+        # inferred from content at parse time rather than fixed by the pinned
+        # snapshot, and an all-integer column would arrive as int64.
         dataset = dataset.cast_column("answer", Value("string"))
         # the test split is the same as the train split (mirrored above)
         return dataset

--- a/sieval/datasets/imo_answer_bench.py
+++ b/sieval/datasets/imo_answer_bench.py
@@ -74,16 +74,14 @@ class IMOAnswerBenchDataset(Dataset[IMOAnswerBenchDatasetSample]):
             "csv", data_files={"train": csv_path, "test": csv_path}, **kwargs
         )
         dataset = ensure_dataset_dict(dataset)
-        # Upstream ships `Problem` / `Short Answer`; lower-case and de-space them so
-        # the columns are addressable as ordinary keys (not a schema reshape — the
-        # upstream names are simply not usable as-is).
+        # Upstream ships `Problem` / `Short Answer`; lower-cased and de-spaced only
+        # because those names are not usable as keys as-is.
         dataset = dataset.rename_column("Problem", "problem")
         dataset = dataset.rename_column("Short Answer", "answer")
-        # Golds are short answers (integers, LaTeX expressions, small answer sets);
-        # kept verbatim — IMO-Bench grades via math-verify, not string normalization.
-        # The cast is load-bearing here: this is a CSV, so the answer dtype is
-        # inferred from content at parse time rather than fixed by the pinned
-        # snapshot, and an all-integer column would arrive as int64.
+        # Golds are short answers (integers, LaTeX, small answer sets), kept
+        # verbatim — IMO-Bench grades via math-verify, not string normalization.
+        # The cast IS load-bearing: CSV dtypes are content-inferred at parse time,
+        # so an all-integer column would arrive as int64.
         dataset = dataset.cast_column("answer", Value("string"))
         # the test split is the same as the train split (mirrored above)
         return dataset

--- a/sieval/meta/index.json
+++ b/sieval/meta/index.json
@@ -1314,7 +1314,7 @@
       "reference_impl": {
         "source": "simple-evals",
         "url": "https://github.com/openai/simple-evals/blob/ee3b0318d8d1d9d72755a4120879be65f7c07e9e/math_eval.py",
-        "notes": "Math postprocess aligned with simple-evals."
+        "notes": "Math postprocess aligned with simple-evals. REPEATS: simple-evals' MathEval defaults to n_repeats=16 and its CLI `math` entry passes 10, while this task defaults to n=1 — set n=10 (or 16) to match. pass@1 over n samples equals simple-evals' mean over n repeated examples, so the two are directly comparable. `n` is a task arg (tasks.<name>.args.n), NOT a model arg: the task forwards it call-time and call-time wins, so setting `n` on the model is silently overridden. k>n is rejected at construction. Scope: those upstream defaults belong to the full math_test split; MATH-500 is simple-evals' math_500_test."
       },
       "status": "stable"
     },

--- a/sieval/meta/index.json
+++ b/sieval/meta/index.json
@@ -383,6 +383,27 @@
       "checksums": {}
     },
     {
+      "name": "hmmt_nov_2025",
+      "display_name": "HMMT Nov 2025",
+      "description": "Harvard-MIT Mathematics Tournament, November 2025, 30 problems.",
+      "source": [
+        "hf:MathArena/hmmt_nov_2025@118dbfb45c4c9467c672268ed55166642897aa46"
+      ],
+      "categories": [
+        {
+          "level1": "Mathematics",
+          "level2": "CompetitionMath"
+        }
+      ],
+      "tags": [
+        "english",
+        "open-ended"
+      ],
+      "deps_group": null,
+      "license": "CC-BY-NC-SA-4.0",
+      "checksums": {}
+    },
+    {
       "name": "human_eval",
       "display_name": "HumanEval",
       "description": "OpenAI HumanEval — 164 Python function-synthesis problems.",
@@ -1107,6 +1128,26 @@
       "reference_impl": {
         "source": "matharena",
         "url": "https://github.com/eth-sri/matharena/blob/a11194deff8c67a232974a383795e8a2776b4c6f/configs/competitions/hmmt/hmmt_feb_2026.yaml",
+        "notes": "MathArena-aligned: boxed prompt, last-boxed extraction; equivalence via math-verify."
+      },
+      "status": "stable"
+    },
+    {
+      "name": "hmmt_nov_2025_0shot_gen",
+      "display_name": "HMMT Nov 2025 (0-shot, generative)",
+      "description": "HMMT November 2025 — Harvard-MIT Mathematics Tournament, 30 problems.",
+      "dataset": "hmmt_nov_2025",
+      "eval_mode": "gen",
+      "n_shot": 0,
+      "tags": [
+        "english",
+        "open-ended"
+      ],
+      "deps_group": "math",
+      "model_type": "chat",
+      "reference_impl": {
+        "source": "matharena",
+        "url": "https://github.com/eth-sri/matharena/blob/a11194deff8c67a232974a383795e8a2776b4c6f/configs/competitions/hmmt/hmmt_nov_2025.yaml",
         "notes": "MathArena-aligned: boxed prompt, last-boxed extraction; equivalence via math-verify."
       },
       "status": "stable"

--- a/sieval/meta/index.json
+++ b/sieval/meta/index.json
@@ -790,7 +790,7 @@
       "reference_impl": {
         "source": "matharena",
         "url": "https://github.com/eth-sri/matharena/blob/a11194deff8c67a232974a383795e8a2776b4c6f/configs/competitions/aime/aime_2026.yaml",
-        "notes": "MathArena-aligned: boxed prompt + 0-999 integer hint, last-boxed extraction; equivalence via math-verify. REPEATS: matharena's runner defaults to `--n 4` and its published leaderboard averages 4 runs per problem, while this task defaults to n=1 — set n=4 to compare against matharena.ai. `n` is a task arg (tasks.<name>.args.n), NOT a model arg: the task forwards it call-time and call-time wins, so setting `n` on the model is silently overridden. k>n is rejected at construction. DEVIATION: golds are normalized by sieval.community.math.strip_string before comparison; matharena does not normalize golds."
+        "notes": "MathArena-aligned: boxed prompt + 0-999 integer hint, last-boxed extraction; equivalence via math-verify. REPEATS: matharena averages 4 runs per problem (runner default `--n 4`) while this task defaults to n=1 — set n=4 to compare against matharena.ai, as a task arg (tasks.<name>.args.n); the model's `n` is silently overridden call-time. k>n is rejected at construction. DEVIATION: golds are normalized by sieval.community.math.strip_string; matharena does not."
       },
       "status": "stable"
     },
@@ -1108,7 +1108,7 @@
       "reference_impl": {
         "source": "matharena",
         "url": "https://github.com/eth-sri/matharena/blob/a11194deff8c67a232974a383795e8a2776b4c6f/configs/competitions/hmmt/hmmt_feb_2025.yaml",
-        "notes": "MathArena-aligned: boxed prompt, last-boxed extraction; equivalence via math-verify. REPEATS: matharena's runner defaults to `--n 4` and its published leaderboard averages 4 runs per problem, while this task defaults to n=1 — set n=4 to compare against matharena.ai. `n` is a task arg (tasks.<name>.args.n), NOT a model arg: the task forwards it call-time and call-time wins, so setting `n` on the model is silently overridden. k>n is rejected at construction. DEVIATION: golds are normalized by sieval.community.math.strip_string before comparison; matharena does not normalize golds."
+        "notes": "MathArena-aligned: boxed prompt, last-boxed extraction; equivalence via math-verify. REPEATS: matharena averages 4 runs per problem (runner default `--n 4`) while this task defaults to n=1 — set n=4 to compare against matharena.ai, as a task arg (tasks.<name>.args.n); the model's `n` is silently overridden call-time. k>n is rejected at construction. DEVIATION: golds are normalized by sieval.community.math.strip_string; matharena does not."
       },
       "status": "stable"
     },
@@ -1128,7 +1128,7 @@
       "reference_impl": {
         "source": "matharena",
         "url": "https://github.com/eth-sri/matharena/blob/a11194deff8c67a232974a383795e8a2776b4c6f/configs/competitions/hmmt/hmmt_feb_2026.yaml",
-        "notes": "MathArena-aligned: boxed prompt, last-boxed extraction; equivalence via math-verify. REPEATS: matharena's runner defaults to `--n 4` and its published leaderboard averages 4 runs per problem, while this task defaults to n=1 — set n=4 to compare against matharena.ai. `n` is a task arg (tasks.<name>.args.n), NOT a model arg: the task forwards it call-time and call-time wins, so setting `n` on the model is silently overridden. k>n is rejected at construction. DEVIATION: golds are normalized by sieval.community.math.strip_string before comparison; matharena does not normalize golds."
+        "notes": "MathArena-aligned: boxed prompt, last-boxed extraction; equivalence via math-verify. REPEATS: matharena averages 4 runs per problem (runner default `--n 4`) while this task defaults to n=1 — set n=4 to compare against matharena.ai, as a task arg (tasks.<name>.args.n); the model's `n` is silently overridden call-time. k>n is rejected at construction. DEVIATION: golds are normalized by sieval.community.math.strip_string; matharena does not."
       },
       "status": "stable"
     },
@@ -1148,7 +1148,7 @@
       "reference_impl": {
         "source": "matharena",
         "url": "https://github.com/eth-sri/matharena/blob/a11194deff8c67a232974a383795e8a2776b4c6f/configs/competitions/hmmt/hmmt_nov_2025.yaml",
-        "notes": "MathArena-aligned: boxed prompt, last-boxed extraction; equivalence via math-verify. REPEATS: matharena's runner defaults to `--n 4` and its published leaderboard averages 4 runs per problem, while this task defaults to n=1 — set n=4 to compare against matharena.ai. `n` is a task arg (tasks.<name>.args.n), NOT a model arg: the task forwards it call-time and call-time wins, so setting `n` on the model is silently overridden. k>n is rejected at construction. DEVIATION: golds are normalized by sieval.community.math.strip_string before comparison; matharena does not normalize golds."
+        "notes": "MathArena-aligned: boxed prompt, last-boxed extraction; equivalence via math-verify. REPEATS: matharena averages 4 runs per problem (runner default `--n 4`) while this task defaults to n=1 — set n=4 to compare against matharena.ai, as a task arg (tasks.<name>.args.n); the model's `n` is silently overridden call-time. k>n is rejected at construction. DEVIATION: golds are normalized by sieval.community.math.strip_string; matharena does not."
       },
       "status": "stable"
     },
@@ -1314,7 +1314,7 @@
       "reference_impl": {
         "source": "simple-evals",
         "url": "https://github.com/openai/simple-evals/blob/ee3b0318d8d1d9d72755a4120879be65f7c07e9e/math_eval.py",
-        "notes": "Math postprocess aligned with simple-evals. REPEATS: simple-evals' MathEval defaults to n_repeats=16 and its CLI `math` entry passes 10, while this task defaults to n=1 — set n=10 (or 16) to match. pass@1 over n samples equals simple-evals' mean over n repeated examples, so the two are directly comparable. `n` is a task arg (tasks.<name>.args.n), NOT a model arg: the task forwards it call-time and call-time wins, so setting `n` on the model is silently overridden. k>n is rejected at construction. Scope: those upstream defaults belong to the full math_test split; MATH-500 is simple-evals' math_500_test."
+        "notes": "Math postprocess aligned with simple-evals. REPEATS: simple-evals' MathEval defaults to n_repeats=16, its CLI `math` entry passes 10, while this task defaults to n=1 — set n=10 (or 16) to match, as a task arg (tasks.<name>.args.n); the model's `n` is silently overridden call-time. pass@1 over n samples equals its mean over n repeats. k>n is rejected at construction. Scope: those upstream defaults are for the full math_test split; MATH-500 is simple-evals' math_500_test."
       },
       "status": "stable"
     },

--- a/sieval/meta/index.json
+++ b/sieval/meta/index.json
@@ -1148,7 +1148,7 @@
       "reference_impl": {
         "source": "matharena",
         "url": "https://github.com/eth-sri/matharena/blob/a11194deff8c67a232974a383795e8a2776b4c6f/configs/competitions/hmmt/hmmt_nov_2025.yaml",
-        "notes": "MathArena-aligned: boxed prompt, last-boxed extraction; equivalence via math-verify. REPEATS: matharena averages 4 runs per problem (runner default `--n 4`) while this task defaults to n=1 — set n=4 to compare against matharena.ai, as a task arg (tasks.<name>.args.n); the model's `n` is silently overridden call-time. k>n is rejected at construction. DEVIATION: golds are normalized by sieval.community.math.strip_string; matharena does not."
+        "notes": "MathArena-aligned: boxed prompt, last-boxed extraction; equivalence via math-verify. REPEATS: matharena averages 4 runs per problem (runner default `--n 4`) while this task defaults to n=1 — set n=4 to compare against matharena.ai, as a task arg (tasks.<name>.args.n); the model's `n` is silently overridden call-time. k>n is rejected at construction. DEVIATION: golds are normalized by sieval.community.math.strip_string; matharena does not. VALIDATED against official MathArena: replaying its published 2640 outputs (22 models x 30 problems x 4 runs) through this task's grading path agrees with the upstream grader on 99.51% of outputs and reproduces 16/22 model scores exactly; Gemini 3 Flash is 93.33% three ways (published, upstream grader, sieval grader). A live sieval run of gemini-3-flash-preview scored 95.00% vs the published 93.33% — sampling variance, not a grading difference: both graders agree on 120/120 of sieval's own outputs."
       },
       "status": "stable"
     },

--- a/sieval/meta/index.json
+++ b/sieval/meta/index.json
@@ -790,7 +790,7 @@
       "reference_impl": {
         "source": "matharena",
         "url": "https://github.com/eth-sri/matharena/blob/a11194deff8c67a232974a383795e8a2776b4c6f/configs/competitions/aime/aime_2026.yaml",
-        "notes": "MathArena-aligned: boxed prompt + 0-999 integer hint, last-boxed extraction; equivalence via math-verify."
+        "notes": "MathArena-aligned: boxed prompt + 0-999 integer hint, last-boxed extraction; equivalence via math-verify. REPEATS: matharena's runner defaults to `--n 4` and its published leaderboard averages 4 runs per problem, while this task defaults to n=1 — set n=4 to compare against matharena.ai. `n` is a task arg (tasks.<name>.args.n), NOT a model arg: the task forwards it call-time and call-time wins, so setting `n` on the model is silently overridden. k>n is rejected at construction. DEVIATION: golds are normalized by sieval.community.math.strip_string before comparison; matharena does not normalize golds."
       },
       "status": "stable"
     },
@@ -1108,7 +1108,7 @@
       "reference_impl": {
         "source": "matharena",
         "url": "https://github.com/eth-sri/matharena/blob/a11194deff8c67a232974a383795e8a2776b4c6f/configs/competitions/hmmt/hmmt_feb_2025.yaml",
-        "notes": "MathArena-aligned: boxed prompt, last-boxed extraction; equivalence via math-verify."
+        "notes": "MathArena-aligned: boxed prompt, last-boxed extraction; equivalence via math-verify. REPEATS: matharena's runner defaults to `--n 4` and its published leaderboard averages 4 runs per problem, while this task defaults to n=1 — set n=4 to compare against matharena.ai. `n` is a task arg (tasks.<name>.args.n), NOT a model arg: the task forwards it call-time and call-time wins, so setting `n` on the model is silently overridden. k>n is rejected at construction. DEVIATION: golds are normalized by sieval.community.math.strip_string before comparison; matharena does not normalize golds."
       },
       "status": "stable"
     },
@@ -1128,7 +1128,7 @@
       "reference_impl": {
         "source": "matharena",
         "url": "https://github.com/eth-sri/matharena/blob/a11194deff8c67a232974a383795e8a2776b4c6f/configs/competitions/hmmt/hmmt_feb_2026.yaml",
-        "notes": "MathArena-aligned: boxed prompt, last-boxed extraction; equivalence via math-verify."
+        "notes": "MathArena-aligned: boxed prompt, last-boxed extraction; equivalence via math-verify. REPEATS: matharena's runner defaults to `--n 4` and its published leaderboard averages 4 runs per problem, while this task defaults to n=1 — set n=4 to compare against matharena.ai. `n` is a task arg (tasks.<name>.args.n), NOT a model arg: the task forwards it call-time and call-time wins, so setting `n` on the model is silently overridden. k>n is rejected at construction. DEVIATION: golds are normalized by sieval.community.math.strip_string before comparison; matharena does not normalize golds."
       },
       "status": "stable"
     },
@@ -1148,7 +1148,7 @@
       "reference_impl": {
         "source": "matharena",
         "url": "https://github.com/eth-sri/matharena/blob/a11194deff8c67a232974a383795e8a2776b4c6f/configs/competitions/hmmt/hmmt_nov_2025.yaml",
-        "notes": "MathArena-aligned: boxed prompt, last-boxed extraction; equivalence via math-verify."
+        "notes": "MathArena-aligned: boxed prompt, last-boxed extraction; equivalence via math-verify. REPEATS: matharena's runner defaults to `--n 4` and its published leaderboard averages 4 runs per problem, while this task defaults to n=1 — set n=4 to compare against matharena.ai. `n` is a task arg (tasks.<name>.args.n), NOT a model arg: the task forwards it call-time and call-time wins, so setting `n` on the model is silently overridden. k>n is rejected at construction. DEVIATION: golds are normalized by sieval.community.math.strip_string before comparison; matharena does not normalize golds."
       },
       "status": "stable"
     },

--- a/sieval/tasks/__init__.pyi
+++ b/sieval/tasks/__init__.pyi
@@ -61,6 +61,9 @@ from .hmmt_feb_2025_0shot_gen import (
 from .hmmt_feb_2026_0shot_gen import (
     HMMTFeb2026ZeroShotGenTask,
 )
+from .hmmt_nov_2025_0shot_gen import (
+    HMMTNov2025ZeroShotGenTask,
+)
 from .human_eval_0shot_base_gen import (
     HumanEvalZeroShotBaseGenTask,
 )
@@ -132,6 +135,7 @@ __all__ = [
     "HLEZeroShotGenTask",
     "HMMTFeb2025ZeroShotGenTask",
     "HMMTFeb2026ZeroShotGenTask",
+    "HMMTNov2025ZeroShotGenTask",
     "HellaSwagFewShotPPLTask",
     "HendrycksMathFewShotBaseGenTask",
     "HumanEvalZeroShotBaseGenTask",

--- a/sieval/tasks/aime_2024_0shot_gen.py
+++ b/sieval/tasks/aime_2024_0shot_gen.py
@@ -50,6 +50,13 @@ class AIME2024ZeroShotGenTask(
 ):
     def __init__(self, dataset, model, name: str | None = None, k: int = 1, n: int = 1):
         super().__init__(dataset=dataset, model=model, name=name)
+        if k > n:
+            raise ValueError(
+                f"pass@{k} needs at least {k} sample(s) per problem, got n={n}. "
+                "Raise the task arg `n` (tasks.<name>.args.n) to at least k — `n` "
+                "is a task arg, not a model arg: the task forwards it call-time "
+                "and call-time wins over the model's configured args."
+            )
         self._k = k
         self._n = n
 
@@ -98,26 +105,56 @@ class AIME2024ZeroShotGenTask(
     async def report(self, finals, fails):
         total = len(finals) + len(fails)
         if total == 0:
-            return {"score": 0.0, "fails": len(fails)}
+            # Emit the same key set as the populated path below, so a consumer
+            # reading `pass@1` does not KeyError on an empty run.
+            return self._metrics(0.0, 0.0, len(fails))
 
         pass_at_1_total = 0.0
         pass_at_k_total = 0.0
+        short = 0
         for f in finals:
             feedbacks = f.feedback_result
             n_samples = len(feedbacks)
-            correct_num = sum(1 for f in feedbacks if f["correct"])
+            if n_samples < self._k:
+                short += 1
+            correct_num = sum(1 for fb in feedbacks if fb["correct"])
             pass_at_1_total += self._pass_at_k(n_samples, correct_num, 1)
             if self._k > 1:
                 pass_at_k_total += self._pass_at_k(n_samples, correct_num, self._k)
 
-        pass_at_1 = pass_at_1_total * 100 / total
-        metrics = {"score": pass_at_1, "fails": len(fails), "pass@1": pass_at_1}
+        if short:
+            logger.warning(
+                "{}/{} sample(s) returned fewer than k={} choices, contributing 0 "
+                "to pass@{}: the model produced fewer choices than the requested "
+                "n={}.",
+                short,
+                len(finals),
+                self._k,
+                self._k,
+                self._n,
+            )
+
+        return self._metrics(
+            pass_at_1_total * 100 / total,
+            pass_at_k_total * 100 / total,
+            len(fails),
+        )
+
+    def _metrics(
+        self, pass_at_1: float, pass_at_k: float, fails: int
+    ) -> dict[str, float]:
+        # Single source of truth for the report key set — the empty-run branch and
+        # the populated branch must not drift apart.
+        metrics = {"score": pass_at_1, "fails": fails, "pass@1": pass_at_1}
         if self._k > 1:
-            metrics[f"pass@{self._k}"] = pass_at_k_total * 100 / total
+            metrics[f"pass@{self._k}"] = pass_at_k
         return metrics
 
     def _pass_at_k(self, n: int, c: int, k: int) -> float:
         if n < k:
+            # Unreachable by configuration: __init__ rejects k > n. Only a model
+            # that returned fewer choices than requested reaches this, and report()
+            # warns about it so the 0 contribution is visible rather than silent.
             return 0.0
         if c == 0:
             return 0.0

--- a/sieval/tasks/aime_2024_0shot_gen.py
+++ b/sieval/tasks/aime_2024_0shot_gen.py
@@ -53,9 +53,8 @@ class AIME2024ZeroShotGenTask(
         if k > n:
             raise ValueError(
                 f"pass@{k} needs at least {k} sample(s) per problem, got n={n}. "
-                "Raise the task arg `n` (tasks.<name>.args.n) to at least k — `n` "
-                "is a task arg, not a model arg: the task forwards it call-time "
-                "and call-time wins over the model's configured args."
+                "Raise the task arg `n` (tasks.<name>.args.n) to at least k — "
+                "setting `n` on the model is silently overridden call-time."
             )
         self._k = k
         self._n = n
@@ -105,8 +104,7 @@ class AIME2024ZeroShotGenTask(
     async def report(self, finals, fails):
         total = len(finals) + len(fails)
         if total == 0:
-            # Emit the same key set as the populated path below, so a consumer
-            # reading `pass@1` does not KeyError on an empty run.
+            # Same key set as the populated path, so `pass@1` never KeyErrors.
             return self._metrics(0.0, 0.0, len(fails))
 
         pass_at_1_total = 0.0
@@ -124,14 +122,13 @@ class AIME2024ZeroShotGenTask(
 
         if short:
             logger.warning(
-                "{}/{} sample(s) returned fewer than k={} choices, contributing 0 "
-                "to pass@{}: the model produced fewer choices than the requested "
-                "n={}.",
+                "{}/{} sample(s) returned fewer than k={} choices (model produced "
+                "fewer than the requested n={}) and contribute 0 to pass@{}.",
                 short,
                 len(finals),
                 self._k,
-                self._k,
                 self._n,
+                self._k,
             )
 
         return self._metrics(
@@ -143,8 +140,7 @@ class AIME2024ZeroShotGenTask(
     def _metrics(
         self, pass_at_1: float, pass_at_k: float, fails: int
     ) -> dict[str, float]:
-        # Single source of truth for the report key set — the empty-run branch and
-        # the populated branch must not drift apart.
+        # Single source of truth for the report key set — both branches route here.
         metrics = {"score": pass_at_1, "fails": fails, "pass@1": pass_at_1}
         if self._k > 1:
             metrics[f"pass@{self._k}"] = pass_at_k
@@ -152,9 +148,8 @@ class AIME2024ZeroShotGenTask(
 
     def _pass_at_k(self, n: int, c: int, k: int) -> float:
         if n < k:
-            # Unreachable by configuration: __init__ rejects k > n. Only a model
-            # that returned fewer choices than requested reaches this, and report()
-            # warns about it so the 0 contribution is visible rather than silent.
+            # Unreachable by config (__init__ rejects k > n); only a model that
+            # returned fewer choices than requested lands here, and report() warns.
             return 0.0
         if c == 0:
             return 0.0

--- a/sieval/tasks/aime_2025_0shot_gen.py
+++ b/sieval/tasks/aime_2025_0shot_gen.py
@@ -53,9 +53,8 @@ class AIME2025ZeroShotGenTask(
         if k > n:
             raise ValueError(
                 f"pass@{k} needs at least {k} sample(s) per problem, got n={n}. "
-                "Raise the task arg `n` (tasks.<name>.args.n) to at least k — `n` "
-                "is a task arg, not a model arg: the task forwards it call-time "
-                "and call-time wins over the model's configured args."
+                "Raise the task arg `n` (tasks.<name>.args.n) to at least k — "
+                "setting `n` on the model is silently overridden call-time."
             )
         self._k = k
         self._n = n
@@ -105,8 +104,7 @@ class AIME2025ZeroShotGenTask(
     async def report(self, finals, fails):
         total = len(finals) + len(fails)
         if total == 0:
-            # Emit the same key set as the populated path below, so a consumer
-            # reading `pass@1` does not KeyError on an empty run.
+            # Same key set as the populated path, so `pass@1` never KeyErrors.
             return self._metrics(0.0, 0.0, len(fails))
 
         pass_at_1_total = 0.0
@@ -124,14 +122,13 @@ class AIME2025ZeroShotGenTask(
 
         if short:
             logger.warning(
-                "{}/{} sample(s) returned fewer than k={} choices, contributing 0 "
-                "to pass@{}: the model produced fewer choices than the requested "
-                "n={}.",
+                "{}/{} sample(s) returned fewer than k={} choices (model produced "
+                "fewer than the requested n={}) and contribute 0 to pass@{}.",
                 short,
                 len(finals),
                 self._k,
-                self._k,
                 self._n,
+                self._k,
             )
 
         return self._metrics(
@@ -143,8 +140,7 @@ class AIME2025ZeroShotGenTask(
     def _metrics(
         self, pass_at_1: float, pass_at_k: float, fails: int
     ) -> dict[str, float]:
-        # Single source of truth for the report key set — the empty-run branch and
-        # the populated branch must not drift apart.
+        # Single source of truth for the report key set — both branches route here.
         metrics = {"score": pass_at_1, "fails": fails, "pass@1": pass_at_1}
         if self._k > 1:
             metrics[f"pass@{self._k}"] = pass_at_k
@@ -152,9 +148,8 @@ class AIME2025ZeroShotGenTask(
 
     def _pass_at_k(self, n: int, c: int, k: int) -> float:
         if n < k:
-            # Unreachable by configuration: __init__ rejects k > n. Only a model
-            # that returned fewer choices than requested reaches this, and report()
-            # warns about it so the 0 contribution is visible rather than silent.
+            # Unreachable by config (__init__ rejects k > n); only a model that
+            # returned fewer choices than requested lands here, and report() warns.
             return 0.0
         if c == 0:
             return 0.0

--- a/sieval/tasks/aime_2025_0shot_gen.py
+++ b/sieval/tasks/aime_2025_0shot_gen.py
@@ -50,6 +50,13 @@ class AIME2025ZeroShotGenTask(
 ):
     def __init__(self, dataset, model, name: str | None = None, k: int = 1, n: int = 1):
         super().__init__(dataset=dataset, model=model, name=name)
+        if k > n:
+            raise ValueError(
+                f"pass@{k} needs at least {k} sample(s) per problem, got n={n}. "
+                "Raise the task arg `n` (tasks.<name>.args.n) to at least k — `n` "
+                "is a task arg, not a model arg: the task forwards it call-time "
+                "and call-time wins over the model's configured args."
+            )
         self._k = k
         self._n = n
 
@@ -98,26 +105,56 @@ class AIME2025ZeroShotGenTask(
     async def report(self, finals, fails):
         total = len(finals) + len(fails)
         if total == 0:
-            return {"score": 0.0, "fails": len(fails)}
+            # Emit the same key set as the populated path below, so a consumer
+            # reading `pass@1` does not KeyError on an empty run.
+            return self._metrics(0.0, 0.0, len(fails))
 
         pass_at_1_total = 0.0
         pass_at_k_total = 0.0
+        short = 0
         for f in finals:
             feedbacks = f.feedback_result
             n_samples = len(feedbacks)
-            correct_num = sum(1 for f in feedbacks if f["correct"])
+            if n_samples < self._k:
+                short += 1
+            correct_num = sum(1 for fb in feedbacks if fb["correct"])
             pass_at_1_total += self._pass_at_k(n_samples, correct_num, 1)
             if self._k > 1:
                 pass_at_k_total += self._pass_at_k(n_samples, correct_num, self._k)
 
-        pass_at_1 = pass_at_1_total * 100 / total
-        metrics = {"score": pass_at_1, "fails": len(fails), "pass@1": pass_at_1}
+        if short:
+            logger.warning(
+                "{}/{} sample(s) returned fewer than k={} choices, contributing 0 "
+                "to pass@{}: the model produced fewer choices than the requested "
+                "n={}.",
+                short,
+                len(finals),
+                self._k,
+                self._k,
+                self._n,
+            )
+
+        return self._metrics(
+            pass_at_1_total * 100 / total,
+            pass_at_k_total * 100 / total,
+            len(fails),
+        )
+
+    def _metrics(
+        self, pass_at_1: float, pass_at_k: float, fails: int
+    ) -> dict[str, float]:
+        # Single source of truth for the report key set — the empty-run branch and
+        # the populated branch must not drift apart.
+        metrics = {"score": pass_at_1, "fails": fails, "pass@1": pass_at_1}
         if self._k > 1:
-            metrics[f"pass@{self._k}"] = pass_at_k_total * 100 / total
+            metrics[f"pass@{self._k}"] = pass_at_k
         return metrics
 
     def _pass_at_k(self, n: int, c: int, k: int) -> float:
         if n < k:
+            # Unreachable by configuration: __init__ rejects k > n. Only a model
+            # that returned fewer choices than requested reaches this, and report()
+            # warns about it so the 0 contribution is visible rather than silent.
             return 0.0
         if c == 0:
             return 0.0

--- a/sieval/tasks/aime_2026_0shot_gen.py
+++ b/sieval/tasks/aime_2026_0shot_gen.py
@@ -39,16 +39,13 @@ class Feedback(TypedDict):
         source="matharena",
         url="https://github.com/eth-sri/matharena/blob/a11194deff8c67a232974a383795e8a2776b4c6f/configs/competitions/aime/aime_2026.yaml",
         notes=(
-            "MathArena-aligned: boxed prompt + 0-999 integer hint, "
-            "last-boxed extraction; equivalence via math-verify. REPEATS: "
-            "matharena's runner defaults to `--n 4` and its published leaderboard "
-            "averages 4 runs per problem, while this task defaults to n=1 — set "
-            "n=4 to compare against matharena.ai. `n` is a task arg "
-            "(tasks.<name>.args.n), NOT a model arg: the task forwards it "
-            "call-time and call-time wins, so setting `n` on the model is silently "
-            "overridden. k>n is rejected at construction. DEVIATION: golds are "
-            "normalized by sieval.community.math.strip_string before comparison; "
-            "matharena does not normalize golds."
+            "MathArena-aligned: boxed prompt + 0-999 integer hint, last-boxed "
+            "extraction; equivalence via math-verify. REPEATS: matharena averages 4 "
+            "runs per problem (runner default `--n 4`) while this task defaults to "
+            "n=1 — set n=4 to compare against matharena.ai, as a task arg "
+            "(tasks.<name>.args.n); the model's `n` is silently overridden "
+            "call-time. k>n is rejected at construction. DEVIATION: golds are "
+            "normalized by sieval.community.math.strip_string; matharena does not."
         ),
     ),
 )
@@ -67,9 +64,8 @@ class AIME2026ZeroShotGenTask(
         if k > n:
             raise ValueError(
                 f"pass@{k} needs at least {k} sample(s) per problem, got n={n}. "
-                "Raise the task arg `n` (tasks.<name>.args.n) to at least k — `n` "
-                "is a task arg, not a model arg: the task forwards it call-time "
-                "and call-time wins over the model's configured args."
+                "Raise the task arg `n` (tasks.<name>.args.n) to at least k — "
+                "setting `n` on the model is silently overridden call-time."
             )
         self._k = k
         self._n = n
@@ -119,8 +115,7 @@ class AIME2026ZeroShotGenTask(
     async def report(self, finals, fails):
         total = len(finals) + len(fails)
         if total == 0:
-            # Emit the same key set as the populated path below, so a consumer
-            # reading `pass@1` does not KeyError on an empty run.
+            # Same key set as the populated path, so `pass@1` never KeyErrors.
             return self._metrics(0.0, 0.0, len(fails))
 
         pass_at_1_total = 0.0
@@ -138,14 +133,13 @@ class AIME2026ZeroShotGenTask(
 
         if short:
             logger.warning(
-                "{}/{} sample(s) returned fewer than k={} choices, contributing 0 "
-                "to pass@{}: the model produced fewer choices than the requested "
-                "n={}.",
+                "{}/{} sample(s) returned fewer than k={} choices (model produced "
+                "fewer than the requested n={}) and contribute 0 to pass@{}.",
                 short,
                 len(finals),
                 self._k,
-                self._k,
                 self._n,
+                self._k,
             )
 
         return self._metrics(
@@ -157,8 +151,7 @@ class AIME2026ZeroShotGenTask(
     def _metrics(
         self, pass_at_1: float, pass_at_k: float, fails: int
     ) -> dict[str, float]:
-        # Single source of truth for the report key set — the empty-run branch and
-        # the populated branch must not drift apart.
+        # Single source of truth for the report key set — both branches route here.
         metrics = {"score": pass_at_1, "fails": fails, "pass@1": pass_at_1}
         if self._k > 1:
             metrics[f"pass@{self._k}"] = pass_at_k
@@ -166,9 +159,8 @@ class AIME2026ZeroShotGenTask(
 
     def _pass_at_k(self, n: int, c: int, k: int) -> float:
         if n < k:
-            # Unreachable by configuration: __init__ rejects k > n. Only a model
-            # that returned fewer choices than requested reaches this, and report()
-            # warns about it so the 0 contribution is visible rather than silent.
+            # Unreachable by config (__init__ rejects k > n); only a model that
+            # returned fewer choices than requested lands here, and report() warns.
             return 0.0
         if c == 0:
             return 0.0

--- a/sieval/tasks/aime_2026_0shot_gen.py
+++ b/sieval/tasks/aime_2026_0shot_gen.py
@@ -40,7 +40,15 @@ class Feedback(TypedDict):
         url="https://github.com/eth-sri/matharena/blob/a11194deff8c67a232974a383795e8a2776b4c6f/configs/competitions/aime/aime_2026.yaml",
         notes=(
             "MathArena-aligned: boxed prompt + 0-999 integer hint, "
-            "last-boxed extraction; equivalence via math-verify."
+            "last-boxed extraction; equivalence via math-verify. REPEATS: "
+            "matharena's runner defaults to `--n 4` and its published leaderboard "
+            "averages 4 runs per problem, while this task defaults to n=1 — set "
+            "n=4 to compare against matharena.ai. `n` is a task arg "
+            "(tasks.<name>.args.n), NOT a model arg: the task forwards it "
+            "call-time and call-time wins, so setting `n` on the model is silently "
+            "overridden. k>n is rejected at construction. DEVIATION: golds are "
+            "normalized by sieval.community.math.strip_string before comparison; "
+            "matharena does not normalize golds."
         ),
     ),
 )
@@ -56,6 +64,13 @@ class AIME2026ZeroShotGenTask(
 ):
     def __init__(self, dataset, model, name: str | None = None, k: int = 1, n: int = 1):
         super().__init__(dataset=dataset, model=model, name=name)
+        if k > n:
+            raise ValueError(
+                f"pass@{k} needs at least {k} sample(s) per problem, got n={n}. "
+                "Raise the task arg `n` (tasks.<name>.args.n) to at least k — `n` "
+                "is a task arg, not a model arg: the task forwards it call-time "
+                "and call-time wins over the model's configured args."
+            )
         self._k = k
         self._n = n
 
@@ -64,7 +79,7 @@ class AIME2026ZeroShotGenTask(
         return [
             {
                 "role": "user",
-                "content": build_prompt(AIME_INSTRUCTION, raw["question"]),
+                "content": build_prompt(AIME_INSTRUCTION, raw["problem"]),
             },
         ]
 
@@ -104,26 +119,56 @@ class AIME2026ZeroShotGenTask(
     async def report(self, finals, fails):
         total = len(finals) + len(fails)
         if total == 0:
-            return {"score": 0.0, "fails": len(fails)}
+            # Emit the same key set as the populated path below, so a consumer
+            # reading `pass@1` does not KeyError on an empty run.
+            return self._metrics(0.0, 0.0, len(fails))
 
         pass_at_1_total = 0.0
         pass_at_k_total = 0.0
+        short = 0
         for f in finals:
             feedbacks = f.feedback_result
             n_samples = len(feedbacks)
-            correct_num = sum(1 for f in feedbacks if f["correct"])
+            if n_samples < self._k:
+                short += 1
+            correct_num = sum(1 for fb in feedbacks if fb["correct"])
             pass_at_1_total += self._pass_at_k(n_samples, correct_num, 1)
             if self._k > 1:
                 pass_at_k_total += self._pass_at_k(n_samples, correct_num, self._k)
 
-        pass_at_1 = pass_at_1_total * 100 / total
-        metrics = {"score": pass_at_1, "fails": len(fails), "pass@1": pass_at_1}
+        if short:
+            logger.warning(
+                "{}/{} sample(s) returned fewer than k={} choices, contributing 0 "
+                "to pass@{}: the model produced fewer choices than the requested "
+                "n={}.",
+                short,
+                len(finals),
+                self._k,
+                self._k,
+                self._n,
+            )
+
+        return self._metrics(
+            pass_at_1_total * 100 / total,
+            pass_at_k_total * 100 / total,
+            len(fails),
+        )
+
+    def _metrics(
+        self, pass_at_1: float, pass_at_k: float, fails: int
+    ) -> dict[str, float]:
+        # Single source of truth for the report key set — the empty-run branch and
+        # the populated branch must not drift apart.
+        metrics = {"score": pass_at_1, "fails": fails, "pass@1": pass_at_1}
         if self._k > 1:
-            metrics[f"pass@{self._k}"] = pass_at_k_total * 100 / total
+            metrics[f"pass@{self._k}"] = pass_at_k
         return metrics
 
     def _pass_at_k(self, n: int, c: int, k: int) -> float:
         if n < k:
+            # Unreachable by configuration: __init__ rejects k > n. Only a model
+            # that returned fewer choices than requested reaches this, and report()
+            # warns about it so the 0 contribution is visible rather than silent.
             return 0.0
         if c == 0:
             return 0.0

--- a/sieval/tasks/hmmt_feb_2025_0shot_gen.py
+++ b/sieval/tasks/hmmt_feb_2025_0shot_gen.py
@@ -39,15 +39,13 @@ class Feedback(TypedDict):
         source="matharena",
         url="https://github.com/eth-sri/matharena/blob/a11194deff8c67a232974a383795e8a2776b4c6f/configs/competitions/hmmt/hmmt_feb_2025.yaml",
         notes=(
-            "MathArena-aligned: boxed prompt, last-boxed extraction; "
-            "equivalence via math-verify. REPEATS: matharena's runner defaults to "
-            "`--n 4` and its published leaderboard averages 4 runs per problem, "
-            "while this task defaults to n=1 — set n=4 to compare against "
-            "matharena.ai. `n` is a task arg (tasks.<name>.args.n), NOT a model "
-            "arg: the task forwards it call-time and call-time wins, so setting `n` "
-            "on the model is silently overridden. k>n is rejected at construction. "
-            "DEVIATION: golds are normalized by sieval.community.math.strip_string "
-            "before comparison; matharena does not normalize golds."
+            "MathArena-aligned: boxed prompt, last-boxed extraction; equivalence "
+            "via math-verify. REPEATS: matharena averages 4 runs per problem "
+            "(runner default `--n 4`) while this task defaults to n=1 — set n=4 to "
+            "compare against matharena.ai, as a task arg (tasks.<name>.args.n); the "
+            "model's `n` is silently overridden call-time. k>n is rejected at "
+            "construction. DEVIATION: golds are normalized by "
+            "sieval.community.math.strip_string; matharena does not."
         ),
     ),
 )
@@ -66,9 +64,8 @@ class HMMTFeb2025ZeroShotGenTask(
         if k > n:
             raise ValueError(
                 f"pass@{k} needs at least {k} sample(s) per problem, got n={n}. "
-                "Raise the task arg `n` (tasks.<name>.args.n) to at least k — `n` "
-                "is a task arg, not a model arg: the task forwards it call-time "
-                "and call-time wins over the model's configured args."
+                "Raise the task arg `n` (tasks.<name>.args.n) to at least k — "
+                "setting `n` on the model is silently overridden call-time."
             )
         self._k = k
         self._n = n
@@ -118,8 +115,7 @@ class HMMTFeb2025ZeroShotGenTask(
     async def report(self, finals, fails):
         total = len(finals) + len(fails)
         if total == 0:
-            # Emit the same key set as the populated path below, so a consumer
-            # reading `pass@1` does not KeyError on an empty run.
+            # Same key set as the populated path, so `pass@1` never KeyErrors.
             return self._metrics(0.0, 0.0, len(fails))
 
         pass_at_1_total = 0.0
@@ -137,14 +133,13 @@ class HMMTFeb2025ZeroShotGenTask(
 
         if short:
             logger.warning(
-                "{}/{} sample(s) returned fewer than k={} choices, contributing 0 "
-                "to pass@{}: the model produced fewer choices than the requested "
-                "n={}.",
+                "{}/{} sample(s) returned fewer than k={} choices (model produced "
+                "fewer than the requested n={}) and contribute 0 to pass@{}.",
                 short,
                 len(finals),
                 self._k,
-                self._k,
                 self._n,
+                self._k,
             )
 
         return self._metrics(
@@ -156,8 +151,7 @@ class HMMTFeb2025ZeroShotGenTask(
     def _metrics(
         self, pass_at_1: float, pass_at_k: float, fails: int
     ) -> dict[str, float]:
-        # Single source of truth for the report key set — the empty-run branch and
-        # the populated branch must not drift apart.
+        # Single source of truth for the report key set — both branches route here.
         metrics = {"score": pass_at_1, "fails": fails, "pass@1": pass_at_1}
         if self._k > 1:
             metrics[f"pass@{self._k}"] = pass_at_k
@@ -165,9 +159,8 @@ class HMMTFeb2025ZeroShotGenTask(
 
     def _pass_at_k(self, n: int, c: int, k: int) -> float:
         if n < k:
-            # Unreachable by configuration: __init__ rejects k > n. Only a model
-            # that returned fewer choices than requested reaches this, and report()
-            # warns about it so the 0 contribution is visible rather than silent.
+            # Unreachable by config (__init__ rejects k > n); only a model that
+            # returned fewer choices than requested lands here, and report() warns.
             return 0.0
         if c == 0:
             return 0.0

--- a/sieval/tasks/hmmt_feb_2025_0shot_gen.py
+++ b/sieval/tasks/hmmt_feb_2025_0shot_gen.py
@@ -40,7 +40,14 @@ class Feedback(TypedDict):
         url="https://github.com/eth-sri/matharena/blob/a11194deff8c67a232974a383795e8a2776b4c6f/configs/competitions/hmmt/hmmt_feb_2025.yaml",
         notes=(
             "MathArena-aligned: boxed prompt, last-boxed extraction; "
-            "equivalence via math-verify."
+            "equivalence via math-verify. REPEATS: matharena's runner defaults to "
+            "`--n 4` and its published leaderboard averages 4 runs per problem, "
+            "while this task defaults to n=1 — set n=4 to compare against "
+            "matharena.ai. `n` is a task arg (tasks.<name>.args.n), NOT a model "
+            "arg: the task forwards it call-time and call-time wins, so setting `n` "
+            "on the model is silently overridden. k>n is rejected at construction. "
+            "DEVIATION: golds are normalized by sieval.community.math.strip_string "
+            "before comparison; matharena does not normalize golds."
         ),
     ),
 )
@@ -56,6 +63,13 @@ class HMMTFeb2025ZeroShotGenTask(
 ):
     def __init__(self, dataset, model, name: str | None = None, k: int = 1, n: int = 1):
         super().__init__(dataset=dataset, model=model, name=name)
+        if k > n:
+            raise ValueError(
+                f"pass@{k} needs at least {k} sample(s) per problem, got n={n}. "
+                "Raise the task arg `n` (tasks.<name>.args.n) to at least k — `n` "
+                "is a task arg, not a model arg: the task forwards it call-time "
+                "and call-time wins over the model's configured args."
+            )
         self._k = k
         self._n = n
 
@@ -64,7 +78,7 @@ class HMMTFeb2025ZeroShotGenTask(
         return [
             {
                 "role": "user",
-                "content": build_prompt(HMMT_INSTRUCTION, raw["question"]),
+                "content": build_prompt(HMMT_INSTRUCTION, raw["problem"]),
             },
         ]
 
@@ -104,26 +118,56 @@ class HMMTFeb2025ZeroShotGenTask(
     async def report(self, finals, fails):
         total = len(finals) + len(fails)
         if total == 0:
-            return {"score": 0.0, "fails": len(fails)}
+            # Emit the same key set as the populated path below, so a consumer
+            # reading `pass@1` does not KeyError on an empty run.
+            return self._metrics(0.0, 0.0, len(fails))
 
         pass_at_1_total = 0.0
         pass_at_k_total = 0.0
+        short = 0
         for f in finals:
             feedbacks = f.feedback_result
             n_samples = len(feedbacks)
-            correct_num = sum(1 for f in feedbacks if f["correct"])
+            if n_samples < self._k:
+                short += 1
+            correct_num = sum(1 for fb in feedbacks if fb["correct"])
             pass_at_1_total += self._pass_at_k(n_samples, correct_num, 1)
             if self._k > 1:
                 pass_at_k_total += self._pass_at_k(n_samples, correct_num, self._k)
 
-        pass_at_1 = pass_at_1_total * 100 / total
-        metrics = {"score": pass_at_1, "fails": len(fails), "pass@1": pass_at_1}
+        if short:
+            logger.warning(
+                "{}/{} sample(s) returned fewer than k={} choices, contributing 0 "
+                "to pass@{}: the model produced fewer choices than the requested "
+                "n={}.",
+                short,
+                len(finals),
+                self._k,
+                self._k,
+                self._n,
+            )
+
+        return self._metrics(
+            pass_at_1_total * 100 / total,
+            pass_at_k_total * 100 / total,
+            len(fails),
+        )
+
+    def _metrics(
+        self, pass_at_1: float, pass_at_k: float, fails: int
+    ) -> dict[str, float]:
+        # Single source of truth for the report key set — the empty-run branch and
+        # the populated branch must not drift apart.
+        metrics = {"score": pass_at_1, "fails": fails, "pass@1": pass_at_1}
         if self._k > 1:
-            metrics[f"pass@{self._k}"] = pass_at_k_total * 100 / total
+            metrics[f"pass@{self._k}"] = pass_at_k
         return metrics
 
     def _pass_at_k(self, n: int, c: int, k: int) -> float:
         if n < k:
+            # Unreachable by configuration: __init__ rejects k > n. Only a model
+            # that returned fewer choices than requested reaches this, and report()
+            # warns about it so the 0 contribution is visible rather than silent.
             return 0.0
         if c == 0:
             return 0.0

--- a/sieval/tasks/hmmt_feb_2026_0shot_gen.py
+++ b/sieval/tasks/hmmt_feb_2026_0shot_gen.py
@@ -40,7 +40,14 @@ class Feedback(TypedDict):
         url="https://github.com/eth-sri/matharena/blob/a11194deff8c67a232974a383795e8a2776b4c6f/configs/competitions/hmmt/hmmt_feb_2026.yaml",
         notes=(
             "MathArena-aligned: boxed prompt, last-boxed extraction; "
-            "equivalence via math-verify."
+            "equivalence via math-verify. REPEATS: matharena's runner defaults to "
+            "`--n 4` and its published leaderboard averages 4 runs per problem, "
+            "while this task defaults to n=1 — set n=4 to compare against "
+            "matharena.ai. `n` is a task arg (tasks.<name>.args.n), NOT a model "
+            "arg: the task forwards it call-time and call-time wins, so setting `n` "
+            "on the model is silently overridden. k>n is rejected at construction. "
+            "DEVIATION: golds are normalized by sieval.community.math.strip_string "
+            "before comparison; matharena does not normalize golds."
         ),
     ),
 )
@@ -56,6 +63,13 @@ class HMMTFeb2026ZeroShotGenTask(
 ):
     def __init__(self, dataset, model, name: str | None = None, k: int = 1, n: int = 1):
         super().__init__(dataset=dataset, model=model, name=name)
+        if k > n:
+            raise ValueError(
+                f"pass@{k} needs at least {k} sample(s) per problem, got n={n}. "
+                "Raise the task arg `n` (tasks.<name>.args.n) to at least k — `n` "
+                "is a task arg, not a model arg: the task forwards it call-time "
+                "and call-time wins over the model's configured args."
+            )
         self._k = k
         self._n = n
 
@@ -64,7 +78,7 @@ class HMMTFeb2026ZeroShotGenTask(
         return [
             {
                 "role": "user",
-                "content": build_prompt(HMMT_INSTRUCTION, raw["question"]),
+                "content": build_prompt(HMMT_INSTRUCTION, raw["problem"]),
             },
         ]
 
@@ -104,26 +118,56 @@ class HMMTFeb2026ZeroShotGenTask(
     async def report(self, finals, fails):
         total = len(finals) + len(fails)
         if total == 0:
-            return {"score": 0.0, "fails": len(fails)}
+            # Emit the same key set as the populated path below, so a consumer
+            # reading `pass@1` does not KeyError on an empty run.
+            return self._metrics(0.0, 0.0, len(fails))
 
         pass_at_1_total = 0.0
         pass_at_k_total = 0.0
+        short = 0
         for f in finals:
             feedbacks = f.feedback_result
             n_samples = len(feedbacks)
-            correct_num = sum(1 for f in feedbacks if f["correct"])
+            if n_samples < self._k:
+                short += 1
+            correct_num = sum(1 for fb in feedbacks if fb["correct"])
             pass_at_1_total += self._pass_at_k(n_samples, correct_num, 1)
             if self._k > 1:
                 pass_at_k_total += self._pass_at_k(n_samples, correct_num, self._k)
 
-        pass_at_1 = pass_at_1_total * 100 / total
-        metrics = {"score": pass_at_1, "fails": len(fails), "pass@1": pass_at_1}
+        if short:
+            logger.warning(
+                "{}/{} sample(s) returned fewer than k={} choices, contributing 0 "
+                "to pass@{}: the model produced fewer choices than the requested "
+                "n={}.",
+                short,
+                len(finals),
+                self._k,
+                self._k,
+                self._n,
+            )
+
+        return self._metrics(
+            pass_at_1_total * 100 / total,
+            pass_at_k_total * 100 / total,
+            len(fails),
+        )
+
+    def _metrics(
+        self, pass_at_1: float, pass_at_k: float, fails: int
+    ) -> dict[str, float]:
+        # Single source of truth for the report key set — the empty-run branch and
+        # the populated branch must not drift apart.
+        metrics = {"score": pass_at_1, "fails": fails, "pass@1": pass_at_1}
         if self._k > 1:
-            metrics[f"pass@{self._k}"] = pass_at_k_total * 100 / total
+            metrics[f"pass@{self._k}"] = pass_at_k
         return metrics
 
     def _pass_at_k(self, n: int, c: int, k: int) -> float:
         if n < k:
+            # Unreachable by configuration: __init__ rejects k > n. Only a model
+            # that returned fewer choices than requested reaches this, and report()
+            # warns about it so the 0 contribution is visible rather than silent.
             return 0.0
         if c == 0:
             return 0.0

--- a/sieval/tasks/hmmt_feb_2026_0shot_gen.py
+++ b/sieval/tasks/hmmt_feb_2026_0shot_gen.py
@@ -39,15 +39,13 @@ class Feedback(TypedDict):
         source="matharena",
         url="https://github.com/eth-sri/matharena/blob/a11194deff8c67a232974a383795e8a2776b4c6f/configs/competitions/hmmt/hmmt_feb_2026.yaml",
         notes=(
-            "MathArena-aligned: boxed prompt, last-boxed extraction; "
-            "equivalence via math-verify. REPEATS: matharena's runner defaults to "
-            "`--n 4` and its published leaderboard averages 4 runs per problem, "
-            "while this task defaults to n=1 — set n=4 to compare against "
-            "matharena.ai. `n` is a task arg (tasks.<name>.args.n), NOT a model "
-            "arg: the task forwards it call-time and call-time wins, so setting `n` "
-            "on the model is silently overridden. k>n is rejected at construction. "
-            "DEVIATION: golds are normalized by sieval.community.math.strip_string "
-            "before comparison; matharena does not normalize golds."
+            "MathArena-aligned: boxed prompt, last-boxed extraction; equivalence "
+            "via math-verify. REPEATS: matharena averages 4 runs per problem "
+            "(runner default `--n 4`) while this task defaults to n=1 — set n=4 to "
+            "compare against matharena.ai, as a task arg (tasks.<name>.args.n); the "
+            "model's `n` is silently overridden call-time. k>n is rejected at "
+            "construction. DEVIATION: golds are normalized by "
+            "sieval.community.math.strip_string; matharena does not."
         ),
     ),
 )
@@ -66,9 +64,8 @@ class HMMTFeb2026ZeroShotGenTask(
         if k > n:
             raise ValueError(
                 f"pass@{k} needs at least {k} sample(s) per problem, got n={n}. "
-                "Raise the task arg `n` (tasks.<name>.args.n) to at least k — `n` "
-                "is a task arg, not a model arg: the task forwards it call-time "
-                "and call-time wins over the model's configured args."
+                "Raise the task arg `n` (tasks.<name>.args.n) to at least k — "
+                "setting `n` on the model is silently overridden call-time."
             )
         self._k = k
         self._n = n
@@ -118,8 +115,7 @@ class HMMTFeb2026ZeroShotGenTask(
     async def report(self, finals, fails):
         total = len(finals) + len(fails)
         if total == 0:
-            # Emit the same key set as the populated path below, so a consumer
-            # reading `pass@1` does not KeyError on an empty run.
+            # Same key set as the populated path, so `pass@1` never KeyErrors.
             return self._metrics(0.0, 0.0, len(fails))
 
         pass_at_1_total = 0.0
@@ -137,14 +133,13 @@ class HMMTFeb2026ZeroShotGenTask(
 
         if short:
             logger.warning(
-                "{}/{} sample(s) returned fewer than k={} choices, contributing 0 "
-                "to pass@{}: the model produced fewer choices than the requested "
-                "n={}.",
+                "{}/{} sample(s) returned fewer than k={} choices (model produced "
+                "fewer than the requested n={}) and contribute 0 to pass@{}.",
                 short,
                 len(finals),
                 self._k,
-                self._k,
                 self._n,
+                self._k,
             )
 
         return self._metrics(
@@ -156,8 +151,7 @@ class HMMTFeb2026ZeroShotGenTask(
     def _metrics(
         self, pass_at_1: float, pass_at_k: float, fails: int
     ) -> dict[str, float]:
-        # Single source of truth for the report key set — the empty-run branch and
-        # the populated branch must not drift apart.
+        # Single source of truth for the report key set — both branches route here.
         metrics = {"score": pass_at_1, "fails": fails, "pass@1": pass_at_1}
         if self._k > 1:
             metrics[f"pass@{self._k}"] = pass_at_k
@@ -165,9 +159,8 @@ class HMMTFeb2026ZeroShotGenTask(
 
     def _pass_at_k(self, n: int, c: int, k: int) -> float:
         if n < k:
-            # Unreachable by configuration: __init__ rejects k > n. Only a model
-            # that returned fewer choices than requested reaches this, and report()
-            # warns about it so the 0 contribution is visible rather than silent.
+            # Unreachable by config (__init__ rejects k > n); only a model that
+            # returned fewer choices than requested lands here, and report() warns.
             return 0.0
         if c == 0:
             return 0.0

--- a/sieval/tasks/hmmt_nov_2025_0shot_gen.py
+++ b/sieval/tasks/hmmt_nov_2025_0shot_gen.py
@@ -40,7 +40,14 @@ class Feedback(TypedDict):
         url="https://github.com/eth-sri/matharena/blob/a11194deff8c67a232974a383795e8a2776b4c6f/configs/competitions/hmmt/hmmt_nov_2025.yaml",
         notes=(
             "MathArena-aligned: boxed prompt, last-boxed extraction; "
-            "equivalence via math-verify."
+            "equivalence via math-verify. REPEATS: matharena's runner defaults to "
+            "`--n 4` and its published leaderboard averages 4 runs per problem, "
+            "while this task defaults to n=1 — set n=4 to compare against "
+            "matharena.ai. `n` is a task arg (tasks.<name>.args.n), NOT a model "
+            "arg: the task forwards it call-time and call-time wins, so setting `n` "
+            "on the model is silently overridden. k>n is rejected at construction. "
+            "DEVIATION: golds are normalized by sieval.community.math.strip_string "
+            "before comparison; matharena does not normalize golds."
         ),
     ),
 )
@@ -56,6 +63,13 @@ class HMMTNov2025ZeroShotGenTask(
 ):
     def __init__(self, dataset, model, name: str | None = None, k: int = 1, n: int = 1):
         super().__init__(dataset=dataset, model=model, name=name)
+        if k > n:
+            raise ValueError(
+                f"pass@{k} needs at least {k} sample(s) per problem, got n={n}. "
+                "Raise the task arg `n` (tasks.<name>.args.n) to at least k — `n` "
+                "is a task arg, not a model arg: the task forwards it call-time "
+                "and call-time wins over the model's configured args."
+            )
         self._k = k
         self._n = n
 
@@ -64,7 +78,7 @@ class HMMTNov2025ZeroShotGenTask(
         return [
             {
                 "role": "user",
-                "content": build_prompt(HMMT_INSTRUCTION, raw["question"]),
+                "content": build_prompt(HMMT_INSTRUCTION, raw["problem"]),
             },
         ]
 
@@ -104,26 +118,56 @@ class HMMTNov2025ZeroShotGenTask(
     async def report(self, finals, fails):
         total = len(finals) + len(fails)
         if total == 0:
-            return {"score": 0.0, "fails": len(fails)}
+            # Emit the same key set as the populated path below, so a consumer
+            # reading `pass@1` does not KeyError on an empty run.
+            return self._metrics(0.0, 0.0, len(fails))
 
         pass_at_1_total = 0.0
         pass_at_k_total = 0.0
+        short = 0
         for f in finals:
             feedbacks = f.feedback_result
             n_samples = len(feedbacks)
-            correct_num = sum(1 for f in feedbacks if f["correct"])
+            if n_samples < self._k:
+                short += 1
+            correct_num = sum(1 for fb in feedbacks if fb["correct"])
             pass_at_1_total += self._pass_at_k(n_samples, correct_num, 1)
             if self._k > 1:
                 pass_at_k_total += self._pass_at_k(n_samples, correct_num, self._k)
 
-        pass_at_1 = pass_at_1_total * 100 / total
-        metrics = {"score": pass_at_1, "fails": len(fails), "pass@1": pass_at_1}
+        if short:
+            logger.warning(
+                "{}/{} sample(s) returned fewer than k={} choices, contributing 0 "
+                "to pass@{}: the model produced fewer choices than the requested "
+                "n={}.",
+                short,
+                len(finals),
+                self._k,
+                self._k,
+                self._n,
+            )
+
+        return self._metrics(
+            pass_at_1_total * 100 / total,
+            pass_at_k_total * 100 / total,
+            len(fails),
+        )
+
+    def _metrics(
+        self, pass_at_1: float, pass_at_k: float, fails: int
+    ) -> dict[str, float]:
+        # Single source of truth for the report key set — the empty-run branch and
+        # the populated branch must not drift apart.
+        metrics = {"score": pass_at_1, "fails": fails, "pass@1": pass_at_1}
         if self._k > 1:
-            metrics[f"pass@{self._k}"] = pass_at_k_total * 100 / total
+            metrics[f"pass@{self._k}"] = pass_at_k
         return metrics
 
     def _pass_at_k(self, n: int, c: int, k: int) -> float:
         if n < k:
+            # Unreachable by configuration: __init__ rejects k > n. Only a model
+            # that returned fewer choices than requested reaches this, and report()
+            # warns about it so the 0 contribution is visible rather than silent.
             return 0.0
         if c == 0:
             return 0.0

--- a/sieval/tasks/hmmt_nov_2025_0shot_gen.py
+++ b/sieval/tasks/hmmt_nov_2025_0shot_gen.py
@@ -39,15 +39,13 @@ class Feedback(TypedDict):
         source="matharena",
         url="https://github.com/eth-sri/matharena/blob/a11194deff8c67a232974a383795e8a2776b4c6f/configs/competitions/hmmt/hmmt_nov_2025.yaml",
         notes=(
-            "MathArena-aligned: boxed prompt, last-boxed extraction; "
-            "equivalence via math-verify. REPEATS: matharena's runner defaults to "
-            "`--n 4` and its published leaderboard averages 4 runs per problem, "
-            "while this task defaults to n=1 — set n=4 to compare against "
-            "matharena.ai. `n` is a task arg (tasks.<name>.args.n), NOT a model "
-            "arg: the task forwards it call-time and call-time wins, so setting `n` "
-            "on the model is silently overridden. k>n is rejected at construction. "
-            "DEVIATION: golds are normalized by sieval.community.math.strip_string "
-            "before comparison; matharena does not normalize golds."
+            "MathArena-aligned: boxed prompt, last-boxed extraction; equivalence "
+            "via math-verify. REPEATS: matharena averages 4 runs per problem "
+            "(runner default `--n 4`) while this task defaults to n=1 — set n=4 to "
+            "compare against matharena.ai, as a task arg (tasks.<name>.args.n); the "
+            "model's `n` is silently overridden call-time. k>n is rejected at "
+            "construction. DEVIATION: golds are normalized by "
+            "sieval.community.math.strip_string; matharena does not."
         ),
     ),
 )
@@ -66,9 +64,8 @@ class HMMTNov2025ZeroShotGenTask(
         if k > n:
             raise ValueError(
                 f"pass@{k} needs at least {k} sample(s) per problem, got n={n}. "
-                "Raise the task arg `n` (tasks.<name>.args.n) to at least k — `n` "
-                "is a task arg, not a model arg: the task forwards it call-time "
-                "and call-time wins over the model's configured args."
+                "Raise the task arg `n` (tasks.<name>.args.n) to at least k — "
+                "setting `n` on the model is silently overridden call-time."
             )
         self._k = k
         self._n = n
@@ -118,8 +115,7 @@ class HMMTNov2025ZeroShotGenTask(
     async def report(self, finals, fails):
         total = len(finals) + len(fails)
         if total == 0:
-            # Emit the same key set as the populated path below, so a consumer
-            # reading `pass@1` does not KeyError on an empty run.
+            # Same key set as the populated path, so `pass@1` never KeyErrors.
             return self._metrics(0.0, 0.0, len(fails))
 
         pass_at_1_total = 0.0
@@ -137,14 +133,13 @@ class HMMTNov2025ZeroShotGenTask(
 
         if short:
             logger.warning(
-                "{}/{} sample(s) returned fewer than k={} choices, contributing 0 "
-                "to pass@{}: the model produced fewer choices than the requested "
-                "n={}.",
+                "{}/{} sample(s) returned fewer than k={} choices (model produced "
+                "fewer than the requested n={}) and contribute 0 to pass@{}.",
                 short,
                 len(finals),
                 self._k,
-                self._k,
                 self._n,
+                self._k,
             )
 
         return self._metrics(
@@ -156,8 +151,7 @@ class HMMTNov2025ZeroShotGenTask(
     def _metrics(
         self, pass_at_1: float, pass_at_k: float, fails: int
     ) -> dict[str, float]:
-        # Single source of truth for the report key set — the empty-run branch and
-        # the populated branch must not drift apart.
+        # Single source of truth for the report key set — both branches route here.
         metrics = {"score": pass_at_1, "fails": fails, "pass@1": pass_at_1}
         if self._k > 1:
             metrics[f"pass@{self._k}"] = pass_at_k
@@ -165,9 +159,8 @@ class HMMTNov2025ZeroShotGenTask(
 
     def _pass_at_k(self, n: int, c: int, k: int) -> float:
         if n < k:
-            # Unreachable by configuration: __init__ rejects k > n. Only a model
-            # that returned fewer choices than requested reaches this, and report()
-            # warns about it so the 0 contribution is visible rather than silent.
+            # Unreachable by config (__init__ rejects k > n); only a model that
+            # returned fewer choices than requested lands here, and report() warns.
             return 0.0
         if c == 0:
             return 0.0

--- a/sieval/tasks/hmmt_nov_2025_0shot_gen.py
+++ b/sieval/tasks/hmmt_nov_2025_0shot_gen.py
@@ -1,0 +1,135 @@
+"""HMMT November 2025 zero-shot generative task.
+
+AI-Generated Code - Claude Opus 4.8 (Anthropic)
+"""
+
+from typing import TypedDict, override
+
+from loguru import logger
+from openai.types.chat import ChatCompletionUserMessageParam
+
+from sieval.community.matharena import HMMT_INSTRUCTION, build_prompt, extract_answer
+from sieval.core.models import ModelOutput
+from sieval.core.tasks import (
+    EvalMode,
+    ReferenceImpl,
+    Task,
+    sieval_task,
+)
+from sieval.datasets import HMMTNov2025DatasetSample
+
+
+class Feedback(TypedDict):
+    correct: bool
+    answer: str
+
+
+@sieval_task(
+    name="hmmt_nov_2025_0shot_gen",
+    display_name="HMMT Nov 2025 (0-shot, generative)",
+    description=(
+        "HMMT November 2025 — Harvard-MIT Mathematics Tournament, 30 problems."
+    ),
+    eval_mode=EvalMode.GEN,
+    n_shot=0,
+    tags=("english", "open-ended"),
+    deps_group="math",
+    model_type="chat",
+    reference_impl=ReferenceImpl(
+        source="matharena",
+        url="https://github.com/eth-sri/matharena/blob/a11194deff8c67a232974a383795e8a2776b4c6f/configs/competitions/hmmt/hmmt_nov_2025.yaml",
+        notes=(
+            "MathArena-aligned: boxed prompt, last-boxed extraction; "
+            "equivalence via math-verify."
+        ),
+    ),
+)
+class HMMTNov2025ZeroShotGenTask(
+    Task[
+        HMMTNov2025DatasetSample,
+        list[ChatCompletionUserMessageParam],
+        ModelOutput,
+        list[str | None],
+        list[Feedback],
+        dict[str, float],
+    ],
+):
+    def __init__(self, dataset, model, name: str | None = None, k: int = 1, n: int = 1):
+        super().__init__(dataset=dataset, model=model, name=name)
+        self._k = k
+        self._n = n
+
+    @override
+    async def preprocess(self, raw, ctx):
+        return [
+            {
+                "role": "user",
+                "content": build_prompt(HMMT_INSTRUCTION, raw["question"]),
+            },
+        ]
+
+    @override
+    async def infer(self, pre, ctx):
+        return await self.model.agenerate(pre, n=self._n)
+
+    @override
+    async def postprocess(self, inf, ctx):
+        # MathArena-aligned: last \boxed{}; non-strict -> fall back to last integer.
+        return [extract_answer(choice, strict_parsing=False) for choice in inf.texts]
+
+    @override
+    async def feedback(self, post, ctx):
+        from math_verify import parse, verify
+
+        feedbacks: list[Feedback] = []
+        ground_truth = ctx.raw_sample["answer"]
+        for pred in post:
+            if pred is None:
+                feedbacks.append({"correct": False, "answer": ground_truth})
+                continue
+            pred_with_env = f"${pred}$"
+            ref_with_env = f"${ground_truth}$"
+            try:
+                parsed_pred = parse(pred_with_env)
+                parsed_ref = parse(ref_with_env)
+                # math_verify.verify expects the gold answer as the first arg.
+                correct = verify(parsed_ref, parsed_pred)
+            except Exception as e:
+                logger.warning("Feedback failed for sample {}: {}", ctx.sample_id, e)
+                correct = False
+            feedbacks.append({"correct": correct, "answer": ground_truth})
+        return True, feedbacks
+
+    @override
+    async def report(self, finals, fails):
+        total = len(finals) + len(fails)
+        if total == 0:
+            return {"score": 0.0, "fails": len(fails)}
+
+        pass_at_1_total = 0.0
+        pass_at_k_total = 0.0
+        for f in finals:
+            feedbacks = f.feedback_result
+            n_samples = len(feedbacks)
+            correct_num = sum(1 for f in feedbacks if f["correct"])
+            pass_at_1_total += self._pass_at_k(n_samples, correct_num, 1)
+            if self._k > 1:
+                pass_at_k_total += self._pass_at_k(n_samples, correct_num, self._k)
+
+        pass_at_1 = pass_at_1_total * 100 / total
+        metrics = {"score": pass_at_1, "fails": len(fails), "pass@1": pass_at_1}
+        if self._k > 1:
+            metrics[f"pass@{self._k}"] = pass_at_k_total * 100 / total
+        return metrics
+
+    def _pass_at_k(self, n: int, c: int, k: int) -> float:
+        if n < k:
+            return 0.0
+        if c == 0:
+            return 0.0
+        # Formula: 1 - product_{i=0}^{k-1} (n - c - i) / (n - i)
+        # This calculates the probability that all k samples are wrong
+        prob_all_wrong = 1.0
+        for i in range(k):
+            prob_all_wrong *= (n - c - i) / (n - i)
+        return 1.0 - prob_all_wrong

--- a/sieval/tasks/hmmt_nov_2025_0shot_gen.py
+++ b/sieval/tasks/hmmt_nov_2025_0shot_gen.py
@@ -45,7 +45,15 @@ class Feedback(TypedDict):
             "compare against matharena.ai, as a task arg (tasks.<name>.args.n); the "
             "model's `n` is silently overridden call-time. k>n is rejected at "
             "construction. DEVIATION: golds are normalized by "
-            "sieval.community.math.strip_string; matharena does not."
+            "sieval.community.math.strip_string; matharena does not. VALIDATED "
+            "against official MathArena: replaying its published 2640 outputs "
+            "(22 models x 30 problems x 4 runs) through this task's grading path "
+            "agrees with the upstream grader on 99.51% of outputs and reproduces "
+            "16/22 model scores exactly; Gemini 3 Flash is 93.33% three ways "
+            "(published, upstream grader, sieval grader). A live sieval run of "
+            "gemini-3-flash-preview scored 95.00% vs the published 93.33% — "
+            "sampling variance, not a grading difference: both graders agree on "
+            "120/120 of sieval's own outputs."
         ),
     ),
 )

--- a/sieval/tasks/imo_answer_bench_0shot_gen.py
+++ b/sieval/tasks/imo_answer_bench_0shot_gen.py
@@ -130,6 +130,13 @@ class IMOAnswerBenchZeroShotGenTask(
 ):
     def __init__(self, dataset, model, name: str | None = None, k: int = 1, n: int = 1):
         super().__init__(dataset=dataset, model=model, name=name)
+        if k > n:
+            raise ValueError(
+                f"pass@{k} needs at least {k} sample(s) per problem, got n={n}. "
+                "Raise the task arg `n` (tasks.<name>.args.n) to at least k — `n` "
+                "is a task arg, not a model arg: the task forwards it call-time "
+                "and call-time wins over the model's configured args."
+            )
         self._k = k
         self._n = n
 
@@ -138,7 +145,7 @@ class IMOAnswerBenchZeroShotGenTask(
         return [
             {
                 "role": "user",
-                "content": build_prompt(IMO_ANSWER_BENCH_INSTRUCTION, raw["question"]),
+                "content": build_prompt(IMO_ANSWER_BENCH_INSTRUCTION, raw["problem"]),
             },
         ]
 
@@ -180,26 +187,56 @@ class IMOAnswerBenchZeroShotGenTask(
     async def report(self, finals, fails):
         total = len(finals) + len(fails)
         if total == 0:
-            return {"score": 0.0, "fails": len(fails)}
+            # Emit the same key set as the populated path below, so a consumer
+            # reading `pass@1` does not KeyError on an empty run.
+            return self._metrics(0.0, 0.0, len(fails))
 
         pass_at_1_total = 0.0
         pass_at_k_total = 0.0
+        short = 0
         for f in finals:
             feedbacks = f.feedback_result
             n_samples = len(feedbacks)
-            correct_num = sum(1 for f in feedbacks if f["correct"])
+            if n_samples < self._k:
+                short += 1
+            correct_num = sum(1 for fb in feedbacks if fb["correct"])
             pass_at_1_total += self._pass_at_k(n_samples, correct_num, 1)
             if self._k > 1:
                 pass_at_k_total += self._pass_at_k(n_samples, correct_num, self._k)
 
-        pass_at_1 = pass_at_1_total * 100 / total
-        metrics = {"score": pass_at_1, "fails": len(fails), "pass@1": pass_at_1}
+        if short:
+            logger.warning(
+                "{}/{} sample(s) returned fewer than k={} choices, contributing 0 "
+                "to pass@{}: the model produced fewer choices than the requested "
+                "n={}.",
+                short,
+                len(finals),
+                self._k,
+                self._k,
+                self._n,
+            )
+
+        return self._metrics(
+            pass_at_1_total * 100 / total,
+            pass_at_k_total * 100 / total,
+            len(fails),
+        )
+
+    def _metrics(
+        self, pass_at_1: float, pass_at_k: float, fails: int
+    ) -> dict[str, float]:
+        # Single source of truth for the report key set — the empty-run branch and
+        # the populated branch must not drift apart.
+        metrics = {"score": pass_at_1, "fails": fails, "pass@1": pass_at_1}
         if self._k > 1:
-            metrics[f"pass@{self._k}"] = pass_at_k_total * 100 / total
+            metrics[f"pass@{self._k}"] = pass_at_k
         return metrics
 
     def _pass_at_k(self, n: int, c: int, k: int) -> float:
         if n < k:
+            # Unreachable by configuration: __init__ rejects k > n. Only a model
+            # that returned fewer choices than requested reaches this, and report()
+            # warns about it so the 0 contribution is visible rather than silent.
             return 0.0
         if c == 0:
             return 0.0

--- a/sieval/tasks/imo_answer_bench_0shot_gen.py
+++ b/sieval/tasks/imo_answer_bench_0shot_gen.py
@@ -133,9 +133,8 @@ class IMOAnswerBenchZeroShotGenTask(
         if k > n:
             raise ValueError(
                 f"pass@{k} needs at least {k} sample(s) per problem, got n={n}. "
-                "Raise the task arg `n` (tasks.<name>.args.n) to at least k — `n` "
-                "is a task arg, not a model arg: the task forwards it call-time "
-                "and call-time wins over the model's configured args."
+                "Raise the task arg `n` (tasks.<name>.args.n) to at least k — "
+                "setting `n` on the model is silently overridden call-time."
             )
         self._k = k
         self._n = n
@@ -187,8 +186,7 @@ class IMOAnswerBenchZeroShotGenTask(
     async def report(self, finals, fails):
         total = len(finals) + len(fails)
         if total == 0:
-            # Emit the same key set as the populated path below, so a consumer
-            # reading `pass@1` does not KeyError on an empty run.
+            # Same key set as the populated path, so `pass@1` never KeyErrors.
             return self._metrics(0.0, 0.0, len(fails))
 
         pass_at_1_total = 0.0
@@ -206,14 +204,13 @@ class IMOAnswerBenchZeroShotGenTask(
 
         if short:
             logger.warning(
-                "{}/{} sample(s) returned fewer than k={} choices, contributing 0 "
-                "to pass@{}: the model produced fewer choices than the requested "
-                "n={}.",
+                "{}/{} sample(s) returned fewer than k={} choices (model produced "
+                "fewer than the requested n={}) and contribute 0 to pass@{}.",
                 short,
                 len(finals),
                 self._k,
-                self._k,
                 self._n,
+                self._k,
             )
 
         return self._metrics(
@@ -225,8 +222,7 @@ class IMOAnswerBenchZeroShotGenTask(
     def _metrics(
         self, pass_at_1: float, pass_at_k: float, fails: int
     ) -> dict[str, float]:
-        # Single source of truth for the report key set — the empty-run branch and
-        # the populated branch must not drift apart.
+        # Single source of truth for the report key set — both branches route here.
         metrics = {"score": pass_at_1, "fails": fails, "pass@1": pass_at_1}
         if self._k > 1:
             metrics[f"pass@{self._k}"] = pass_at_k
@@ -234,9 +230,8 @@ class IMOAnswerBenchZeroShotGenTask(
 
     def _pass_at_k(self, n: int, c: int, k: int) -> float:
         if n < k:
-            # Unreachable by configuration: __init__ rejects k > n. Only a model
-            # that returned fewer choices than requested reaches this, and report()
-            # warns about it so the 0 contribution is visible rather than silent.
+            # Unreachable by config (__init__ rejects k > n); only a model that
+            # returned fewer choices than requested lands here, and report() warns.
             return 0.0
         if c == 0:
             return 0.0

--- a/sieval/tasks/math_500_0shot_gen.py
+++ b/sieval/tasks/math_500_0shot_gen.py
@@ -33,7 +33,17 @@ class Feedback(TypedDict):
     reference_impl=ReferenceImpl(
         source="simple-evals",
         url="https://github.com/openai/simple-evals/blob/ee3b0318d8d1d9d72755a4120879be65f7c07e9e/math_eval.py",
-        notes="Math postprocess aligned with simple-evals.",
+        notes=(
+            "Math postprocess aligned with simple-evals. REPEATS: simple-evals' "
+            "MathEval defaults to n_repeats=16 and its CLI `math` entry passes 10, "
+            "while this task defaults to n=1 — set n=10 (or 16) to match. pass@1 "
+            "over n samples equals simple-evals' mean over n repeated examples, so "
+            "the two are directly comparable. `n` is a task arg "
+            "(tasks.<name>.args.n), NOT a model arg: the task forwards it call-time "
+            "and call-time wins, so setting `n` on the model is silently overridden. "
+            "k>n is rejected at construction. Scope: those upstream defaults belong "
+            "to the full math_test split; MATH-500 is simple-evals' math_500_test."
+        ),
     ),
 )
 class MATH500ZeroShotGenTask(

--- a/sieval/tasks/math_500_0shot_gen.py
+++ b/sieval/tasks/math_500_0shot_gen.py
@@ -48,6 +48,13 @@ class MATH500ZeroShotGenTask(
 ):
     def __init__(self, dataset, model, name: str | None = None, k: int = 1, n: int = 1):
         super().__init__(dataset=dataset, model=model, name=name)
+        if k > n:
+            raise ValueError(
+                f"pass@{k} needs at least {k} sample(s) per problem, got n={n}. "
+                "Raise the task arg `n` (tasks.<name>.args.n) to at least k — `n` "
+                "is a task arg, not a model arg: the task forwards it call-time "
+                "and call-time wins over the model's configured args."
+            )
         self._k = k
         self._n = n
 
@@ -96,26 +103,56 @@ class MATH500ZeroShotGenTask(
     async def report(self, finals, fails):
         total = len(finals) + len(fails)
         if total == 0:
-            return {"score": 0.0, "fails": len(fails)}
+            # Emit the same key set as the populated path below, so a consumer
+            # reading `pass@1` does not KeyError on an empty run.
+            return self._metrics(0.0, 0.0, len(fails))
 
         pass_at_1_total = 0.0
         pass_at_k_total = 0.0
+        short = 0
         for f in finals:
             feedbacks = f.feedback_result
             n_samples = len(feedbacks)
-            correct_num = sum(1 for f in feedbacks if f["correct"])
+            if n_samples < self._k:
+                short += 1
+            correct_num = sum(1 for fb in feedbacks if fb["correct"])
             pass_at_1_total += self._pass_at_k(n_samples, correct_num, 1)
             if self._k > 1:
                 pass_at_k_total += self._pass_at_k(n_samples, correct_num, self._k)
 
-        pass_at_1 = pass_at_1_total * 100 / total
-        metrics = {"score": pass_at_1, "fails": len(fails), "pass@1": pass_at_1}
+        if short:
+            logger.warning(
+                "{}/{} sample(s) returned fewer than k={} choices, contributing 0 "
+                "to pass@{}: the model produced fewer choices than the requested "
+                "n={}.",
+                short,
+                len(finals),
+                self._k,
+                self._k,
+                self._n,
+            )
+
+        return self._metrics(
+            pass_at_1_total * 100 / total,
+            pass_at_k_total * 100 / total,
+            len(fails),
+        )
+
+    def _metrics(
+        self, pass_at_1: float, pass_at_k: float, fails: int
+    ) -> dict[str, float]:
+        # Single source of truth for the report key set — the empty-run branch and
+        # the populated branch must not drift apart.
+        metrics = {"score": pass_at_1, "fails": fails, "pass@1": pass_at_1}
         if self._k > 1:
-            metrics[f"pass@{self._k}"] = pass_at_k_total * 100 / total
+            metrics[f"pass@{self._k}"] = pass_at_k
         return metrics
 
     def _pass_at_k(self, n: int, c: int, k: int) -> float:
         if n < k:
+            # Unreachable by configuration: __init__ rejects k > n. Only a model
+            # that returned fewer choices than requested reaches this, and report()
+            # warns about it so the 0 contribution is visible rather than silent.
             return 0.0
         if c == 0:
             return 0.0

--- a/sieval/tasks/math_500_0shot_gen.py
+++ b/sieval/tasks/math_500_0shot_gen.py
@@ -35,14 +35,12 @@ class Feedback(TypedDict):
         url="https://github.com/openai/simple-evals/blob/ee3b0318d8d1d9d72755a4120879be65f7c07e9e/math_eval.py",
         notes=(
             "Math postprocess aligned with simple-evals. REPEATS: simple-evals' "
-            "MathEval defaults to n_repeats=16 and its CLI `math` entry passes 10, "
-            "while this task defaults to n=1 — set n=10 (or 16) to match. pass@1 "
-            "over n samples equals simple-evals' mean over n repeated examples, so "
-            "the two are directly comparable. `n` is a task arg "
-            "(tasks.<name>.args.n), NOT a model arg: the task forwards it call-time "
-            "and call-time wins, so setting `n` on the model is silently overridden. "
-            "k>n is rejected at construction. Scope: those upstream defaults belong "
-            "to the full math_test split; MATH-500 is simple-evals' math_500_test."
+            "MathEval defaults to n_repeats=16, its CLI `math` entry passes 10, "
+            "while this task defaults to n=1 — set n=10 (or 16) to match, as a task "
+            "arg (tasks.<name>.args.n); the model's `n` is silently overridden "
+            "call-time. pass@1 over n samples equals its mean over n repeats. k>n "
+            "is rejected at construction. Scope: those upstream defaults are for the "
+            "full math_test split; MATH-500 is simple-evals' math_500_test."
         ),
     ),
 )
@@ -61,9 +59,8 @@ class MATH500ZeroShotGenTask(
         if k > n:
             raise ValueError(
                 f"pass@{k} needs at least {k} sample(s) per problem, got n={n}. "
-                "Raise the task arg `n` (tasks.<name>.args.n) to at least k — `n` "
-                "is a task arg, not a model arg: the task forwards it call-time "
-                "and call-time wins over the model's configured args."
+                "Raise the task arg `n` (tasks.<name>.args.n) to at least k — "
+                "setting `n` on the model is silently overridden call-time."
             )
         self._k = k
         self._n = n
@@ -113,8 +110,7 @@ class MATH500ZeroShotGenTask(
     async def report(self, finals, fails):
         total = len(finals) + len(fails)
         if total == 0:
-            # Emit the same key set as the populated path below, so a consumer
-            # reading `pass@1` does not KeyError on an empty run.
+            # Same key set as the populated path, so `pass@1` never KeyErrors.
             return self._metrics(0.0, 0.0, len(fails))
 
         pass_at_1_total = 0.0
@@ -132,14 +128,13 @@ class MATH500ZeroShotGenTask(
 
         if short:
             logger.warning(
-                "{}/{} sample(s) returned fewer than k={} choices, contributing 0 "
-                "to pass@{}: the model produced fewer choices than the requested "
-                "n={}.",
+                "{}/{} sample(s) returned fewer than k={} choices (model produced "
+                "fewer than the requested n={}) and contribute 0 to pass@{}.",
                 short,
                 len(finals),
                 self._k,
-                self._k,
                 self._n,
+                self._k,
             )
 
         return self._metrics(
@@ -151,8 +146,7 @@ class MATH500ZeroShotGenTask(
     def _metrics(
         self, pass_at_1: float, pass_at_k: float, fails: int
     ) -> dict[str, float]:
-        # Single source of truth for the report key set — the empty-run branch and
-        # the populated branch must not drift apart.
+        # Single source of truth for the report key set — both branches route here.
         metrics = {"score": pass_at_1, "fails": fails, "pass@1": pass_at_1}
         if self._k > 1:
             metrics[f"pass@{self._k}"] = pass_at_k
@@ -160,9 +154,8 @@ class MATH500ZeroShotGenTask(
 
     def _pass_at_k(self, n: int, c: int, k: int) -> float:
         if n < k:
-            # Unreachable by configuration: __init__ rejects k > n. Only a model
-            # that returned fewer choices than requested reaches this, and report()
-            # warns about it so the 0 contribution is visible rather than silent.
+            # Unreachable by config (__init__ rejects k > n); only a model that
+            # returned fewer choices than requested lands here, and report() warns.
             return 0.0
         if c == 0:
             return 0.0

--- a/tests/unit/datasets/test_imo_answer_bench.py
+++ b/tests/unit/datasets/test_imo_answer_bench.py
@@ -53,10 +53,11 @@ def test_load_reads_v2_csv_and_renames_columns():
     assert data_files["train"].endswith("/imo_answer_bench/answerbench_v2.csv")
     assert data_files["test"].endswith("/imo_answer_bench/answerbench_v2.csv")
 
-    # renamed to the shared math schema; both splits present, no leftover columns
+    # upstream `Problem` / `Short Answer` lower-cased into addressable keys; both
+    # splits present, no leftover originals
     for split in ("train", "test"):
         cols = loaded[split].column_names
-        assert "question" in cols and "answer" in cols
+        assert "problem" in cols and "answer" in cols
         assert "Problem" not in cols and "Short Answer" not in cols
     assert loaded["test"][0]["answer"] == "1431655764"
 

--- a/tests/unit/tasks/test_hmmt_nov_2025_0shot_gen.py
+++ b/tests/unit/tasks/test_hmmt_nov_2025_0shot_gen.py
@@ -1,0 +1,25 @@
+"""Import-discipline test for the HMMT Nov 2025 task.
+
+AI-Generated Code - Claude Opus 4.8 (Anthropic)
+"""
+
+import subprocess
+import sys
+
+
+def test_import_does_not_pull_math_verify():
+    code = (
+        "import sys\n"
+        "import sieval.tasks.hmmt_nov_2025_0shot_gen\n"
+        "assert 'math_verify' not in sys.modules, "
+        "'math_verify must be lazy-imported'\n"
+    )
+    # Run in a fresh interpreter so pytest's already-loaded modules don't mask the
+    # check.
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr

--- a/tests/unit/tasks/test_math_pass_at_k_family.py
+++ b/tests/unit/tasks/test_math_pass_at_k_family.py
@@ -1,0 +1,122 @@
+"""Shared contract for the pass@k math tasks.
+
+These eight task modules are clones of one another in ``__init__``, ``report``
+and ``_pass_at_k``. Asserting the contract once, over all of them, is what stops
+a fix landing in one file and silently drifting in the other seven — the failure
+mode that produced the ``k > n`` and report-key-set bugs in the first place.
+
+AI-Generated Code - Claude Opus 5 (1M context) (Anthropic)
+"""
+
+import pytest
+from datasets import Dataset as HFDataset
+from datasets import DatasetDict as HFDatasetDict
+
+from sieval.core.models import ChatModel, ModelOutput
+from sieval.core.tasks import TaskContext
+from sieval.datasets.aime_2024 import AIME2024Dataset
+from sieval.datasets.aime_2025 import AIME2025Dataset
+from sieval.datasets.aime_2026 import AIME2026Dataset
+from sieval.datasets.hmmt_feb_2025 import HMMTFeb2025Dataset
+from sieval.datasets.hmmt_feb_2026 import HMMTFeb2026Dataset
+from sieval.datasets.hmmt_nov_2025 import HMMTNov2025Dataset
+from sieval.datasets.imo_answer_bench import IMOAnswerBenchDataset
+from sieval.datasets.math_500 import MATH500Dataset
+from sieval.tasks.aime_2024_0shot_gen import AIME2024ZeroShotGenTask
+from sieval.tasks.aime_2025_0shot_gen import AIME2025ZeroShotGenTask
+from sieval.tasks.aime_2026_0shot_gen import AIME2026ZeroShotGenTask
+from sieval.tasks.hmmt_feb_2025_0shot_gen import HMMTFeb2025ZeroShotGenTask
+from sieval.tasks.hmmt_feb_2026_0shot_gen import HMMTFeb2026ZeroShotGenTask
+from sieval.tasks.hmmt_nov_2025_0shot_gen import HMMTNov2025ZeroShotGenTask
+from sieval.tasks.imo_answer_bench_0shot_gen import IMOAnswerBenchZeroShotGenTask
+from sieval.tasks.math_500_0shot_gen import MATH500ZeroShotGenTask
+
+PROBLEM = "What is 6 times 7?"
+ANSWER = "42"
+
+# (task_cls, dataset_cls, sample field holding the problem statement).
+# The field is whatever the loader exposes: every MathArena/HF source ships
+# `problem`, so only opencompass/AIME2025 (which ships `question`) differs.
+FAMILY = [
+    (AIME2024ZeroShotGenTask, AIME2024Dataset, "problem"),
+    (AIME2025ZeroShotGenTask, AIME2025Dataset, "question"),
+    (AIME2026ZeroShotGenTask, AIME2026Dataset, "problem"),
+    (HMMTFeb2025ZeroShotGenTask, HMMTFeb2025Dataset, "problem"),
+    (HMMTFeb2026ZeroShotGenTask, HMMTFeb2026Dataset, "problem"),
+    (HMMTNov2025ZeroShotGenTask, HMMTNov2025Dataset, "problem"),
+    (MATH500ZeroShotGenTask, MATH500Dataset, "problem"),
+    (IMOAnswerBenchZeroShotGenTask, IMOAnswerBenchDataset, "problem"),
+]
+IDS = [t.__name__ for t, _, _ in FAMILY]
+
+
+class _StubChatModel(ChatModel):
+    def __init__(self):
+        super().__init__(model="mock-chat", api_key="fake")
+
+    async def _agenerate_impl(self, prompt, **kwargs) -> ModelOutput:
+        _ = (prompt, kwargs)
+        return ModelOutput(model=self.meta(), texts=[rf"\boxed{{{ANSWER}}}"])
+
+    async def _alogprobs_impl(self, prompt, **kwargs) -> ModelOutput:
+        _ = (prompt, kwargs)
+        return ModelOutput(model=self.meta(), texts=[""])
+
+
+def _sample(field: str) -> dict[str, str]:
+    return {field: PROBLEM, "answer": ANSWER}
+
+
+def _build(task_cls, dataset_cls, field, *, k: int = 1, n: int = 1):
+    rows = HFDataset.from_list([_sample(field)])
+    dataset = dataset_cls(_hf_dict=HFDatasetDict({"train": rows, "test": rows}))
+    return task_cls(dataset, _StubChatModel(), k=k, n=n)
+
+
+@pytest.mark.parametrize(("task_cls", "dataset_cls", "field"), FAMILY, ids=IDS)
+def test_k_greater_than_n_is_rejected(task_cls, dataset_cls, field):
+    # Without the guard this constructs fine and every pass@4 comes out 0.0 —
+    # a confidently wrong headline number rather than an error.
+    with pytest.raises(ValueError, match=r"pass@4"):
+        _build(task_cls, dataset_cls, field, k=4, n=1)
+
+
+@pytest.mark.parametrize(("task_cls", "dataset_cls", "field"), FAMILY, ids=IDS)
+def test_k_equal_to_n_is_accepted(task_cls, dataset_cls, field):
+    # The guard must reject only k > n, not the legitimate k == n.
+    assert _build(task_cls, dataset_cls, field, k=4, n=4) is not None
+
+
+@pytest.mark.parametrize(("task_cls", "dataset_cls", "field"), FAMILY, ids=IDS)
+@pytest.mark.parametrize("k", [1, 4])
+@pytest.mark.anyio
+async def test_report_key_set_is_identical_when_empty(task_cls, dataset_cls, field, k):
+    task = _build(task_cls, dataset_cls, field, k=k, n=k)
+    raw = _sample(field)
+    feedback = [{"correct": True, "answer": ANSWER} for _ in range(k)]
+    populated = await task.report(
+        [TaskContext(sample_id=0, raw_sample=raw, feedback_result=feedback)], []
+    )
+    empty = await task.report([], [])
+
+    # An empty run previously dropped `pass@1`/`pass@k`, so a consumer reading
+    # those keys hit a KeyError only on fully-failed runs.
+    assert set(empty) == set(populated)
+    assert "pass@1" in empty
+    if k > 1:  # for k == 1 the pass@k key *is* pass@1
+        assert f"pass@{k}" in empty
+
+
+@pytest.mark.parametrize(("task_cls", "dataset_cls", "field"), FAMILY, ids=IDS)
+@pytest.mark.anyio
+async def test_preprocess_reads_the_field_its_loader_exposes(
+    task_cls, dataset_cls, field
+):
+    # Guards the loader/task field-name contract: a task still reading the old
+    # `question` key against a `problem` loader would KeyError here.
+    task = _build(task_cls, dataset_cls, field)
+    raw = _sample(field)
+
+    pre = await task.preprocess(raw, TaskContext(sample_id=0, raw_sample=raw))
+
+    assert PROBLEM in str(pre)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Type

- feature — new benchmark, task, or capability

## Summary

- Adds **HMMT November 2025** (30 problems) as a final-answer math benchmark: `hmmt_nov_2025` dataset + `hmmt_nov_2025_0shot_gen` task.
- Aligned to the MathArena reference impl ([eth-sri/matharena @a11194de `configs/competitions/hmmt/hmmt_nov_2025.yaml`](https://github.com/eth-sri/matharena/blob/a11194deff8c67a232974a383795e8a2776b4c6f/configs/competitions/hmmt/hmmt_nov_2025.yaml)): boxed prompt + last-boxed extraction with the non-strict last-integer fallback, reusing the already-vendored `sieval/community/matharena.py`; equivalence judged by `math-verify`.
- Dataset pinned to `hf:MathArena/hmmt_nov_2025@118dbfb4` (CC-BY-NC-SA-4.0, per the HF card).
- **Commits 2–3 fix six pre-existing issues across the whole pass@k math family** (8 tasks / 5 loaders) — two are real bugs, four are fidelity/documentation defects — rather than adding a third byte-identical clone of them. Details below.
- **Commit 4 fixes the repo tooling that let those defects through**: two dead PostToolUse hooks, a `sys.path` trap in two scripts that produced a false preflight FAIL on this very PR, and the rule doc that claimed all of it was automated.
- **Commit 5 trims ~30% of the prose** commits 1–4 added (comments, `reference_impl.notes`, both rule files, `CONTRIBUTING.md`) without dropping a fact. Reviewable as prose-only: no logic changes, and the one non-comment edit is a rewrapped `logger.warning` whose format args were reordered to match.
- Commits are self-contained: commit 1 alone is a complete, mergeable benchmark addition if you would rather split the family work into its own PR, and commits 4–5 touch no `sieval/` logic at all.

### Family fixes (commits 2–3)

1. **`k > n` silently reported `pass@k = 0.0`.** Verified: `_pass_at_k(n=1, c=1, k=4)` returned `0.0` with the single sample *correct* — a confidently wrong headline number, not an error. Now rejected at construction. This is reachable in practice: matharena's runner defaults to `--n 4`, so anyone reproducing reaches for `k=4`, and setting `n` on the **model** is silently overridden (`ChatModel` merges `{**self._kwargs, **kwargs}` and the task forwards `n` call-time, so call-time wins). `reference_impl.notes` now records both facts, matching the convention #44 set.
2. **`report()` dropped `pass@1`/`pass@k` on the `total == 0` branch**, so a consumer reading those keys hit a `KeyError` only on fully-failed runs. Both branches now go through one `_metrics()` helper. Also added: when a sample returns fewer choices than `k` (model shortfall, not misconfiguration), `report()` warns once instead of silently contributing 0.
3. **Sample field names now follow upstream instead of being reshaped.** The four MathArena loaders renamed `problem` → `question` to "match the shared math sample schema" — but no such schema exists: the family was split 5 `question` / 3 `problem`, every task binds 1:1 to its own `TypedDict`, and no polymorphic consumer needs a uniform name. `aime_2025` keeps `question` (its upstream ships `question`). `imo_answer_bench` keeps its rename — upstream ships `Problem` / `Short Answer`, not usable as-is — retargeted to `problem`.
4. **Comments.** `_strip_sample` cited `aime_2024` / `math_500` as precedent, but both additionally strip the *problem* text, so the citation described the opposite of the code. Cross-references replaced with the invariant itself (they rot — that is how this drifted). Gold normalization is now annotated as a deviation from matharena, which does not normalize golds. `community/matharena.py`'s "AIME/HMMT 2026" docstring limits dropped.

5. **Three of the five `cast_column("answer", Value("string"))` calls were no-ops and are deleted.** Measured against the HF datasets-server rather than assumed: `MathArena/aime_2026` ships `answer: int64`, so its cast is load-bearing; `imo_answer_bench` parses a CSV, so its dtype is content-inferred rather than fixed by the pin, also load-bearing. The three HMMT sets all ship `string` on their pinned revisions. Deleted under the same standard that removed the rename in (3): keep it if its stated reason survives checking, drop it if the reason is only uniformity. The replacement comments state why there is *no* cast, so "restoring uniformity" is not the obvious next edit.

6. **`math_500` had no repeat-count record**, so its `n=1` default silently diverged from simple-evals (`MathEval` defaults to `n_repeats=16`; the CLI `math` entry passes `10`). Its `reference_impl.notes` now records this, plus the scope caveat that those upstream defaults apply to the full `math_test` split while MATH-500 is simple-evals' `math_500_test`. `aime_2024` / `aime_2025` deliberately get no such note: simple-evals has **no** AIME eval at the cited SHA, so their citation is correctly scoped to postprocess + `ANSWER_PATTERN` extraction, which is what their notes already say.

### Tooling + rules (commit 4)

Nothing under `sieval/` changes here. Reviewing the family fixes surfaced that the guardrails meant to catch them were not running.

7. **Both sync PostToolUse hooks in `.claude/settings.json` were dead.** They gated on `^sieval/(tasks|datasets)/`, but Claude Code supplies an **absolute** `file_path`, so the `^` anchor could never match — stub sync and meta-index sync had silently never fired. Reviving the anchor alone would have converted an inert bug into an active one: the commands invoked `scripts/sync_*.py` relative to the *session* cwd, so an edit inside a git worktree would have regenerated the **primary** checkout's registry and stubs. Fixed together — the owning checkout is resolved with `git -C "$(dirname "$f")" rev-parse --show-toplevel`. The ruff/ty hooks are deliberately left alone: they gate on `\.pyi?$` with no path anchor, which is correct, since anchoring them to `sieval/` would drop `tests/` and `scripts/` coverage.
8. **`sys.path` trap in `scripts/sync_meta_index.py` and `scripts/check_preflight.py`.** `python scripts/foo.py` puts `scripts/` on `sys.path[0]` and never adds the repo root, so `import sieval` resolved through the shared editable install — from a worktree that is a *different checkout*, and `sync_meta_index.py` would write the other branch's registry here. Not hypothetical: it produced a false preflight FAIL while preparing this PR. Both scripts now insert their own `ROOT` first. (`sync_package_stubs.py` needs no fix — it parses with `ast` and never imports `sieval`.)
9. **`.claude/rules/tasks.md` claimed all four hooks were automated with "no need to run manually."** Untrue while two were dead, and still overstated once fixed: the hooks only fire on Write/Edit inside a Claude Code session, not for `sed -i`, `git apply`, or a rebase. Rewritten as convenience-not-guarantee, with the instruction to `--check` both sync scripts before committing and the **asymmetry recorded**: preflight's `check_meta_index_sync` fails CI on index drift, while stub drift has *no* automated enforcer anywhere (verified: no pre-commit or CI reference to either sync script).
10. **Two rules generalized from this PR's defects**, so the next contributor does not rediscover them: a sampling-protocol checklist item in `.claude/rules/tasks.md` (record the upstream repeat count in `reference_impl.notes` when it differs from the task's default `n` — from items 1 and 6), and a new §"Upstream Sample Shape" in `.claude/rules/datasets.md` (keep upstream field names; cast a dtype only when the pinned revision requires it, measured rather than copied from a sibling — from items 3 and 5). Both note that nothing enforces them and why. `CONTRIBUTING.md` mirrors the user-facing halves, as `.claude/rules/engineering-infra.md` requires.

## Related Issues

None.

## Test Plan

### Automated

- [x] Lint/format clean — `ruff check sieval tests scripts` + `ruff format --check` → **All checks passed!**, 346 files formatted
- [x] Type check clean — `ty check sieval` → *All checks passed!*
- [x] Unit tests pass — full `pytest tests/unit` → **2559 passed**
- [x] Preflight clean — `scripts/check_preflight.py --level quick`: all `[PASS]`, incl. `check_meta_index_sync`, `check_datasets` (all sources pinned), `check_tasks` (38 tasks), `check_imports`
- [x] Layer boundaries — `scripts/check_layer_imports.py` clean

New test `tests/unit/tasks/test_math_pass_at_k_family.py` is one parametrized contract over all eight tasks, not eight copies — the point is that a fix landing in one file cannot drift from the rest. **Mutation-checked**: removing the `k > n` guard, reverting the empty-branch key set, or reverting the field rename each makes it fail.

`tests/unit/datasets/test_imo_answer_bench.py` was updated because the rename target changed by design (`question` → `problem`), not because the original expectation was wrong.

### Manual

- [x] `sieval dataset download hmmt_nov_2025` resolves against the pinned revision (4 files fetched).
- [x] Pinned revision verified live: `118dbfb4` is the dataset's current `main`; fields `problem_idx: int64 / answer: string / problem: string`; 30 rows, matching upstream `n_problems: 30`; HF card license `cc-by-nc-sa-4.0` matches the declared value.
- [x] Upstream config cross-checked at the pinned SHA: `instruction` byte-identical to `HMMT_INSTRUCTION`, `strict_parsing: false` matches the `strict_parsing=False` call site, `dataset_path` matches the registered source.
- [x] **Grading path re-verified end-to-end on all 30 golds after the loader change**: feeding `\boxed{<raw gold>}` through `strip_string` → `extract_answer` → `math_verify.verify` gives **30/30 self-consistent, 0 failures**. `strip_string` touches exactly 3 of 30 golds, all fraction rewrites (`1/91` → `\frac{1}{91}`, `91/6`, `199/8`) that `math-verify` already treats as equivalent — hence the deviation is score-neutral on this snapshot.
- [x] Loader + task re-verified together after removing `rename_column`: columns are `problem_idx / answer / problem`, and the rendered prompt is `Put your final answer within \boxed{}.\n\n<problem>`.
- [x] **Cast deletion verified against the real pinned data, not just the dtype metadata**: all three HMMT loaders run through their modified `load()` give `answer=Value('string')` with every value an actual `str`, columns unchanged, 30 / 30 / 33 rows respectively.
- [x] **Hook fix verified by firing the real command string, not by reading the regex.** Extracted both commands from `settings.json` and gated five path shapes: worktree-absolute → worktree root, primary-absolute → primary root, relative → the cwd's root, `sieval/core/...` → no fire, `/tmp/scratch.py` → no fire. All five correct. Then a real fire of the meta hook, run *from the primary checkout* against a worktree file, printed `Wrote 32 dataset and 38 task entries` (38 = the **worktree's** task count) into the worktree's index, exit 0, primary checkout untouched — so the anchor fix, the repo-root fix, and the `sys.path` fix compose.
- [x] Both sync scripts `--check` clean after the doc commit (`sync_meta_index.py --check`, `sync_package_stubs.py --check`), and `settings.json` re-validated as parseable JSON.

### Alignment with official MathArena — verified

Measured outside this environment (no model credentials here), then recorded in `reference_impl.notes` so the artifact carries it. This separates **grading** from **sampling**, which a plain expected-vs-actual table cannot:

| Check | Result |
| --- | --- |
| Replay MathArena's published outputs through this task's grading path (2640 outputs = 22 models × 30 problems × 4 runs) | **99.51%** per-output agreement with the upstream grader; **16/22** model scores reproduced exactly |
| Gemini 3 Flash on the official outputs — published number vs upstream grader vs sieval grader | **93.33% three ways** |
| Live sieval run, `gemini-3-flash-preview`, `n=4` | **95.00%** vs published **93.33%** |

The live-run gap is **sampling variance, not implementation divergence**: both graders agree on **120/120** of sieval's own outputs, so the grading path is identical and only the sampled generations differ.

Note the internal run predates commits 2–3, which changed the sample field (`question` → `problem`) — the post-change re-verification covering that is the rendered-prompt and 30/30 gold round-trip checks under Manual below.

## Checklist

### Required (all PRs)

- [x] PR title follows conventional format (`type(scope): description`)
- [x] No internal paths, credentials, or personal info in committed files (the `#8` in the revision-pin comment is this repo's public PR #8, matching the sibling loaders)
- [x] AI-generated code has `AI-Generated Code - <model> (<provider>)` in module docstring
- [x] No new upper-layer dependencies added to `core/`
- [x] Deleted code verified — the removed `rename_column` calls had no other consumers: persisted contexts carry stage results, not `raw_sample`, and no YAML references sample field names (both checked), so the blast radius is each loader plus its own 1:1 task. The removed `cast_column` calls change nothing observable: the three affected loaders still emit `answer=Value('string')` against their pinned data (verified by loading them), and no test asserted the cast

### If: New or Modified Benchmark

- [x] Reference paper/repo linked in Summary
- [x] Score comparison table included — see "Alignment with official MathArena" above: 99.51% grader agreement over MathArena's 2640 published outputs, 16/22 model scores reproduced exactly, and a live `gemini-3-flash-preview` run whose 95.00% vs 93.33% gap is proven to be sampling variance (120/120 dual-grader agreement). Recorded in `reference_impl.notes`, not just here
- [x] Dataset loading tested (`sieval dataset download hmmt_nov_2025` succeeds)
- [x] Task registered in package-level `__init__.pyi` (regenerated via `scripts/sync_package_stubs.py`, not hand-edited; `meta/index.json` regenerated via `scripts/sync_meta_index.py`)

### If: community/ Changes

- [x] Upstream diff documented — `community/matharena.py` changes are docstring-only (dropped the stale "2026" scoping now that HMMT Nov 2025 and Feb 2025 are also consumers). The vendored extractor's existing "deliberate adaptations" block is unchanged.
- [x] License attribution preserved — MIT attribution on the vendored matharena slice untouched.

### If: Breaking Change

- [x] Described what breaks and migration path in Summary — the sample field rename (`question` → `problem`) is internal to each loader/task pair. Nothing on disk or in config changes: persisted contexts carry stage results rather than `raw_sample`, and no YAML references sample field names. A `k > n` task config that previously produced a silent `pass@k = 0.0` now fails at construction with a message naming the fix; `examples/leaderboard-math-sft.yaml` uses `k: 1, n: 32` and is unaffected.
- [x] Existing tests updated to reflect new behavior

### If: New Dependency

No new dependencies — `math-verify` and the `math` deps group already exist for the sibling HMMT/AIME tasks. Verified the declared `deps_group="math"` covers the transitive lazy `import regex` in `community/matharena.py` (`regex>=2024.0.0` is in the group).

🤖 Generated with [Claude Code](https://claude.com/claude-code)