### PR TITLE
fix(tests): move registries and module cache as a unit, behind one shared helper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,9 @@ jobs:
 
   typecheck:
     needs: changes
-    if: needs.changes.outputs.code == 'true'
+    # `[tool.ty.environment] root = ["./"]` — ty checks tests/ too, so a
+    # test-only change can break it. Keep the trigger as wide as the tool.
+    if: needs.changes.outputs.code == 'true' || needs.changes.outputs.tests == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/tests/README.md
+++ b/tests/README.md
@@ -172,6 +172,28 @@ All shared test infrastructure lives here — available to every test layer with
 | `make_perf_config(tmp_path, **overrides)` | `TaskRunnerConfig` for performance tests |
 | `write_completed_samples(root, n_completed)` | Write FINAL contexts to disk for resume tests |
 
+### Registry isolation
+
+| Class | Description |
+| --- | --- |
+| `ModuleIsolation(scope, lazy_packages=(), exclude=())` | Snapshot/restore a `sys.modules` subtree — pair it with any fixture that clears a task/dataset registry |
+
+`import_all_tasks()` and `get_task_class()` only re-run a module's `@sieval_task` decorator while
+`sieval.tasks.{name}` is absent from `sys.modules`, so **a registry and its module cache must be
+cleared and restored as a unit**. Clearing one half alone breaks a test in one direction or the
+other — a cleared registry with cached modules leaves names unregistered (`KeyError`), while a
+restored registry with purged modules trips the duplicate-name guard on the next import.
+
+`ModuleIsolation` owns the part that is easy to get wrong: `sys.modules` is not the only view, so
+`restore()` also rebinds parent-package attributes and unbinds copies the test imported on top —
+otherwise `monkeypatch.setattr("sieval.datasets.x.load_dataset", ...)`, which resolves by attribute
+traversal from the root, silently patches a module nobody uses. Registry `clear()`/`update()` stays
+in each fixture, since the relevant registry subset differs per site.
+
+Used by the autouse fixtures in `tests/unit/core/tasks/test_meta.py`,
+`tests/unit/core/datasets/test_meta.py`, `tests/unit/test_lazy_exports.py`,
+`tests/unit/tasks/test_theoremqa_kshot_base_gen.py`, and `tests/unit/cli/conftest.py`.
+
 ---
 
 ## Writing Tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -185,14 +185,18 @@ other — a cleared registry with cached modules leaves names unregistered (`Key
 restored registry with purged modules trips the duplicate-name guard on the next import.
 
 `ModuleIsolation` owns the part that is easy to get wrong: `sys.modules` is not the only view, so
-`restore()` also rebinds parent-package attributes and unbinds copies the test imported on top —
-otherwise `monkeypatch.setattr("sieval.datasets.x.load_dataset", ...)`, which resolves by attribute
-traversal from the root, silently patches a module nobody uses. Registry `clear()`/`update()` stays
-in each fixture, since the relevant registry subset differs per site.
+both directions keep parent-package attributes in step — `evict()` unbinds the modules it drops and
+`restore()` rebinds the snapshot then unbinds copies the test imported on top. Skip either side and
+`monkeypatch.setattr("sieval.datasets.x.load_dataset", ...)`, which resolves by attribute traversal
+from the root, silently patches a module nobody uses; `from sieval.tasks import x` hands back the
+dropped copy for the same reason. Pass `lazy_packages` whenever a package's lazy `__getattr__` cache
+can outlive the module copy it resolved from. Registry `clear()`/`update()` stays in each fixture,
+since the relevant registry subset differs per site.
 
 Used by the autouse fixtures in `tests/unit/core/tasks/test_meta.py`,
 `tests/unit/core/datasets/test_meta.py`, `tests/unit/test_lazy_exports.py`,
 `tests/unit/tasks/test_theoremqa_kshot_base_gen.py`, and `tests/unit/cli/conftest.py`.
+Its own contract is pinned by `tests/unit/test_module_isolation.py`.
 
 ---
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,9 +19,11 @@ import random
 import sys
 import threading
 import time
+from collections.abc import Iterator
 from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
+from types import ModuleType
 from typing import Any
 
 import anyio
@@ -39,6 +41,138 @@ from sieval.core.runners.runner import TaskRunnerConfig
 from sieval.core.tasks.context import TaskContext, TaskStage
 from sieval.core.tasks.saver import TaskSaver
 from sieval.core.tasks.task import Task
+
+
+# ===================================================================
+# Registry / module-cache isolation
+# ===================================================================
+class ModuleIsolation:
+    """Snapshot a ``sys.modules`` subtree and put it back exactly as found.
+
+    Pair this with any fixture that clears ``TASK_REGISTRY`` / ``_TASK_CLASSES`` /
+    ``DATASET_REGISTRY`` / ``SAMPLE_TO_DATASET``. ``import_all_tasks()`` and
+    ``get_task_class()`` only re-run a module's ``@sieval_task`` decorator while
+    ``sieval.tasks.{name}`` is absent from ``sys.modules``, so a registry and its
+    module cache have to move as a unit — clearing one half alone breaks a test in
+    one direction or the other:
+
+    * cleared registry + cached modules — registration silently no-ops, so the
+      name stays unregistered and ``get_task_class()`` raises ``KeyError``.
+    * restored registry + purged modules — the next ``import_all_tasks()`` re-runs
+      the decorators against an already-populated registry and trips the
+      duplicate-name guard.
+
+    ``sys.modules`` is not the only view. Parent packages keep their own attribute
+    bindings, and a dotted-string target (``monkeypatch.setattr("pkg.mod.attr")``,
+    ``mock.patch("pkg.mod.attr")``) is resolved by attribute traversal from the
+    root package, never through the cache — so a child attribute left pointing at
+    a discarded copy patches a module nobody uses. ``restore()`` therefore rebinds
+    parents for the snapshotted modules *and* unbinds whatever the test imported
+    on top of them.
+
+    ``scope`` and ``exclude`` entries ending in ``"."`` match by prefix; the rest
+    match exactly. ``exclude`` wins::
+
+        ModuleIsolation(("sieval.tasks.",))  # submodules only
+        ModuleIsolation(("sieval.tasks", "sieval.tasks."))  # package included
+        ModuleIsolation(("sieval.datasets.theoremqa",))  # that one module
+
+    Exclude a subtree when something *outside* the scope holds a reference into
+    it that a restore cannot repair — see the downloader note in
+    ``tests/unit/cli/conftest.py``.
+
+    ``lazy_packages`` names packages whose lazy ``__getattr__`` resolves an export
+    once and then caches it in the package's own ``__dict__`` (``sieval.tasks``,
+    ``sieval.datasets``). Those caches move with the modules for the same reason
+    the parent attributes do: a class cached from a copy this fixture later
+    discards no longer matches its own ``SAMPLE_TO_DATASET`` key, and the next
+    ``@sieval_task`` FK lookup fails with "No @sieval_dataset found for sample
+    type". The package's ``__all__`` is the authoritative name list.
+    """
+
+    def __init__(
+        self,
+        scope: tuple[str, ...],
+        lazy_packages: tuple[str, ...] = (),
+        exclude: tuple[str, ...] = (),
+    ) -> None:
+        self._scope = scope
+        self._lazy_packages = lazy_packages
+        self._exclude = exclude
+        self._modules: dict[str, ModuleType] = {}
+        self._exports: dict[tuple[str, str], object] = {}
+
+    @staticmethod
+    def _matches(name: str, patterns: tuple[str, ...]) -> bool:
+        return any(
+            name.startswith(pattern) if pattern.endswith(".") else name == pattern
+            for pattern in patterns
+        )
+
+    def _in_scope(self, name: str) -> bool:
+        return self._matches(name, self._scope) and not self._matches(
+            name, self._exclude
+        )
+
+    def _iter_lazy_caches(self) -> Iterator[tuple[ModuleType, str]]:
+        """Yield ``(package, export_name)`` for every declared lazy export in play."""
+        for pkg_name in self._lazy_packages:
+            pkg = sys.modules.get(pkg_name)
+            if pkg is None:
+                continue
+            for export in getattr(pkg, "__all__", ()):
+                yield pkg, export
+
+    def snapshot(self) -> None:
+        """Record the module objects and cached lazy exports currently in scope."""
+        self._modules = {
+            name: module for name, module in sys.modules.items() if self._in_scope(name)
+        }
+        self._exports = {
+            (pkg.__name__, export): pkg.__dict__[export]
+            for pkg, export in self._iter_lazy_caches()
+            if export in pkg.__dict__
+        }
+
+    def evict(self) -> None:
+        """Drop the snapshotted modules and lazy exports from the live caches."""
+        # Caches first: a package that is itself in scope takes its ``__dict__``
+        # with it, and then there is nothing left to pop from.
+        self._drop_lazy_caches()
+        for name in self._modules:
+            del sys.modules[name]
+
+    def _drop_lazy_caches(self) -> None:
+        for pkg, export in list(self._iter_lazy_caches()):
+            pkg.__dict__.pop(export, None)
+
+    def restore(self) -> None:
+        """Purge whatever is live in scope, then reinstate the snapshot."""
+        live = {
+            name: module for name, module in sys.modules.items() if self._in_scope(name)
+        }
+        for name in live:
+            del sys.modules[name]
+        sys.modules.update(self._modules)
+        for name, module in self._modules.items():
+            parent_name, _, attr = name.rpartition(".")
+            if (parent := sys.modules.get(parent_name)) is not None:
+                setattr(parent, attr, module)
+        # Unbind the copies the test imported on top of the snapshot. Identity
+        # is checked so this can never clobber an unrelated same-named attribute.
+        for name, module in live.items():
+            if name in self._modules:
+                continue
+            parent_name, _, attr = name.rpartition(".")
+            parent = sys.modules.get(parent_name)
+            if parent is not None and parent.__dict__.get(attr) is module:
+                del parent.__dict__[attr]
+        # Same purge-then-reinstate as the modules: an export the test resolved
+        # on its own would otherwise outlive the copy it came from.
+        self._drop_lazy_caches()
+        for (pkg_name, export), value in self._exports.items():
+            if (pkg := sys.modules.get(pkg_name)) is not None:
+                pkg.__dict__[export] = value
 
 
 # ===================================================================

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,9 +66,16 @@ class ModuleIsolation:
     bindings, and a dotted-string target (``monkeypatch.setattr("pkg.mod.attr")``,
     ``mock.patch("pkg.mod.attr")``) is resolved by attribute traversal from the
     root package, never through the cache — so a child attribute left pointing at
-    a discarded copy patches a module nobody uses. ``restore()`` therefore rebinds
-    parents for the snapshotted modules *and* unbinds whatever the test imported
-    on top of them.
+    a discarded copy patches a module nobody uses. Both directions therefore keep
+    the parent bindings in step: ``evict()`` unbinds the modules it drops, and
+    ``restore()`` rebinds parents for the snapshotted modules *and* unbinds
+    whatever the test imported on top of them.
+
+    A dropped module left bound on its parent is not a cosmetic leak — it is the
+    same failure this class exists to prevent, one scope earlier. ``from pkg
+    import submodule`` resolves through ``hasattr`` before it considers an import,
+    so the stale attribute wins, the module body never re-executes, and the
+    decorator never re-runs against the registry the fixture just cleared.
 
     ``scope`` and ``exclude`` entries ending in ``"."`` match by prefix; the rest
     match exactly. ``exclude`` wins::
@@ -134,13 +141,26 @@ class ModuleIsolation:
             if export in pkg.__dict__
         }
 
+    @staticmethod
+    def _unbind_from_parent(name: str, module: ModuleType) -> None:
+        """Drop *name*'s attribute on its parent package, if it still points here.
+
+        Identity is checked so this can never clobber an unrelated same-named
+        attribute; a parent that is itself gone needs no repair and is skipped.
+        """
+        parent_name, _, attr = name.rpartition(".")
+        parent = sys.modules.get(parent_name)
+        if parent is not None and parent.__dict__.get(attr) is module:
+            del parent.__dict__[attr]
+
     def evict(self) -> None:
-        """Drop the snapshotted modules and lazy exports from the live caches."""
+        """Drop the snapshotted modules, their parent bindings, and lazy exports."""
         # Caches first: a package that is itself in scope takes its ``__dict__``
         # with it, and then there is nothing left to pop from.
         self._drop_lazy_caches()
-        for name in self._modules:
+        for name, module in self._modules.items():
             del sys.modules[name]
+            self._unbind_from_parent(name, module)
 
     def _drop_lazy_caches(self) -> None:
         for pkg, export in list(self._iter_lazy_caches()):
@@ -158,15 +178,10 @@ class ModuleIsolation:
             parent_name, _, attr = name.rpartition(".")
             if (parent := sys.modules.get(parent_name)) is not None:
                 setattr(parent, attr, module)
-        # Unbind the copies the test imported on top of the snapshot. Identity
-        # is checked so this can never clobber an unrelated same-named attribute.
+        # Unbind the copies the test imported on top of the snapshot.
         for name, module in live.items():
-            if name in self._modules:
-                continue
-            parent_name, _, attr = name.rpartition(".")
-            parent = sys.modules.get(parent_name)
-            if parent is not None and parent.__dict__.get(attr) is module:
-                del parent.__dict__[attr]
+            if name not in self._modules:
+                self._unbind_from_parent(name, module)
         # Same purge-then-reinstate as the modules: an export the test resolved
         # on its own would otherwise outlive the copy it came from.
         self._drop_lazy_caches()

--- a/tests/unit/cli/conftest.py
+++ b/tests/unit/cli/conftest.py
@@ -1,83 +1,61 @@
 """Shared fixtures for sieval.cli.{dataset,task} unit tests.
 
-Tracks and cleans up `sieval.datasets.*` and `sieval.tasks.*` modules loaded
-during the test session, and restores the dataset/task registries after each
-test. This prevents cross-test pollution where pre-loaded modules prevent
-`import_all_datasets/tasks()` from re-registering in downstream tests.
+Restores the dataset/task registries and the `sieval.datasets.*` /
+`sieval.tasks.*` module cache after each test, so a test that triggers
+`import_all_datasets/tasks()` cannot leave the next one with a half-moved pair.
 
 AI-Generated Code - Claude Opus 4.6 (Anthropic)
 """
 
-import sys
-from contextlib import suppress
-
 import pytest
 
 from sieval.core.datasets.meta import DATASET_REGISTRY, SAMPLE_TO_DATASET
-from sieval.core.tasks.meta import TASK_REGISTRY
+from sieval.core.tasks.meta import _TASK_CLASSES, TASK_REGISTRY
+from tests.conftest import ModuleIsolation
 
-_LAZY_DATASET_SUFFIXES = ("Dataset", "DatasetSample", "CSVSample")
-_LAZY_TASK_SUFFIXES = ("Task",)
-
-# `sieval.datasets.downloaders.*` holds no `@sieval_dataset` decorators — it's
-# the handler registry. Evicting it desyncs the `URLHandler`/`HFHandler` class
-# identities from the instances cached in `downloaders.base._HANDLERS` (held
-# alive by the `from sieval.datasets.downloaders import resolve` closure in
-# `sieval.cli.dataset.{commands,render}`). Downstream tests that
-# `patch("...url.URLHandler.download")` then patch the *re-imported* class
-# while `_HANDLERS` still dispatches through the pre-eviction one, so the
-# mock is silently bypassed. Exclude the downloader subtree from eviction.
-_DOWNLOADER_PREFIX = "sieval.datasets.downloaders"
-
-
-def _clear_lazy_cache(pkg_name: str, suffixes: tuple[str, ...]) -> None:
-    """Remove lazy-resolved names from a package's global dict."""
-
-    try:
-        pkg = sys.modules.get(pkg_name)
-        if pkg is None:
-            return
-        for key in list(vars(pkg)):
-            if not key.startswith("_") and key.endswith(suffixes):
-                with suppress(AttributeError):
-                    delattr(pkg, key)
-    except Exception:
-        pass
+# `sieval.datasets.downloaders.*` holds no `@sieval_dataset` decorators — it's the
+# handler registry, and it has to stay out of scope entirely. `downloaders.base`
+# caches handler *instances* in a module-level `_HANDLERS`, and
+# `sieval.cli.dataset.{commands,render}` bind `resolve` at their own import time,
+# which is outside this scope and so never re-binds. Recreate the subtree and the
+# CLI keeps dispatching through the first `_HANDLERS` while
+# `patch("...url.URLHandler.download")` — resolved by attribute traversal — lands
+# on the new class, silently bypassing the mock and hitting the real network.
+# Restoring the originals cannot repair that: the pinned reference predates us.
+_DOWNLOADERS = "sieval.datasets.downloaders"
 
 
 @pytest.fixture(autouse=True)
 def _cleanup_registries_and_modules():
-    """Save registry state + pre-loaded modules; restore all after each test."""
+    """Save registry state + module cache; restore both after each test.
+
+    Restore-only by design — unlike the isolation fixtures in
+    `tests/unit/core/{tasks,datasets}/test_meta.py`, nothing here is cleared up
+    front: these tests exercise the CLI against the real registries. See
+    `ModuleIsolation` for why the module cache has to be restored alongside them.
+    """
     saved_ds = dict(DATASET_REGISTRY)
     saved_map = dict(SAMPLE_TO_DATASET)
     saved_tasks = dict(TASK_REGISTRY)
-    preloaded = {
-        name
-        for name in sys.modules
-        if name.startswith("sieval.datasets.") or name.startswith("sieval.tasks.")
-    }
-    yield
-    # Restore registries
-    DATASET_REGISTRY.clear()
-    DATASET_REGISTRY.update(saved_ds)
-    SAMPLE_TO_DATASET.clear()
-    SAMPLE_TO_DATASET.update(saved_map)
-    TASK_REGISTRY.clear()
-    TASK_REGISTRY.update(saved_tasks)
-    # Unload any newly loaded sieval.datasets.* / sieval.tasks.* submodules
-    # (excluding the downloader subtree — see _DOWNLOADER_PREFIX note above).
-    for name in list(sys.modules):
-        if (
-            (name.startswith("sieval.datasets.") or name.startswith("sieval.tasks."))
-            and name not in preloaded
-            and not name.startswith(_DOWNLOADER_PREFIX)
-        ):
-            del sys.modules[name]
-    # Clear lazy-resolved globals in the package __init__ modules so that
-    # subsequent tests that call import_all_datasets/tasks() can re-trigger
-    # the @register_dataset/@register_task decorators properly.
-    _clear_lazy_cache("sieval.datasets", _LAZY_DATASET_SUFFIXES)
-    _clear_lazy_cache("sieval.tasks", _LAZY_TASK_SUFFIXES)
+    saved_task_classes = dict(_TASK_CLASSES)
+    modules = ModuleIsolation(
+        ("sieval.datasets.", "sieval.tasks."),
+        lazy_packages=("sieval.datasets", "sieval.tasks"),
+        exclude=(_DOWNLOADERS, f"{_DOWNLOADERS}."),
+    )
+    modules.snapshot()
+    try:
+        yield
+    finally:
+        DATASET_REGISTRY.clear()
+        DATASET_REGISTRY.update(saved_ds)
+        SAMPLE_TO_DATASET.clear()
+        SAMPLE_TO_DATASET.update(saved_map)
+        TASK_REGISTRY.clear()
+        TASK_REGISTRY.update(saved_tasks)
+        _TASK_CLASSES.clear()
+        _TASK_CLASSES.update(saved_task_classes)
+        modules.restore()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/core/datasets/test_meta.py
+++ b/tests/unit/core/datasets/test_meta.py
@@ -21,6 +21,7 @@ from sieval.core.datasets.meta import (
     iter_dataset_metas,
     sieval_dataset,
 )
+from tests.conftest import ModuleIsolation
 
 
 class FooSample(TypedDict):
@@ -33,54 +34,28 @@ class BarSample(TypedDict):
 
 @pytest.fixture(autouse=True)
 def _clean_registries():
-    """Give every test empty registries *and* an empty `sieval.datasets` module
-    cache, then put all three back exactly as found.
+    """Give every test empty dataset registries *and* an empty `sieval.datasets`
+    module cache — see `ModuleIsolation` for why the two must move together.
 
-    They have to move as a unit: `import_all_datasets()` only re-runs a
-    module's `@sieval_dataset` decorator when `sieval.datasets.{name}` is
-    absent from `sys.modules`, so clearing one side without the other breaks a
-    test in one direction or the other:
-
-    - cleared registries + cached modules — the decorators never re-fire, so
-      `import_all_datasets()` leaves `DATASET_REGISTRY` / `SAMPLE_TO_DATASET`
-      empty. Any earlier file that imported dataset modules (directly, or via a
-      task module, or via its own `import_all_datasets()`) is enough.
-    - restored registries + purged modules — the next `import_all_datasets()`
-      re-runs the decorators against populated registries and trips the
-      duplicate-name guard.
-
-    Mirrors `_clean_registry` in `tests/unit/core/tasks/test_meta.py`, and
-    `_preserve_registries` in `tests/unit/tasks/test_theoremqa_kshot_base_gen.py`
-    narrows the same coupling to a single pair of modules.
+    Only submodules are in scope; the `sieval.datasets` package itself stays
+    cached.
     """
-    import sys
-
     saved_ds = DATASET_REGISTRY.copy()
     saved_map = SAMPLE_TO_DATASET.copy()
-    saved_modules = {
-        name: module
-        for name, module in sys.modules.items()
-        if name.startswith("sieval.datasets.")
-    }
+    modules = ModuleIsolation(("sieval.datasets.",))
+    modules.snapshot()
+
     DATASET_REGISTRY.clear()
     SAMPLE_TO_DATASET.clear()
-    for name in saved_modules:
-        del sys.modules[name]
-    yield
-    DATASET_REGISTRY.clear()
-    DATASET_REGISTRY.update(saved_ds)
-    SAMPLE_TO_DATASET.clear()
-    SAMPLE_TO_DATASET.update(saved_map)
-    for name in [n for n in sys.modules if n.startswith("sieval.datasets.")]:
-        del sys.modules[name]
-    sys.modules.update(saved_modules)
-    # Re-point the parent packages at the restored modules too. `sys.modules` is
-    # not the only view: `monkeypatch.setattr("sieval.datasets.x.y", ...)`
-    # resolves `x` by attribute traversal from `sieval`, so a child attribute
-    # still bound to the re-imported copy would patch a module nobody uses.
-    for name, module in saved_modules.items():
-        parent_name, _, attr = name.rpartition(".")
-        setattr(sys.modules[parent_name], attr, module)
+    modules.evict()
+    try:
+        yield
+    finally:
+        DATASET_REGISTRY.clear()
+        DATASET_REGISTRY.update(saved_ds)
+        SAMPLE_TO_DATASET.clear()
+        SAMPLE_TO_DATASET.update(saved_map)
+        modules.restore()
 
 
 def test_sieval_dataset_happy_path():

--- a/tests/unit/core/datasets/test_meta.py
+++ b/tests/unit/core/datasets/test_meta.py
@@ -33,30 +33,54 @@ class BarSample(TypedDict):
 
 @pytest.fixture(autouse=True)
 def _clean_registries():
-    """Each test starts with empty registries; restore afterwards.
+    """Give every test empty registries *and* an empty `sieval.datasets` module
+    cache, then put all three back exactly as found.
 
-    Also tracks `sieval.datasets.*` entries in `sys.modules` so that a test
-    that triggers `import_all_datasets()` does not leave modules cached —
-    otherwise later tests that rely on the real dataset decorators running
-    (e.g. Task-side reverse-lookup) will see an empty `SAMPLE_TO_DATASET`.
+    They have to move as a unit: `import_all_datasets()` only re-runs a
+    module's `@sieval_dataset` decorator when `sieval.datasets.{name}` is
+    absent from `sys.modules`, so clearing one side without the other breaks a
+    test in one direction or the other:
+
+    - cleared registries + cached modules — the decorators never re-fire, so
+      `import_all_datasets()` leaves `DATASET_REGISTRY` / `SAMPLE_TO_DATASET`
+      empty. Any earlier file that imported dataset modules (directly, or via a
+      task module, or via its own `import_all_datasets()`) is enough.
+    - restored registries + purged modules — the next `import_all_datasets()`
+      re-runs the decorators against populated registries and trips the
+      duplicate-name guard.
+
+    Mirrors `_clean_registry` in `tests/unit/core/tasks/test_meta.py`, and
+    `_preserve_registries` in `tests/unit/tasks/test_theoremqa_kshot_base_gen.py`
+    narrows the same coupling to a single pair of modules.
     """
     import sys
 
     saved_ds = DATASET_REGISTRY.copy()
     saved_map = SAMPLE_TO_DATASET.copy()
-    preloaded_modules = {
-        name for name in sys.modules if name.startswith("sieval.datasets.")
+    saved_modules = {
+        name: module
+        for name, module in sys.modules.items()
+        if name.startswith("sieval.datasets.")
     }
     DATASET_REGISTRY.clear()
     SAMPLE_TO_DATASET.clear()
+    for name in saved_modules:
+        del sys.modules[name]
     yield
     DATASET_REGISTRY.clear()
     DATASET_REGISTRY.update(saved_ds)
     SAMPLE_TO_DATASET.clear()
     SAMPLE_TO_DATASET.update(saved_map)
-    for name in list(sys.modules):
-        if name.startswith("sieval.datasets.") and name not in preloaded_modules:
-            del sys.modules[name]
+    for name in [n for n in sys.modules if n.startswith("sieval.datasets.")]:
+        del sys.modules[name]
+    sys.modules.update(saved_modules)
+    # Re-point the parent packages at the restored modules too. `sys.modules` is
+    # not the only view: `monkeypatch.setattr("sieval.datasets.x.y", ...)`
+    # resolves `x` by attribute traversal from `sieval`, so a child attribute
+    # still bound to the re-imported copy would patch a module nobody uses.
+    for name, module in saved_modules.items():
+        parent_name, _, attr = name.rpartition(".")
+        setattr(sys.modules[parent_name], attr, module)
 
 
 def test_sieval_dataset_happy_path():

--- a/tests/unit/core/datasets/test_meta.py
+++ b/tests/unit/core/datasets/test_meta.py
@@ -38,11 +38,14 @@ def _clean_registries():
     module cache — see `ModuleIsolation` for why the two must move together.
 
     Only submodules are in scope; the `sieval.datasets` package itself stays
-    cached.
+    cached. Its lazy export cache is still declared, because staying cached is
+    exactly what lets it hold a class resolved from a copy that `restore()`
+    later discards — a class that then stops matching its own
+    `SAMPLE_TO_DATASET` key.
     """
     saved_ds = DATASET_REGISTRY.copy()
     saved_map = SAMPLE_TO_DATASET.copy()
-    modules = ModuleIsolation(("sieval.datasets.",))
+    modules = ModuleIsolation(("sieval.datasets.",), lazy_packages=("sieval.datasets",))
     modules.snapshot()
 
     DATASET_REGISTRY.clear()

--- a/tests/unit/core/tasks/test_meta.py
+++ b/tests/unit/core/tasks/test_meta.py
@@ -27,6 +27,7 @@ from sieval.core.tasks.meta import (
     sieval_task,
     task_meta_to_dict,
 )
+from tests.conftest import ModuleIsolation
 
 # ── Stub sample type + dataset class for reverse-lookup tests ──
 
@@ -149,55 +150,31 @@ def test_task_meta_constructs():
 @pytest.fixture(autouse=True)
 def _clean_registry():
     """Give every test an empty task registry *and* an empty ``sieval.tasks``
-    module cache, then put both back exactly as found.
+    module cache — see ``ModuleIsolation`` for why the two must move together.
 
-    The two must move as a unit. ``import_all_tasks()`` / ``get_task_class()``
-    only re-run a module's ``@sieval_task`` decorator when
-    ``sieval.tasks.{name}`` is absent from ``sys.modules``, so clearing one
-    half without the other breaks a test in one direction or the other:
-
-    * cleared registry + cached modules — registration silently no-ops, so
-      ``import_all_tasks()`` leaves the name unregistered and
-      ``get_task_class()`` raises ``KeyError``. Another test file
-      top-level-importing a task module is enough to trigger this.
-    * restored registry + purged modules — the next ``import_all_tasks()``
-      (e.g. ``test_meta_pilot.py``) re-runs the decorators against an
-      already-populated registry and trips the duplicate-name guard.
-
-    Only submodules are evicted; ``sieval.tasks`` itself stays cached so its
-    ``__path__`` keeps the identity that path-injecting tests rely on.
+    Only submodules are in scope; ``sieval.tasks`` itself stays cached so its
+    ``__path__`` keeps the identity that path-injecting tests rely on. The
+    dataset registries are deliberately untouched — ``_stub_sample_mapping``
+    above seeds ``SAMPLE_TO_DATASET`` for every test in this file.
     """
-    import sys
-
     from sieval.core.tasks.meta import _TASK_CLASSES
 
     reg_snapshot = dict(TASK_REGISTRY)
     cls_snapshot = dict(_TASK_CLASSES)
-    module_snapshot = {
-        name: module
-        for name, module in sys.modules.items()
-        if name.startswith("sieval.tasks.")
-    }
+    modules = ModuleIsolation(("sieval.tasks.",))
+    modules.snapshot()
+
     TASK_REGISTRY.clear()
     _TASK_CLASSES.clear()
-    for name in module_snapshot:
-        del sys.modules[name]
-    yield
-    TASK_REGISTRY.clear()
-    TASK_REGISTRY.update(reg_snapshot)
-    _TASK_CLASSES.clear()
-    _TASK_CLASSES.update(cls_snapshot)
-    for name in [n for n in sys.modules if n.startswith("sieval.tasks.")]:
-        del sys.modules[name]
-    sys.modules.update(module_snapshot)
-    # Re-point the parent packages at the restored modules too. ``sys.modules``
-    # is not the only view: ``monkeypatch.setattr("sieval.tasks.x.y", ...)``
-    # resolves ``x`` by attribute traversal from ``sieval``, so a child
-    # attribute still bound to the re-imported copy would patch a module
-    # nobody uses.
-    for name, module in module_snapshot.items():
-        parent_name, _, attr = name.rpartition(".")
-        setattr(sys.modules[parent_name], attr, module)
+    modules.evict()
+    try:
+        yield
+    finally:
+        TASK_REGISTRY.clear()
+        TASK_REGISTRY.update(reg_snapshot)
+        _TASK_CLASSES.clear()
+        _TASK_CLASSES.update(cls_snapshot)
+        modules.restore()
 
 
 def test_clean_registry_fixture_leaves_task_modules_reimportable():
@@ -207,6 +184,10 @@ def test_clean_registry_fixture_leaves_task_modules_reimportable():
     `import_all_tasks()` genuinely re-runs every `@sieval_task` decorator. When
     the cache was left populated, tasks another test file had already imported
     at module level came back unregistered — silently, and only for those tasks.
+
+    Also pins the eponymous-module convention `get_task_class()` depends on
+    (`sieval/core/tasks/meta.py`): every registered name must be reachable as
+    `sieval.tasks.{name}`, or `sieval task list` cannot resolve its class.
     """
     import sys
 
@@ -222,6 +203,12 @@ def test_clean_registry_fixture_leaves_task_modules_reimportable():
     assert tasks, "shipped index is non-empty"
     missing = {t.name for t in tasks} - set(TASK_REGISTRY)
     assert not missing, f"indexed tasks left unregistered: {sorted(missing)}"
+    off_convention = [
+        name for name in TASK_REGISTRY if f"sieval.tasks.{name}" not in sys.modules
+    ]
+    assert not off_convention, (
+        f"tasks not defined in an eponymous module: {sorted(off_convention)}"
+    )
 
 
 def test_sieval_task_attaches_meta_and_registers():

--- a/tests/unit/core/tasks/test_meta.py
+++ b/tests/unit/core/tasks/test_meta.py
@@ -148,15 +148,24 @@ def test_task_meta_constructs():
 
 @pytest.fixture(autouse=True)
 def _clean_registry():
-    """Snapshot + clear TASK_REGISTRY / _TASK_CLASSES for every test; restore after.
+    """Give every test an empty task registry *and* an empty ``sieval.tasks``
+    module cache, then put both back exactly as found.
 
-    Also isolates ``sys.modules`` — tests that call ``import_all_tasks()``
-    would otherwise leave ``sieval.tasks.*`` entries cached; a subsequent
-    ``import_all_tasks()`` from another test file would then short-circuit on
-    those cache hits, skip module-body execution, and never re-run the
-    ``@sieval_task`` decorators, leaving downstream tests with an empty
-    registry. Drop any ``sieval.tasks.*`` module newly imported during the
-    test so the next caller starts from a clean slate.
+    The two must move as a unit. ``import_all_tasks()`` / ``get_task_class()``
+    only re-run a module's ``@sieval_task`` decorator when
+    ``sieval.tasks.{name}`` is absent from ``sys.modules``, so clearing one
+    half without the other breaks a test in one direction or the other:
+
+    * cleared registry + cached modules — registration silently no-ops, so
+      ``import_all_tasks()`` leaves the name unregistered and
+      ``get_task_class()`` raises ``KeyError``. Another test file
+      top-level-importing a task module is enough to trigger this.
+    * restored registry + purged modules — the next ``import_all_tasks()``
+      (e.g. ``test_meta_pilot.py``) re-runs the decorators against an
+      already-populated registry and trips the duplicate-name guard.
+
+    Only submodules are evicted; ``sieval.tasks`` itself stays cached so its
+    ``__path__`` keeps the identity that path-injecting tests rely on.
     """
     import sys
 
@@ -164,19 +173,55 @@ def _clean_registry():
 
     reg_snapshot = dict(TASK_REGISTRY)
     cls_snapshot = dict(_TASK_CLASSES)
-    task_modules_before = {
-        name for name in sys.modules if name.startswith("sieval.tasks")
+    module_snapshot = {
+        name: module
+        for name, module in sys.modules.items()
+        if name.startswith("sieval.tasks.")
     }
     TASK_REGISTRY.clear()
     _TASK_CLASSES.clear()
+    for name in module_snapshot:
+        del sys.modules[name]
     yield
     TASK_REGISTRY.clear()
     TASK_REGISTRY.update(reg_snapshot)
     _TASK_CLASSES.clear()
     _TASK_CLASSES.update(cls_snapshot)
-    for name in list(sys.modules):
-        if name.startswith("sieval.tasks") and name not in task_modules_before:
-            del sys.modules[name]
+    for name in [n for n in sys.modules if n.startswith("sieval.tasks.")]:
+        del sys.modules[name]
+    sys.modules.update(module_snapshot)
+    # Re-point the parent packages at the restored modules too. ``sys.modules``
+    # is not the only view: ``monkeypatch.setattr("sieval.tasks.x.y", ...)``
+    # resolves ``x`` by attribute traversal from ``sieval``, so a child
+    # attribute still bound to the re-imported copy would patch a module
+    # nobody uses.
+    for name, module in module_snapshot.items():
+        parent_name, _, attr = name.rpartition(".")
+        setattr(sys.modules[parent_name], attr, module)
+
+
+def test_clean_registry_fixture_leaves_task_modules_reimportable():
+    """Lock the `_clean_registry` contract that the rest of this file rests on.
+
+    Registry and `sieval.tasks` module cache must both start empty, so
+    `import_all_tasks()` genuinely re-runs every `@sieval_task` decorator. When
+    the cache was left populated, tasks another test file had already imported
+    at module level came back unregistered — silently, and only for those tasks.
+    """
+    import sys
+
+    from sieval.core.tasks.meta import import_all_tasks
+    from sieval.meta import load_index
+
+    assert not TASK_REGISTRY
+    assert not [name for name in sys.modules if name.startswith("sieval.tasks.")]
+
+    import_all_tasks()
+
+    _, tasks = load_index()
+    assert tasks, "shipped index is non-empty"
+    missing = {t.name for t in tasks} - set(TASK_REGISTRY)
+    assert not missing, f"indexed tasks left unregistered: {sorted(missing)}"
 
 
 def test_sieval_task_attaches_meta_and_registers():
@@ -620,33 +665,65 @@ def test_tasks_for_dataset_empty_for_unknown():
 
 
 def test_get_task_class_returns_registered_class():
-    """Verify `get_task_class` returns the Task subclass registered under *name*."""
-    from sieval.core.tasks.meta import TASK_REGISTRY, get_task_class, import_all_tasks
-    from sieval.meta import load_index
+    """An already-registered name resolves straight out of `_TASK_CLASSES`.
 
-    import_all_tasks()
-    _, tasks = load_index()
-    assert tasks, "pilot index is non-empty"
-    name = tasks[0].name
-    # `get_task_class` resolves a cleared-registry miss by importing
-    # `sieval.tasks.{name}`, but that only re-runs the `@sieval_task` decorator
-    # if the module isn't already cached. Another test file (e.g. one that calls
-    # `import_all_tasks()` or imports a task at module top level) may have leaked
-    # it into `sys.modules`, in which case this test's own `import_all_tasks()`
-    # short-circuits and leaves `name` unregistered — surfacing only when it is
-    # `tasks[0]` under randomized collection order. Evict it so resolution is
-    # genuinely exercised (the autouse fixture restores module state on teardown).
+    The target is registered by this test rather than read off the shipped
+    index, so the assertion is exact (identity, not `issubclass`) and does not
+    shift with whichever task happens to sort first.
+    """
+    from sieval.core.tasks.meta import get_task_class
+
+    @sieval_task(
+        name="lookup_pilot",
+        display_name="Lookup Pilot",
+        description="registered target for get_task_class",
+        eval_mode=EvalMode.GEN,
+    )
+    class _LookupPilotTask(_StubTask):
+        pass
+
+    assert get_task_class("lookup_pilot") is _LookupPilotTask
+
+
+def test_get_task_class_lazy_imports_unregistered_module(tmp_path):
+    """A name missing from `_TASK_CLASSES` resolves by importing
+    `sieval.tasks.{name}` — the one-task-per-eponymous-module convention that
+    lets point lookups skip a full `import_all_tasks()`.
+    """
     import sys
 
-    sys.modules.pop(f"sieval.tasks.{name}", None)
-    # A registered name must resolve — we don't assert a specific class to
-    # stay resilient to pilot changes; just that the lookup works.
-    from sieval.core.tasks.task import Task
+    import sieval.tasks
+    from sieval.core.tasks.meta import TASK_REGISTRY, get_task_class
 
-    cls = get_task_class(name)
-    assert issubclass(cls, Task)
-    assert cls.__name__  # non-empty class name
-    assert name in TASK_REGISTRY  # sanity: name really is registered
+    name = "lazy_task_for_test"
+    # Decorating in a real module file (rather than in this test body) is what
+    # makes the import the only path to registration.
+    (tmp_path / f"{name}.py").write_text(
+        "from sieval.core.tasks.meta import EvalMode, sieval_task\n"
+        f"from {__name__} import _StubTask\n"
+        "\n"
+        "\n"
+        "@sieval_task(\n"
+        f'    name="{name}",\n'
+        '    display_name="Lazy",\n'
+        '    description="lazy-import target",\n'
+        "    eval_mode=EvalMode.GEN,\n"
+        ")\n"
+        "class LazyForTestTask(_StubTask):\n"
+        "    pass\n"
+    )
+    sieval.tasks.__path__.insert(0, str(tmp_path))
+    try:
+        assert name not in TASK_REGISTRY  # only the import can register it
+        cls = get_task_class(name)
+        assert cls.__name__ == "LazyForTestTask"
+        assert TASK_REGISTRY[name].display_name == "Lazy"
+    finally:
+        sieval.tasks.__path__.remove(str(tmp_path))
+        sys.modules.pop(f"sieval.tasks.{name}", None)
+        # The successful import also bound the submodule on the package; drop it
+        # so nothing outside this test can reach a module whose file is gone.
+        sieval.tasks.__dict__.pop(name, None)
 
 
 def test_get_task_class_raises_key_error_on_unknown_name():

--- a/tests/unit/core/tasks/test_meta.py
+++ b/tests/unit/core/tasks/test_meta.py
@@ -153,7 +153,9 @@ def _clean_registry():
     module cache — see ``ModuleIsolation`` for why the two must move together.
 
     Only submodules are in scope; ``sieval.tasks`` itself stays cached so its
-    ``__path__`` keeps the identity that path-injecting tests rely on. The
+    ``__path__`` keeps the identity that path-injecting tests rely on. Its lazy
+    export cache is still declared, because staying cached is exactly what lets
+    it hold a class resolved from a copy that ``restore()`` later discards. The
     dataset registries are deliberately untouched — ``_stub_sample_mapping``
     above seeds ``SAMPLE_TO_DATASET`` for every test in this file.
     """
@@ -161,7 +163,7 @@ def _clean_registry():
 
     reg_snapshot = dict(TASK_REGISTRY)
     cls_snapshot = dict(_TASK_CLASSES)
-    modules = ModuleIsolation(("sieval.tasks.",))
+    modules = ModuleIsolation(("sieval.tasks.",), lazy_packages=("sieval.tasks",))
     modules.snapshot()
 
     TASK_REGISTRY.clear()
@@ -185,9 +187,19 @@ def test_clean_registry_fixture_leaves_task_modules_reimportable():
     the cache was left populated, tasks another test file had already imported
     at module level came back unregistered — silently, and only for those tasks.
 
+    The cache half of that only has teeth once something has populated it, so
+    running this file alone leaves the second assertion trivially true. It earns
+    its keep in a full-suite or multi-file run, where an earlier file has already
+    imported a task module.
+
     Also pins the eponymous-module convention `get_task_class()` depends on
     (`sieval/core/tasks/meta.py`): every registered name must be reachable as
-    `sieval.tasks.{name}`, or `sieval task list` cannot resolve its class.
+    `sieval.tasks.{name}`, or `sieval task list` cannot resolve its class. Note
+    this is deliberately stricter than the lazy export map, which also accepts
+    subpackage-hosted tasks as `"subpkg.module_stem"` (`sieval/tasks/__init__.py`
+    "Subpackage .py modules"). Such a task would import and export fine but be
+    unreachable through `get_task_class()`, so the flat layout is the binding
+    constraint until that lookup learns to walk subpackages.
     """
     import sys
 

--- a/tests/unit/tasks/test_theoremqa_kshot_base_gen.py
+++ b/tests/unit/tasks/test_theoremqa_kshot_base_gen.py
@@ -7,6 +7,7 @@ AI-Generated Code - GPT-5.5 (OpenAI)
 import importlib
 import subprocess
 import sys
+from types import ModuleType
 
 import pytest
 from datasets import Dataset as HFDataset
@@ -22,13 +23,23 @@ _TASK_EXPORTS = ("TheoremQAKShotBaseGenTask",)
 _DATASET_EXPORTS = ("TheoremQADataset", "TheoremQADatasetSample")
 
 
+_PACKAGE_EXPORTS = (
+    ("sieval.tasks", _TASK_EXPORTS),
+    ("sieval.datasets", _DATASET_EXPORTS),
+)
+
+
 def _drop_theoremqa_modules() -> None:
+    """Evict both theoremqa modules and the packages' cached lazy exports.
+
+    This file imports the task/dataset on demand (`_task_module()`,
+    `_dataset()`) rather than at top level, so dropping them is what makes each
+    test's import re-execute the module bodies and re-run the `@sieval_task` /
+    `@sieval_dataset` decorators into the registries the fixture just cleared.
+    """
     sys.modules.pop(_TASK_MODULE, None)
     sys.modules.pop(_DATASET_MODULE, None)
-    for package_name, exports in (
-        ("sieval.tasks", _TASK_EXPORTS),
-        ("sieval.datasets", _DATASET_EXPORTS),
-    ):
+    for package_name, exports in _PACKAGE_EXPORTS:
         package = sys.modules.get(package_name)
         if package is None:
             continue
@@ -36,8 +47,61 @@ def _drop_theoremqa_modules() -> None:
             package.__dict__.pop(export, None)
 
 
+def _snapshot_theoremqa_modules() -> tuple[
+    dict[str, ModuleType], dict[tuple[str, str], object]
+]:
+    """Capture exactly what `_drop_theoremqa_modules` evicts.
+
+    Lets teardown put the originals back instead of handing the next caller
+    restored registries that name modules no longer in `sys.modules` — that
+    pairing makes the following `import_all_tasks()` / `import_all_datasets()`
+    re-run the decorators and trip the duplicate-name guard.
+    """
+    modules = {
+        name: sys.modules[name]
+        for name in (_TASK_MODULE, _DATASET_MODULE)
+        if name in sys.modules
+    }
+    exports: dict[tuple[str, str], object] = {}
+    for package_name, export_names in _PACKAGE_EXPORTS:
+        package = sys.modules.get(package_name)
+        if package is None:
+            continue
+        for export in export_names:
+            if export in package.__dict__:
+                exports[package_name, export] = package.__dict__[export]
+    return modules, exports
+
+
+def _restore_theoremqa_modules(
+    modules: dict[str, ModuleType], exports: dict[tuple[str, str], object]
+) -> None:
+    """Inverse of `_drop_theoremqa_modules`, from a `_snapshot_...` pair."""
+    for name, module in modules.items():
+        sys.modules[name] = module
+        # Re-point the parent package at the original too: `sys.modules` is not
+        # the only view, and `monkeypatch.setattr("sieval.datasets.theoremqa.x")`
+        # resolves by attribute traversal from `sieval`.
+        parent_name, _, attr = name.rpartition(".")
+        setattr(sys.modules[parent_name], attr, module)
+    for (package_name, export), value in exports.items():
+        sys.modules[package_name].__dict__[export] = value
+
+
 @pytest.fixture(autouse=True)
 def _preserve_registries():
+    """Clear the four registries and evict both theoremqa modules, then restore
+    the whole set — registries *and* module cache — as it was found.
+
+    The two halves have to move together. Registries cleared alongside dropped
+    modules is what lets each test's on-demand import re-register; but the
+    restore has to put the modules back as well, or the next
+    `import_all_tasks()` / `import_all_datasets()` re-executes them against
+    already-populated registries and raises on the duplicate name.
+
+    Same coupling as `_clean_registry` in `tests/unit/core/tasks/test_meta.py`,
+    narrowed from whole packages to these two modules.
+    """
     from sieval.core.datasets.meta import DATASET_REGISTRY, SAMPLE_TO_DATASET
     from sieval.core.tasks.meta import _TASK_CLASSES, TASK_REGISTRY
 
@@ -45,6 +109,7 @@ def _preserve_registries():
     task_classes_snapshot = dict(_TASK_CLASSES)
     dataset_snapshot = dict(DATASET_REGISTRY)
     sample_map_snapshot = dict(SAMPLE_TO_DATASET)
+    module_snapshot, export_snapshot = _snapshot_theoremqa_modules()
 
     TASK_REGISTRY.clear()
     _TASK_CLASSES.clear()
@@ -54,6 +119,8 @@ def _preserve_registries():
     try:
         yield
     finally:
+        # Drop the copies this test imported, then reinstate the originals the
+        # restored registry snapshots refer to.
         _drop_theoremqa_modules()
         TASK_REGISTRY.clear()
         TASK_REGISTRY.update(task_snapshot)
@@ -63,6 +130,7 @@ def _preserve_registries():
         DATASET_REGISTRY.update(dataset_snapshot)
         SAMPLE_TO_DATASET.clear()
         SAMPLE_TO_DATASET.update(sample_map_snapshot)
+        _restore_theoremqa_modules(module_snapshot, export_snapshot)
 
 
 class _MockGenModel(GenModel):

--- a/tests/unit/tasks/test_theoremqa_kshot_base_gen.py
+++ b/tests/unit/tasks/test_theoremqa_kshot_base_gen.py
@@ -7,7 +7,6 @@ AI-Generated Code - GPT-5.5 (OpenAI)
 import importlib
 import subprocess
 import sys
-from types import ModuleType
 
 import pytest
 from datasets import Dataset as HFDataset
@@ -16,91 +15,23 @@ from datasets import DatasetDict as HFDatasetDict
 from sieval.core.models import ModelOutput
 from sieval.core.models.gen_model import GenModel
 from sieval.core.tasks.context import TaskContext
+from tests.conftest import ModuleIsolation
 
 _TASK_MODULE = "sieval.tasks.theoremqa_kshot_base_gen"
 _DATASET_MODULE = "sieval.datasets.theoremqa"
-_TASK_EXPORTS = ("TheoremQAKShotBaseGenTask",)
-_DATASET_EXPORTS = ("TheoremQADataset", "TheoremQADatasetSample")
-
-
-_PACKAGE_EXPORTS = (
-    ("sieval.tasks", _TASK_EXPORTS),
-    ("sieval.datasets", _DATASET_EXPORTS),
-)
-
-
-def _drop_theoremqa_modules() -> None:
-    """Evict both theoremqa modules and the packages' cached lazy exports.
-
-    This file imports the task/dataset on demand (`_task_module()`,
-    `_dataset()`) rather than at top level, so dropping them is what makes each
-    test's import re-execute the module bodies and re-run the `@sieval_task` /
-    `@sieval_dataset` decorators into the registries the fixture just cleared.
-    """
-    sys.modules.pop(_TASK_MODULE, None)
-    sys.modules.pop(_DATASET_MODULE, None)
-    for package_name, exports in _PACKAGE_EXPORTS:
-        package = sys.modules.get(package_name)
-        if package is None:
-            continue
-        for export in exports:
-            package.__dict__.pop(export, None)
-
-
-def _snapshot_theoremqa_modules() -> tuple[
-    dict[str, ModuleType], dict[tuple[str, str], object]
-]:
-    """Capture exactly what `_drop_theoremqa_modules` evicts.
-
-    Lets teardown put the originals back instead of handing the next caller
-    restored registries that name modules no longer in `sys.modules` — that
-    pairing makes the following `import_all_tasks()` / `import_all_datasets()`
-    re-run the decorators and trip the duplicate-name guard.
-    """
-    modules = {
-        name: sys.modules[name]
-        for name in (_TASK_MODULE, _DATASET_MODULE)
-        if name in sys.modules
-    }
-    exports: dict[tuple[str, str], object] = {}
-    for package_name, export_names in _PACKAGE_EXPORTS:
-        package = sys.modules.get(package_name)
-        if package is None:
-            continue
-        for export in export_names:
-            if export in package.__dict__:
-                exports[package_name, export] = package.__dict__[export]
-    return modules, exports
-
-
-def _restore_theoremqa_modules(
-    modules: dict[str, ModuleType], exports: dict[tuple[str, str], object]
-) -> None:
-    """Inverse of `_drop_theoremqa_modules`, from a `_snapshot_...` pair."""
-    for name, module in modules.items():
-        sys.modules[name] = module
-        # Re-point the parent package at the original too: `sys.modules` is not
-        # the only view, and `monkeypatch.setattr("sieval.datasets.theoremqa.x")`
-        # resolves by attribute traversal from `sieval`.
-        parent_name, _, attr = name.rpartition(".")
-        setattr(sys.modules[parent_name], attr, module)
-    for (package_name, export), value in exports.items():
-        sys.modules[package_name].__dict__[export] = value
+_LAZY_PACKAGES = ("sieval.tasks", "sieval.datasets")
 
 
 @pytest.fixture(autouse=True)
 def _preserve_registries():
     """Clear the four registries and evict both theoremqa modules, then restore
-    the whole set — registries *and* module cache — as it was found.
+    the whole set — see `ModuleIsolation` for why the two must move together.
 
-    The two halves have to move together. Registries cleared alongside dropped
-    modules is what lets each test's on-demand import re-register; but the
-    restore has to put the modules back as well, or the next
-    `import_all_tasks()` / `import_all_datasets()` re-executes them against
-    already-populated registries and raises on the duplicate name.
-
-    Same coupling as `_clean_registry` in `tests/unit/core/tasks/test_meta.py`,
-    narrowed from whole packages to these two modules.
+    This file imports the task/dataset on demand (`_task_module()`,
+    `_dataset()`) rather than at top level, so evicting them is what makes each
+    test's import re-execute the module bodies and re-run the `@sieval_task` /
+    `@sieval_dataset` decorators into the registries just cleared. Scope is the
+    two exact modules rather than the whole packages.
     """
     from sieval.core.datasets.meta import DATASET_REGISTRY, SAMPLE_TO_DATASET
     from sieval.core.tasks.meta import _TASK_CLASSES, TASK_REGISTRY
@@ -109,19 +40,17 @@ def _preserve_registries():
     task_classes_snapshot = dict(_TASK_CLASSES)
     dataset_snapshot = dict(DATASET_REGISTRY)
     sample_map_snapshot = dict(SAMPLE_TO_DATASET)
-    module_snapshot, export_snapshot = _snapshot_theoremqa_modules()
+    modules = ModuleIsolation((_TASK_MODULE, _DATASET_MODULE), _LAZY_PACKAGES)
+    modules.snapshot()
 
     TASK_REGISTRY.clear()
     _TASK_CLASSES.clear()
     DATASET_REGISTRY.clear()
     SAMPLE_TO_DATASET.clear()
-    _drop_theoremqa_modules()
+    modules.evict()
     try:
         yield
     finally:
-        # Drop the copies this test imported, then reinstate the originals the
-        # restored registry snapshots refer to.
-        _drop_theoremqa_modules()
         TASK_REGISTRY.clear()
         TASK_REGISTRY.update(task_snapshot)
         _TASK_CLASSES.clear()
@@ -130,7 +59,7 @@ def _preserve_registries():
         DATASET_REGISTRY.update(dataset_snapshot)
         SAMPLE_TO_DATASET.clear()
         SAMPLE_TO_DATASET.update(sample_map_snapshot)
-        _restore_theoremqa_modules(module_snapshot, export_snapshot)
+        modules.restore()
 
 
 class _MockGenModel(GenModel):

--- a/tests/unit/test_lazy_exports.py
+++ b/tests/unit/test_lazy_exports.py
@@ -21,28 +21,64 @@ def _drop_package_modules(package_name: str) -> None:
             sys.modules.pop(module_name, None)
 
 
+def _snapshot_package_modules(package_name: str) -> dict[str, ModuleType]:
+    """Capture every `sys.modules` entry `_drop_package_modules` would remove."""
+    return {
+        module_name: module
+        for module_name, module in sys.modules.items()
+        if module_name == package_name or module_name.startswith(f"{package_name}.")
+    }
+
+
+def _restore_package_modules(saved: dict[str, ModuleType]) -> None:
+    """Inverse of `_drop_package_modules`, from a `_snapshot_...` result.
+
+    Rebinding the parent attributes matters as much as `sys.modules`: these
+    tests replace the package object itself, and attribute-based resolution
+    (`pkg.submodule`, and `monkeypatch.setattr("pkg.submodule.attr", ...)`,
+    which traverses from the root) reads those, not the cache.
+    """
+    sys.modules.update(saved)
+    for module_name, module in saved.items():
+        parent_name, _, attr = module_name.rpartition(".")
+        setattr(sys.modules[parent_name], attr, module)
+
+
 @pytest.fixture(autouse=True)
 def _preserve_registries():
-    """Snapshot/restore task + dataset registries around every test.
+    """Snapshot/restore the task + dataset registries *and* both packages'
+    module caches around every test.
 
     Tests here re-import sieval.tasks / sieval.datasets submodules, which
     re-invokes @sieval_task / @sieval_dataset and trips the duplicate-name
     guards. Clearing the registries before each test lets the re-import
-    proceed; restoring afterwards keeps subsequent tests' expectations intact.
+    proceed — but the two have to be restored as a unit too. Handing the next
+    caller populated registries whose modules are no longer cached makes its
+    `import_all_tasks()` / `import_all_datasets()` re-run those same decorators
+    and hit the very guard this fixture works around.
+
+    Same coupling as `_clean_registry` in `tests/unit/core/tasks/test_meta.py`.
     """
     try:
         from sieval.core.datasets.meta import (
             DATASET_REGISTRY,
             SAMPLE_TO_DATASET,
         )
-        from sieval.core.tasks.meta import TASK_REGISTRY
+        from sieval.core.tasks.meta import _TASK_CLASSES, TASK_REGISTRY
     except ImportError:
         yield
         return
     task_snapshot = dict(TASK_REGISTRY)
+    task_classes_snapshot = dict(_TASK_CLASSES)
     dataset_snapshot = dict(DATASET_REGISTRY)
     sample_map_snapshot = dict(SAMPLE_TO_DATASET)
+    # Snapshot before dropping: these tests replace the package objects
+    # themselves, so the originals are only recoverable from here.
+    module_snapshots = [
+        _snapshot_package_modules(name) for name in ("sieval.tasks", "sieval.datasets")
+    ]
     TASK_REGISTRY.clear()
+    _TASK_CLASSES.clear()
     DATASET_REGISTRY.clear()
     SAMPLE_TO_DATASET.clear()
     # Also drop both packages' submodules from sys.modules so lazy re-imports
@@ -56,10 +92,18 @@ def _preserve_registries():
     finally:
         TASK_REGISTRY.clear()
         TASK_REGISTRY.update(task_snapshot)
+        _TASK_CLASSES.clear()
+        _TASK_CLASSES.update(task_classes_snapshot)
         DATASET_REGISTRY.clear()
         DATASET_REGISTRY.update(dataset_snapshot)
         SAMPLE_TO_DATASET.clear()
         SAMPLE_TO_DATASET.update(sample_map_snapshot)
+        # Discard whatever the test imported, then reinstate the originals the
+        # restored registries refer to.
+        _drop_package_modules("sieval.tasks")
+        _drop_package_modules("sieval.datasets")
+        for saved in module_snapshots:
+            _restore_package_modules(saved)
 
 
 def _read_stub_all(stub_path: Path) -> list[str]:

--- a/tests/unit/test_lazy_exports.py
+++ b/tests/unit/test_lazy_exports.py
@@ -14,6 +14,8 @@ from types import ModuleType
 
 import pytest
 
+from tests.conftest import ModuleIsolation
+
 
 def _drop_package_modules(package_name: str) -> None:
     for module_name in list(sys.modules):
@@ -21,43 +23,19 @@ def _drop_package_modules(package_name: str) -> None:
             sys.modules.pop(module_name, None)
 
 
-def _snapshot_package_modules(package_name: str) -> dict[str, ModuleType]:
-    """Capture every `sys.modules` entry `_drop_package_modules` would remove."""
-    return {
-        module_name: module
-        for module_name, module in sys.modules.items()
-        if module_name == package_name or module_name.startswith(f"{package_name}.")
-    }
-
-
-def _restore_package_modules(saved: dict[str, ModuleType]) -> None:
-    """Inverse of `_drop_package_modules`, from a `_snapshot_...` result.
-
-    Rebinding the parent attributes matters as much as `sys.modules`: these
-    tests replace the package object itself, and attribute-based resolution
-    (`pkg.submodule`, and `monkeypatch.setattr("pkg.submodule.attr", ...)`,
-    which traverses from the root) reads those, not the cache.
-    """
-    sys.modules.update(saved)
-    for module_name, module in saved.items():
-        parent_name, _, attr = module_name.rpartition(".")
-        setattr(sys.modules[parent_name], attr, module)
-
-
 @pytest.fixture(autouse=True)
 def _preserve_registries():
     """Snapshot/restore the task + dataset registries *and* both packages'
-    module caches around every test.
+    module caches around every test — see `ModuleIsolation` for why the two
+    must move together.
 
     Tests here re-import sieval.tasks / sieval.datasets submodules, which
     re-invokes @sieval_task / @sieval_dataset and trips the duplicate-name
-    guards. Clearing the registries before each test lets the re-import
-    proceed — but the two have to be restored as a unit too. Handing the next
-    caller populated registries whose modules are no longer cached makes its
-    `import_all_tasks()` / `import_all_datasets()` re-run those same decorators
-    and hit the very guard this fixture works around.
-
-    Same coupling as `_clean_registry` in `tests/unit/core/tasks/test_meta.py`.
+    guards; clearing the registries first lets the re-import proceed. The
+    packages themselves are in scope (not just their submodules) because these
+    tests replace the package objects to exercise the lazy `__getattr__`.
+    Tasks pull datasets via `from sieval.datasets import ...`, so a task-side
+    re-import only works if the dataset side is purged too.
     """
     try:
         from sieval.core.datasets.meta import (
@@ -72,21 +50,16 @@ def _preserve_registries():
     task_classes_snapshot = dict(_TASK_CLASSES)
     dataset_snapshot = dict(DATASET_REGISTRY)
     sample_map_snapshot = dict(SAMPLE_TO_DATASET)
-    # Snapshot before dropping: these tests replace the package objects
-    # themselves, so the originals are only recoverable from here.
-    module_snapshots = [
-        _snapshot_package_modules(name) for name in ("sieval.tasks", "sieval.datasets")
-    ]
+    modules = ModuleIsolation(
+        ("sieval.tasks", "sieval.tasks.", "sieval.datasets", "sieval.datasets.")
+    )
+    modules.snapshot()
+
     TASK_REGISTRY.clear()
     _TASK_CLASSES.clear()
     DATASET_REGISTRY.clear()
     SAMPLE_TO_DATASET.clear()
-    # Also drop both packages' submodules from sys.modules so lazy re-imports
-    # re-run @sieval_task / @sieval_dataset against the cleared registries.
-    # Tasks pull datasets via `from sieval.datasets import ...`, so a task-side
-    # re-import only works if the dataset side is purged too.
-    _drop_package_modules("sieval.tasks")
-    _drop_package_modules("sieval.datasets")
+    modules.evict()
     try:
         yield
     finally:
@@ -98,12 +71,7 @@ def _preserve_registries():
         DATASET_REGISTRY.update(dataset_snapshot)
         SAMPLE_TO_DATASET.clear()
         SAMPLE_TO_DATASET.update(sample_map_snapshot)
-        # Discard whatever the test imported, then reinstate the originals the
-        # restored registries refer to.
-        _drop_package_modules("sieval.tasks")
-        _drop_package_modules("sieval.datasets")
-        for saved in module_snapshots:
-            _restore_package_modules(saved)
+        modules.restore()
 
 
 def _read_stub_all(stub_path: Path) -> list[str]:

--- a/tests/unit/test_module_isolation.py
+++ b/tests/unit/test_module_isolation.py
@@ -106,7 +106,12 @@ def test_evict_lets_from_package_import_re_execute_the_module():
     isolation.snapshot()
     isolation.evict()
 
-    from module_isolation_probe import alpha as reimported
+    # The statement form is the assertion: `import_module` looks the name up in
+    # `sys.modules` and would never touch the parent attribute under test. `ty`
+    # cannot resolve a package this module writes to disk at runtime.
+    from module_isolation_probe import (  # ty: ignore[unresolved-import]
+        alpha as reimported,
+    )
 
     assert reimported is not alpha, "stale parent attribute served a dropped module"
     assert sys.modules[f"{_PKG}.alpha"] is reimported

--- a/tests/unit/test_module_isolation.py
+++ b/tests/unit/test_module_isolation.py
@@ -1,0 +1,202 @@
+"""Contract tests for the `ModuleIsolation` helper in `tests/conftest.py`.
+
+Every assertion here is about `sys.modules` mechanics, so the subject is a
+synthetic package built on disk rather than `sieval.tasks` / `sieval.datasets`.
+Re-importing a real task module would re-run `@sieval_task` and trip the
+duplicate-name guard, which is precisely why the five adopting fixtures have to
+clear a registry first — coupling these tests to that would test the fixtures
+again instead of the helper they share. The synthetic package mirrors the one
+structural feature that matters: a lazy `__getattr__` that caches each export in
+the package's own `__dict__`.
+
+AI-Generated Code - Claude Opus 5 (Anthropic)
+"""
+
+import importlib
+import sys
+from collections.abc import Iterator
+
+import pytest
+
+from tests.conftest import ModuleIsolation
+
+_PKG = "module_isolation_probe"
+
+_INIT = """
+__all__ = ["Thing"]
+
+
+def __getattr__(name):
+    if name not in __all__:
+        raise AttributeError(name)
+    import importlib
+
+    module = importlib.import_module(f"{__name__}.thing")
+    value = getattr(module, name)
+    globals()[name] = value
+    return value
+"""
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _probe_package(tmp_path_factory) -> Iterator[None]:
+    """Put a synthetic package with a lazy `__getattr__` on `sys.path`."""
+    root = tmp_path_factory.mktemp("module_isolation")
+    pkg = root / _PKG
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text(_INIT)
+    (pkg / "alpha.py").write_text('VALUE = "alpha"\n')
+    (pkg / "beta.py").write_text('VALUE = "beta"\n')
+    (pkg / "thing.py").write_text("class Thing:\n    pass\n")
+    sys.path.insert(0, str(root))
+    importlib.invalidate_caches()
+    try:
+        yield
+    finally:
+        sys.path.remove(str(root))
+        _purge()
+        importlib.invalidate_caches()
+
+
+def _purge() -> None:
+    for name in [n for n in sys.modules if n == _PKG or n.startswith(f"{_PKG}.")]:
+        del sys.modules[name]
+
+
+@pytest.fixture(autouse=True)
+def _fresh_probe_modules() -> Iterator[None]:
+    """No probe module survives into or out of a test."""
+    _purge()
+    yield
+    _purge()
+
+
+def _import(*suffixes: str):
+    """Import the package plus the named submodules, returning them in order."""
+    return tuple(
+        importlib.import_module(_PKG if not s else f"{_PKG}.{s}")
+        for s in ("", *suffixes)
+    )
+
+
+def test_evict_unbinds_the_parent_attribute():
+    """A dropped module must not stay reachable as an attribute of its parent."""
+    pkg, alpha = _import("alpha")
+    assert pkg.__dict__["alpha"] is alpha  # the import bound it
+
+    isolation = ModuleIsolation((f"{_PKG}.",))
+    isolation.snapshot()
+    isolation.evict()
+
+    assert f"{_PKG}.alpha" not in sys.modules
+    assert "alpha" not in pkg.__dict__, "evicted module still bound on its parent"
+
+
+def test_evict_lets_from_package_import_re_execute_the_module():
+    """`from pkg import submodule` must miss, not hit a dropped copy.
+
+    The import system consults `hasattr(package, name)` before it considers an
+    import, so a parent attribute surviving `evict()` short-circuits the whole
+    point of evicting: the module body never re-executes and a decorator inside
+    it never re-runs against the registry the caller just cleared.
+    """
+    _, alpha = _import("alpha")
+
+    isolation = ModuleIsolation((f"{_PKG}.",))
+    isolation.snapshot()
+    isolation.evict()
+
+    from module_isolation_probe import alpha as reimported
+
+    assert reimported is not alpha, "stale parent attribute served a dropped module"
+    assert sys.modules[f"{_PKG}.alpha"] is reimported
+
+
+def test_restore_rebinds_the_snapshotted_parent_attribute():
+    """After restore, parent attribute and cache agree on the original object."""
+    pkg, alpha = _import("alpha")
+
+    isolation = ModuleIsolation((f"{_PKG}.",))
+    isolation.snapshot()
+    isolation.evict()
+    importlib.import_module(f"{_PKG}.alpha")  # a copy the fixture will discard
+    isolation.restore()
+
+    assert sys.modules[f"{_PKG}.alpha"] is alpha
+    assert pkg.__dict__["alpha"] is alpha, "parent still bound to the discarded copy"
+
+
+def test_restore_unbinds_modules_the_test_imported():
+    """A module imported on top of the snapshot leaves no trace behind."""
+    (pkg,) = _import()
+    assert f"{_PKG}.beta" not in sys.modules  # deliberately outside the snapshot
+
+    isolation = ModuleIsolation((f"{_PKG}.",))
+    isolation.snapshot()
+    importlib.import_module(f"{_PKG}.beta")
+    isolation.restore()
+
+    assert f"{_PKG}.beta" not in sys.modules
+    assert "beta" not in pkg.__dict__, "extra module left bound on its parent"
+
+
+def test_restore_leaves_an_unrelated_same_named_attribute_alone():
+    """The unbind is identity-checked, so it cannot clobber a test's own stub."""
+    (pkg,) = _import()
+    isolation = ModuleIsolation((f"{_PKG}.",))
+    isolation.snapshot()
+    importlib.import_module(f"{_PKG}.beta")
+    sentinel = object()
+    pkg.__dict__["beta"] = sentinel  # e.g. a monkeypatched stand-in
+    isolation.restore()
+
+    assert pkg.__dict__["beta"] is sentinel
+
+
+def test_lazy_export_cache_moves_with_the_modules():
+    """A cached export must not outlive the module copy it was resolved from."""
+    (pkg,) = _import()
+    original = pkg.Thing  # resolved through the lazy __getattr__ and cached
+    original_module = sys.modules[f"{_PKG}.thing"]
+
+    isolation = ModuleIsolation((f"{_PKG}.",), lazy_packages=(_PKG,))
+    isolation.snapshot()
+    isolation.evict()
+    assert "Thing" not in pkg.__dict__, "cached export survived eviction"
+
+    assert pkg.Thing is not original  # re-resolved against the fresh copy
+    isolation.restore()
+
+    assert pkg.__dict__["Thing"] is original, "export outlived its module"
+    assert sys.modules[f"{_PKG}.thing"] is original_module
+
+
+def test_restore_tolerates_a_parent_that_is_gone():
+    """Teardown must not raise when the parent package is no longer cached.
+
+    `restore()` runs after the caller has already put its registries back, so a
+    `KeyError` here would surface as a teardown error on an otherwise green test.
+    """
+    _, alpha = _import("alpha")
+
+    isolation = ModuleIsolation((f"{_PKG}.",))
+    isolation.snapshot()
+    isolation.evict()
+    del sys.modules[_PKG]
+
+    isolation.restore()  # must not raise
+
+    assert sys.modules[f"{_PKG}.alpha"] is alpha
+
+
+def test_exclude_keeps_a_subtree_out_of_scope():
+    """An excluded module is neither evicted nor unbound."""
+    pkg, alpha, beta = _import("alpha", "beta")
+
+    isolation = ModuleIsolation((f"{_PKG}.",), exclude=(f"{_PKG}.beta",))
+    isolation.snapshot()
+    isolation.evict()
+
+    assert f"{_PKG}.alpha" not in sys.modules
+    assert sys.modules[f"{_PKG}.beta"] is beta
+    assert pkg.__dict__["beta"] is beta


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Type

- fix — bug fix or alignment correction

## Summary

- `import_all_tasks()` / `get_task_class()` only re-run a module's `@sieval_task` decorator when `sieval.tasks.{name}` is absent from `sys.modules`, so a registry and its module cache must be cleared **and** restored together.
- Six fixtures clear a task/dataset registry; four guarded only one half. Cleared registry + cached modules ⇒ registration silently no-ops and `get_task_class()` raises `KeyError` (#52). Restored registry + purged modules ⇒ the next `import_all_tasks()` trips the duplicate-name guard.
- Restoring `sys.modules` alone is not enough: dotted-string targets (`monkeypatch.setattr`, `mock.patch`) resolve by **attribute traversal from the root package**, so a child attribute left bound to a discarded copy patches a module nobody uses (this surfaced as the real HF loader being called in `test_ifbench.py`).
- **Commit 1** fixes all four fixtures. **Commit 2** extracts the module surgery into `ModuleIsolation` (`tests/conftest.py`) so one invariant has one home instead of four verbatim copies cross-referencing each other in prose, and adopts it at the fifth site, `tests/unit/cli/conftest.py` (widest autouse scope; also had an unsnapshotted `_TASK_CLASSES`). Registry `clear()`/`update()` stays per-fixture — the subset genuinely differs and was never where the bugs lived. Net −7 lines.
- Extracting surfaced two more defects, fixed once in `restore()`: **extras were never unbound** (38 `sieval.tasks.*` attributes pointed at modules absent from `sys.modules` after `tests/unit/core/tasks/test_meta.py`; now 0), and `sys.modules[parent]` was raw-indexed, so a missing parent would raise `KeyError` from teardown *after* the registry restore had run.
- **Commit 3** (from review) closes the same one-sided guarding on the *other* side of the fixture: `restore()` kept the parent bindings in step, `evict()` did not — so from setup until teardown the parent package still pointed at the copies just discarded. Measured before: **89 test bodies** ran against a dangling or stale binding (47 in `core/tasks/test_meta.py`, 12 in `tasks/test_theoremqa_kshot_base_gen.py`, 30 in `core/datasets/test_meta.py`); now 0. Reachable, not cosmetic — with an earlier file having top-level-imported a task, inside the fixture's own scope `from sieval.tasks import aa_lcr_0shot_gen` returned the pre-evict copy (the import system consults `hasattr` before it considers an import, so the module body never re-executed and `@sieval_task` never re-ran against the registry just cleared — the `KeyError` shape of #52), and `monkeypatch.resolve("sieval.tasks.aa_lcr_0shot_gen")` was not `importlib.import_module(...)`, so a dotted-string patch target would land on a module nobody uses. The identity-checked unbind moves into `_unbind_from_parent()` and both directions call it. Commit 3 also declares `lazy_packages` at the two sites that omitted it (`core/{tasks,datasets}/test_meta.py` — a package left cached is precisely what can hold a class resolved from a copy `restore()` later discards), adds `tests/unit/test_module_isolation.py`, and records why the eponymous-module assertion is deliberately stricter than the lazy export map, which also accepts `"subpkg.module_stem"`.
- **Commit 4** fixes a `ty` error commit 3 introduced and CI could not see: the new test synthesizes its probe package on disk at runtime and puts the root on `sys.path`, so `from module_isolation_probe import alpha` is unresolvable statically. Measured — `ty check sieval scripts tests` exited 1 with that file present and 0 with it moved aside. Suppressed inline rather than rewritten as `importlib.import_module`, because the statement form *is* the assertion: `import_module` resolves through `sys.modules` and would never touch the parent attribute under test (re-verified that the parenthesized form still discriminates — with `_unbind_from_parent()` removed from `evict()`, the test still fails). Inline over a file-scoped `[[tool.ty.overrides]]` entry so a genuinely broken import elsewhere in the file is still reported.
- **Commit 5** closes the gap that hid it. `typecheck` was gated on the `code` paths-filter (`sieval/**`, `scripts/**`, `pyproject.toml`, `pdm.lock`), but `[tool.ty.environment] root = ["./"]` means `ty check` covers `tests/` too — so a test-only PR can break the type check and still report all-green, which is precisely what happened here. Confirmed by construction, not assumption: a file with a deliberate `invalid-return-type` under `tests/unit/` is reported by `ty check`. The trigger now matches `checks` (`code || tests`). `allowed-skips` keeps `typecheck` listed — a docs-only PR still skips it legitimately, and `check` stays the one required context.
- Drops #44's inline `sys.modules.pop` workaround. `test_get_task_class_returns_registered_class` registers its own target, so it asserts identity and no longer depends on whichever task sorts first; the lazy-import **success** branch gets its own test (previously untested — the old test was a `_TASK_CLASSES` cache hit); and the fixture-invariant guard test now also pins the eponymous-module convention across all 37 registered tasks, which `sieval task list` needs for every row.

### Two workarounds in `tests/unit/cli/conftest.py` were tested for removal

Both results are recorded in the code rather than assumed:

- **Downloader exclusion — kept.** A restore cannot replace it: `sieval.cli.dataset.{commands,render}` bind `resolve` at their own import time, outside any scope this fixture controls, pinning the first `_HANDLERS` forever. Removing it sent 4 tests to the real network (runtime 5s → 81s). The comment now explains this instead of only describing the symptom.
- **Suffix-matched lazy-cache clearing — replaced.** It was hiding a third defect: a class cached by a package's lazy `__getattr__` outlives the module copy it came from and stops matching its own `SAMPLE_TO_DATASET` key, so the next `@sieval_task` FK lookup fails with *"No @sieval_dataset found for sample type"*. `ModuleIsolation` now snapshots and restores those caches from each package's `__all__` rather than guessing by name suffix.

Note: the fix suggested in #52 (purge on setup, no restore) only inverts the inconsistency — verified to fail 5 tests in plain file order.

## Related Issues

Closes #52

## Test Plan

### Automated

- [x] Lint/format clean (`ruff check && ruff format --check`)
- [x] Type check clean (`ty check`) — commit 3 broke this and commit 4 fixes it, measured as `ty check sieval scripts tests` (exit 1 → 0)
- [x] Unit tests pass (`pdm run pytest`) — 2570 passed for `tests/unit/` + `tests/integration/`

After commit 5 CI runs `typecheck` on this PR, so the second box above is machine-verified rather than self-reported — on the earlier revisions the job was skipped.

`pytest-randomly` is not a declared dependency and is absent from `pdm.lock`, so `--randomly-seed` was unavailable. Deterministic substitute — random file-order permutations of the registry-touching test files:

| | result |
|---|---|
| after commit 1 | 12/12 green (898 passed each) |
| after commit 2 | 12/12 green (898 passed each) — same orders, unchanged |
| `main` | fails the same orders, 4–14 failures per seed |

Failures on `main` land exactly where predicted: `test_ifbench.py`, `test_c_eval.py`, `test_meta_pilot.py`, `test_get_task_class_returns_registered_class`, `test_sync_meta_index.py`, `test_mbpp.py`.

Additionally: full suite `2641 passed` (the 5 remaining failures are pre-existing in `tests/performance/` + `tests/acceptance/performance/` and reproduce identically on `origin/main` in isolation — 1 × `AttributeError: 'PerfMockDataset' object has no attribute 'select'` and 4 × `ResumeVersionError`; the earlier revision of this section attributed all 5 to the `AttributeError`); six whole-repo traversal orders; each of the 22 task-importing test files swept individually ahead of `test_meta` / `test_meta_pilot` / `test_sync_meta_index`; `scripts/check_preflight.py` 19 PASS / 0 FAIL.

**Commit 3** re-verification. Same substitute method, on an explicitly-listed set — `test_lazy_exports.py`, `test_module_isolation.py`, `core/tasks/test_meta.py`, `core/tasks/test_meta_pilot.py`, `core/datasets/test_meta.py`, `tasks/test_theoremqa_kshot_base_gen.py`, `tasks/test_aa_lcr_0shot_gen.py`, `scripts/test_sync_meta_index.py`, `cli/`, `datasets/test_ifbench.py`, `datasets/test_c_eval.py` (a different set from the 898-test one above, so the counts are not comparable row-to-row):

| | result |
|---|---|
| 10 seeded file-order permutations | 10/10 green (780 passed each) |
| `ModuleIsolation` mutation sweep | 8/8 mutations killed |
| `scripts/check_preflight.py` | 19 PASS / 0 FAIL |

The mutation sweep covers every behaviour of the class, including three that had no coverage at all before commit 3: the extras unbind, the `sys.modules.get(parent)` hardening, and `exclude`. Swapping the identity check for a bare `attr in parent.__dict__` is caught too.

### Manual

- [x] Stale-attribute probe — walks `vars(sieval.tasks)` / `vars(sieval.datasets)` counting attributes whose `sys.modules[name] is not value`. Reads **0** after each of the five sites (was 38 / 1 / 2+2), and `_pytest.monkeypatch.resolve("sieval.tasks.gsm8k_0shot_gen") is importlib.import_module(...)` is now `True` (was `False`).

- [x] Commit 3 widens that probe to the **mid-test** state (after fixture setup, before the test body) and to **lazy-export identity**, which a module-only probe cannot see: 0 dangling or stale bindings at both points across all 2570 tests. Both directions are now asserted by `tests/unit/test_module_isolation.py`, so neither has to be re-run by hand.

Each new assertion was checked against the pre-fix fixture to confirm it actually fails — no decorative assertions.

## Checklist

### Required (all PRs)

- [x] PR title follows conventional format (`type(scope): description`)
- [x] No internal paths, credentials, or personal info in committed files
- [x] AI-generated code has `AI-Generated Code - <model> (<provider>)` in module docstring
- [x] No new upper-layer dependencies added to `core/` — test-only change, `core/` untouched
- [x] Deleted code verified — no remaining call sites depend on it (`_drop_package_modules` kept: still used by two tests directly)


