### PR TITLE
fix(datasets): attribute subpackage exports per module, matching tasks/

### DIFF
--- a/scripts/sync_package_stubs.py
+++ b/scripts/sync_package_stubs.py
@@ -246,7 +246,22 @@ def main() -> int:
         check=args.check,
     )
 
-    # Task subpackages
+    # Task subpackages get their own stub; dataset subpackages deliberately do not.
+    # Generating one per dataset subpackage breaks two ways, because a generated stub
+    # *shadows* the real __init__.py rather than supplementing it:
+    #   - datasets/ruler/__init__.py re-exports helpers from a private module
+    #     (_shared.py), which suffix-based discovery cannot see, so the stub would
+    #     list 2 of its 7 names and hide len_tag/thinking_prefill from type checkers.
+    #   - datasets/downloaders/ is infrastructure, not a benchmark; its API carries no
+    #     dataset suffix at all, so the stub would come out empty and hide resolve().
+    # _iter_subpackage_dirs cannot tell those apart from a benchmark subpackage.
+    #
+    # The loop below is currently inert (no task subpackage is registered) and is kept
+    # for the benchmark subpackages that land here. Note it is not a model to copy:
+    # under the empty-__init__.py rule in sieval/tasks/CLAUDE.md the stub it writes
+    # promises names the empty __init__ never binds, so `sieval.tasks.<sub>.XTask`
+    # type-checks but raises AttributeError. The top-level stub is the one that
+    # matches runtime, and package-level import is the documented entrypoint.
     for subpkg_dir in _iter_subpackage_dirs(TASKS_DIR):
         ok &= sync_stub(
             subpkg_dir / "__init__.pyi",

--- a/scripts/sync_package_stubs.py
+++ b/scripts/sync_package_stubs.py
@@ -255,10 +255,11 @@ def main() -> int:
     # ruler/'s helpers re-exported from _shared.py, and all of downloaders/ (which is
     # infrastructure, not a benchmark). Don't add the symmetric loop.
     #
-    # Not a model to copy either: sieval/tasks/CLAUDE.md mandates an empty subpackage
-    # __init__.py, so the stub below promises names that __init__ never binds —
-    # sieval.tasks.<sub>.XTask type-checks but raises AttributeError. Import task
-    # classes from the top-level package, which is the form the runtime map matches.
+    # Not a model to copy either: per sieval/tasks/CLAUDE.md a task subpackage's
+    # __init__.py is empty, and an empty __init__ binds none of the names this stub
+    # promises — sieval.tasks.<sub>.XTask type-checks but raises AttributeError. The
+    # convention is unenforced, so the stub is right only if the subpackage re-exports.
+    # Import from the top-level package, which is what the runtime map matches.
     for subpkg_dir in _iter_subpackage_dirs(TASKS_DIR):
         ok &= sync_stub(
             subpkg_dir / "__init__.pyi",

--- a/scripts/sync_package_stubs.py
+++ b/scripts/sync_package_stubs.py
@@ -90,11 +90,8 @@ def discover_tasks(package_dir: Path) -> dict[str, str]:
     for name, mod in _discover_task_classes(_iter_module_paths(package_dir)).items():
         _register_export(export_to_module, name, mod, "task")
 
-    # 2) Subpackage task modules — attributed as "subpkg.module_stem" to match the
-    # runtime registry (sieval/tasks/__init__.py). Registering the bare subpackage
-    # name here disagreed with it, which would have emitted `from .subpkg import X`
-    # into the top-level stub while runtime imports `sieval.tasks.subpkg.<module>`.
-    # Latent only because no task subpackage is currently registered.
+    # 2) Subpackage task modules — "subpkg.module_stem", matching the runtime
+    # registry in sieval/tasks/__init__.py. Must stay in sync with it.
     for subpkg_dir in _iter_subpackage_dirs(package_dir):
         subpkg_name = subpkg_dir.name
         for name, mod in _discover_task_classes(_iter_module_paths(subpkg_dir)).items():
@@ -246,22 +243,10 @@ def main() -> int:
         check=args.check,
     )
 
-    # Task subpackages get their own stub; dataset subpackages deliberately do not.
-    # Generating one per dataset subpackage breaks two ways, because a generated stub
-    # *shadows* the real __init__.py rather than supplementing it:
-    #   - datasets/ruler/__init__.py re-exports helpers from a private module
-    #     (_shared.py), which suffix-based discovery cannot see, so the stub would
-    #     list 2 of its 7 names and hide len_tag/thinking_prefill from type checkers.
-    #   - datasets/downloaders/ is infrastructure, not a benchmark; its API carries no
-    #     dataset suffix at all, so the stub would come out empty and hide resolve().
-    # _iter_subpackage_dirs cannot tell those apart from a benchmark subpackage.
-    #
-    # The loop below is currently inert (no task subpackage is registered) and is kept
-    # for the benchmark subpackages that land here. Note it is not a model to copy:
-    # under the empty-__init__.py rule in sieval/tasks/CLAUDE.md the stub it writes
-    # promises names the empty __init__ never binds, so `sieval.tasks.<sub>.XTask`
-    # type-checks but raises AttributeError. The top-level stub is the one that
-    # matches runtime, and package-level import is the documented entrypoint.
+    # Task subpackages only. A generated stub shadows the real __init__.py, so doing
+    # this for dataset subpackages hides whatever suffix-based discovery can't see:
+    # ruler/'s helpers re-exported from _shared.py, and all of downloaders/ (which is
+    # infrastructure, not a benchmark). Don't add the symmetric loop.
     for subpkg_dir in _iter_subpackage_dirs(TASKS_DIR):
         ok &= sync_stub(
             subpkg_dir / "__init__.pyi",

--- a/scripts/sync_package_stubs.py
+++ b/scripts/sync_package_stubs.py
@@ -104,15 +104,6 @@ def discover_tasks(package_dir: Path) -> dict[str, str]:
     return export_to_module
 
 
-def discover_subpackage_tasks(subpkg_dir: Path) -> dict[str, str]:
-    """Discover task exports within a single subpackage directory.
-
-    Returns ``{ClassName: module_stem}`` mapping (module-level, not
-    prefixed with the subpackage name).
-    """
-    return _discover_task_classes(_iter_module_paths(subpkg_dir))
-
-
 def _discover_dataset_classes(
     module_paths: list[Path],
     prefix: str = "",
@@ -250,23 +241,13 @@ def main() -> int:
         check=args.check,
     )
 
-    # Task subpackages only. A generated stub shadows the real __init__.py, so doing
-    # this for dataset subpackages hides whatever suffix-based discovery can't see:
-    # ruler/'s helpers re-exported from _shared.py, and all of downloaders/ (which is
-    # infrastructure, not a benchmark). Don't add the symmetric loop.
-    #
-    # Not a model to copy either: per sieval/tasks/CLAUDE.md a task subpackage's
-    # __init__.py is empty, and an empty __init__ binds none of the names this stub
-    # promises — sieval.tasks.<sub>.XTask type-checks but raises AttributeError. The
-    # convention is unenforced, so the stub is right only if the subpackage re-exports.
-    # Import from the top-level package, which is what the runtime map matches.
-    for subpkg_dir in _iter_subpackage_dirs(TASKS_DIR):
-        ok &= sync_stub(
-            subpkg_dir / "__init__.pyi",
-            render_stub(discover_subpackage_tasks(subpkg_dir)),
-            check=args.check,
-        )
-
+    # Only the two lazy packages get a stub, because only they have a runtime export
+    # map for one to mirror. Subpackages are ordinary packages: their own __init__.py
+    # is their type surface, and a generated .pyi would *shadow* it rather than
+    # supplement it — hiding whatever suffix-based discovery cannot see (ruler/'s
+    # helpers re-exported from _shared.py) or emptying it outright (downloaders/,
+    # which is infrastructure and carries no dataset suffix at all). Don't add a
+    # per-subpackage loop for either package.
     if ok:
         return 0
 

--- a/scripts/sync_package_stubs.py
+++ b/scripts/sync_package_stubs.py
@@ -90,13 +90,15 @@ def discover_tasks(package_dir: Path) -> dict[str, str]:
     for name, mod in _discover_task_classes(_iter_module_paths(package_dir)).items():
         _register_export(export_to_module, name, mod, "task")
 
-    # 2) Subpackage task modules — scan .py files inside each subpackage
+    # 2) Subpackage task modules — attributed as "subpkg.module_stem" to match the
+    # runtime registry (sieval/tasks/__init__.py). Registering the bare subpackage
+    # name here disagreed with it, which would have emitted `from .subpkg import X`
+    # into the top-level stub while runtime imports `sieval.tasks.subpkg.<module>`.
+    # Latent only because no task subpackage is currently registered.
     for subpkg_dir in _iter_subpackage_dirs(package_dir):
         subpkg_name = subpkg_dir.name
-        for name, _mod in _discover_task_classes(
-            _iter_module_paths(subpkg_dir)
-        ).items():
-            _register_export(export_to_module, name, subpkg_name, "task")
+        for name, mod in _discover_task_classes(_iter_module_paths(subpkg_dir)).items():
+            _register_export(export_to_module, name, f"{subpkg_name}.{mod}", "task")
 
     return export_to_module
 
@@ -160,13 +162,13 @@ def discover_datasets(package_dir: Path) -> dict[str, str]:
     for name, mod in _discover_dataset_classes(_iter_module_paths(package_dir)).items():
         _register_export(export_to_module, name, mod, "dataset")
 
-    # 2) Subpackage dataset modules — scan .py files inside each subpackage
+    # 2) Subpackage dataset modules — "subpkg.module_stem", as for tasks above.
     for subpkg_dir in _iter_subpackage_dirs(package_dir):
         subpkg_name = subpkg_dir.name
-        for name, _mod in _discover_dataset_classes(
+        for name, mod in _discover_dataset_classes(
             _iter_module_paths(subpkg_dir)
         ).items():
-            _register_export(export_to_module, name, subpkg_name, "dataset")
+            _register_export(export_to_module, name, f"{subpkg_name}.{mod}", "dataset")
 
     return export_to_module
 

--- a/scripts/sync_package_stubs.py
+++ b/scripts/sync_package_stubs.py
@@ -60,14 +60,17 @@ def _register_export(
 
 def _discover_task_classes(
     module_paths: list[Path],
+    prefix: str = "",
 ) -> dict[str, str]:
     """Scan *module_paths* for public ``*Task`` class definitions.
 
-    Returns ``{ClassName: module_stem}`` mapping.
+    Returns ``{ClassName: module_stem}``, or ``{ClassName: "prefix.module_stem"}`` when
+    *prefix* is given, so the duplicate-export error names the module the caller
+    registers rather than a bare stem.
     """
     export_to_module: dict[str, str] = {}
     for module_path in module_paths:
-        module_name = module_path.stem
+        module_name = f"{prefix}.{module_path.stem}" if prefix else module_path.stem
         module_ast = ast.parse(
             module_path.read_text(encoding="utf-8"),
             filename=str(module_path),
@@ -93,9 +96,10 @@ def discover_tasks(package_dir: Path) -> dict[str, str]:
     # 2) Subpackage task modules — "subpkg.module_stem", matching the runtime
     # registry in sieval/tasks/__init__.py. Must stay in sync with it.
     for subpkg_dir in _iter_subpackage_dirs(package_dir):
-        subpkg_name = subpkg_dir.name
-        for name, mod in _discover_task_classes(_iter_module_paths(subpkg_dir)).items():
-            _register_export(export_to_module, name, f"{subpkg_name}.{mod}", "task")
+        for name, mod in _discover_task_classes(
+            _iter_module_paths(subpkg_dir), prefix=subpkg_dir.name
+        ).items():
+            _register_export(export_to_module, name, mod, "task")
 
     return export_to_module
 
@@ -109,16 +113,20 @@ def discover_subpackage_tasks(subpkg_dir: Path) -> dict[str, str]:
     return _discover_task_classes(_iter_module_paths(subpkg_dir))
 
 
-def _discover_dataset_classes(module_paths: list[Path]) -> dict[str, str]:
+def _discover_dataset_classes(
+    module_paths: list[Path],
+    prefix: str = "",
+) -> dict[str, str]:
     """Scan *module_paths* for public Dataset/DatasetSample/CSVSample class definitions.
 
-    Returns ``{ClassName: module_stem}`` mapping.
+    Returns ``{ClassName: module_stem}``, or ``{ClassName: "prefix.module_stem"}`` when
+    *prefix* is given, as for ``_discover_task_classes``.
     """
     export_to_module: dict[str, str] = {}
     suffixes = ("Dataset", "DatasetSample", "CSVSample")
 
     for module_path in module_paths:
-        module_name = module_path.stem
+        module_name = f"{prefix}.{module_path.stem}" if prefix else module_path.stem
         module_ast = ast.parse(
             module_path.read_text(encoding="utf-8"),
             filename=str(module_path),
@@ -161,11 +169,10 @@ def discover_datasets(package_dir: Path) -> dict[str, str]:
 
     # 2) Subpackage dataset modules — "subpkg.module_stem", as for tasks above.
     for subpkg_dir in _iter_subpackage_dirs(package_dir):
-        subpkg_name = subpkg_dir.name
         for name, mod in _discover_dataset_classes(
-            _iter_module_paths(subpkg_dir)
+            _iter_module_paths(subpkg_dir), prefix=subpkg_dir.name
         ).items():
-            _register_export(export_to_module, name, f"{subpkg_name}.{mod}", "dataset")
+            _register_export(export_to_module, name, mod, "dataset")
 
     return export_to_module
 
@@ -247,6 +254,11 @@ def main() -> int:
     # this for dataset subpackages hides whatever suffix-based discovery can't see:
     # ruler/'s helpers re-exported from _shared.py, and all of downloaders/ (which is
     # infrastructure, not a benchmark). Don't add the symmetric loop.
+    #
+    # Not a model to copy either: sieval/tasks/CLAUDE.md mandates an empty subpackage
+    # __init__.py, so the stub below promises names that __init__ never binds —
+    # sieval.tasks.<sub>.XTask type-checks but raises AttributeError. Import task
+    # classes from the top-level package, which is the form the runtime map matches.
     for subpkg_dir in _iter_subpackage_dirs(TASKS_DIR):
         ok &= sync_stub(
             subpkg_dir / "__init__.pyi",

--- a/sieval/datasets/CLAUDE.md
+++ b/sieval/datasets/CLAUDE.md
@@ -22,5 +22,6 @@ A multi-module benchmark gets a subdirectory; `datasets/__init__.py` lazy-loads 
   `__init__.py` to re-export. Re-export only what other packages import directly.
 - Discovery skips `_*.py`, and the duplicate-export guard applies *within* a
   subpackage — two modules exporting one name is an error, not last-one-wins.
-- No generated `__init__.pyi` here, unlike task subpackages — the hand-written
-  `__init__.py` is the type surface and a stub would shadow it.
+- No generated `__init__.pyi` — the hand-written `__init__.py` is the type surface, and
+  a stub would shadow it rather than supplement it. Only `datasets/__init__.py` itself
+  gets one, because only it has a runtime export map to mirror.

--- a/sieval/datasets/CLAUDE.md
+++ b/sieval/datasets/CLAUDE.md
@@ -27,4 +27,9 @@ a subdirectory, and the top-level `datasets/__init__.py` handles lazy loading.
   duplicate-export guard fires *within* a subpackage too. Two modules in one
   subpackage exporting the same name is an error, not last-one-wins.
 - Private modules (`_*.py`) are skipped by discovery, so per-family internals stay
-  invisible to the registry.
+  invisible to the registry. A subpackage may still re-export from them for other
+  packages to import (`datasets/ruler/__init__.py` does, for helpers a Task needs).
+- A dataset subpackage gets **no** generated `__init__.pyi`, unlike a task
+  subpackage — its hand-written `__init__.py` is its own type surface, and a
+  generated stub would shadow it and hide anything sourced from a private module.
+  `sync_package_stubs.py` has the details; do not add the symmetric loop.

--- a/sieval/datasets/CLAUDE.md
+++ b/sieval/datasets/CLAUDE.md
@@ -13,3 +13,18 @@
 - `deps_group` here is **loader-side** deps; evaluator-side deps stay on the Task.
 - `hf:` sources are revision-pinned; `url:` sources carry per-file `checksums` (sha256).
   Regenerate the meta index (`scripts/sync_meta_index.py`) after editing either.
+
+## Subpackages
+
+Mirrors `sieval/tasks/CLAUDE.md`: a benchmark that needs several loader modules gets
+a subdirectory, and the top-level `datasets/__init__.py` handles lazy loading.
+
+- The top-level registry attributes a subpackage export to `subpkg.module_stem`, so
+  it resolves straight to the defining module and does **not** require the
+  subpackage's `__init__.py` to re-export it. Re-export only what other packages
+  import directly (e.g. helpers a Task needs) — not to satisfy the registry.
+- One consequence worth knowing: because the recorded module is per-file, the
+  duplicate-export guard fires *within* a subpackage too. Two modules in one
+  subpackage exporting the same name is an error, not last-one-wins.
+- Private modules (`_*.py`) are skipped by discovery, so per-family internals stay
+  invisible to the registry.

--- a/sieval/datasets/CLAUDE.md
+++ b/sieval/datasets/CLAUDE.md
@@ -16,20 +16,11 @@
 
 ## Subpackages
 
-Mirrors `sieval/tasks/CLAUDE.md`: a benchmark that needs several loader modules gets
-a subdirectory, and the top-level `datasets/__init__.py` handles lazy loading.
+A multi-module benchmark gets a subdirectory; `datasets/__init__.py` lazy-loads it.
 
-- The top-level registry attributes a subpackage export to `subpkg.module_stem`, so
-  it resolves straight to the defining module and does **not** require the
-  subpackage's `__init__.py` to re-export it. Re-export only what other packages
-  import directly (e.g. helpers a Task needs) — not to satisfy the registry.
-- One consequence worth knowing: because the recorded module is per-file, the
-  duplicate-export guard fires *within* a subpackage too. Two modules in one
-  subpackage exporting the same name is an error, not last-one-wins.
-- Private modules (`_*.py`) are skipped by discovery, so per-family internals stay
-  invisible to the registry. A subpackage may still re-export from them for other
-  packages to import (`datasets/ruler/__init__.py` does, for helpers a Task needs).
-- A dataset subpackage gets **no** generated `__init__.pyi`, unlike a task
-  subpackage — its hand-written `__init__.py` is its own type surface, and a
-  generated stub would shadow it and hide anything sourced from a private module.
-  `sync_package_stubs.py` has the details; do not add the symmetric loop.
+- Registered as `subpkg.module_stem`, so the registry never needs the subpackage's
+  `__init__.py` to re-export. Re-export only what other packages import directly.
+- Discovery skips `_*.py`, and the duplicate-export guard applies *within* a
+  subpackage — two modules exporting one name is an error, not last-one-wins.
+- No generated `__init__.pyi` here, unlike task subpackages — the hand-written
+  `__init__.py` is the type surface and a stub would shadow it.

--- a/sieval/datasets/__init__.py
+++ b/sieval/datasets/__init__.py
@@ -103,13 +103,17 @@ def _discover_dataset_exports() -> dict[str, str]:
         for name in _scan_dataset_exports(module_path):
             _register(name, module_path.stem)
 
-    # 2) Subpackage .py modules — mapped to the subpackage, which re-exports them
-    # from its __init__. (The task registry instead maps to "subpkg.module_stem";
-    # the two conventions differ, see sieval/tasks/__init__.py.)
+    # 2) Subpackage .py modules — mapped as "subpkg.module_stem", matching
+    # sieval/tasks/__init__.py. Resolving straight to the defining module means the
+    # registry does not depend on the subpackage's __init__ re-exporting anything
+    # (sieval/tasks/CLAUDE.md requires that __init__ be empty), and it keeps the
+    # duplicate guard below effective *within* a subpackage — attributing every
+    # module to the bare subpackage name made two same-named exports collide
+    # silently, since the guard only fires when the recorded module differs.
     for subpkg_dir in _iter_subpackage_dirs():
         for module_path in _iter_module_paths_in(subpkg_dir):
             for name in _scan_dataset_exports(module_path):
-                _register(name, subpkg_dir.name)
+                _register(name, f"{subpkg_dir.name}.{module_path.stem}")
 
     return export_to_module
 

--- a/sieval/datasets/__init__.py
+++ b/sieval/datasets/__init__.py
@@ -76,7 +76,12 @@ def _scan_dataset_exports(module_path: Path) -> list[str]:
 
 
 def _discover_dataset_exports() -> dict[str, str]:
-    """Map each export name to the module ``__getattr__`` should import it from."""
+    """Map each export name to the module ``__getattr__`` should import it from.
+
+    ``scripts/sync_package_stubs.py`` reimplements this scan deliberately — the stub
+    generator must not import the package it generates stubs for — so the two have to
+    agree for the generated ``.pyi`` to match runtime resolution.
+    """
     export_to_module: dict[str, str] = {}
 
     def _register(export_name: str, module_name: str) -> None:
@@ -97,7 +102,7 @@ def _discover_dataset_exports() -> dict[str, str]:
     # __init__.py. Resolving to the defining module keeps the registry independent of
     # what the subpackage's __init__ re-exports, and keeps _register's guard effective
     # within a subpackage (the bare subpackage name made same-named exports collide
-    # silently). scripts/sync_package_stubs.py must agree.
+    # silently).
     for subpkg_dir in _iter_subpackage_dirs():
         for module_path in _iter_module_paths_in(subpkg_dir):
             for name in _scan_dataset_exports(module_path):

--- a/sieval/datasets/__init__.py
+++ b/sieval/datasets/__init__.py
@@ -56,11 +56,8 @@ def _is_typeddict_call(node: ast.AST) -> bool:
 
 
 def _scan_dataset_exports(module_path: Path) -> list[str]:
-    """Return public dataset export names defined in *module_path* (AST only).
-
-    Classes whose name ends in one of ``_DATASET_EXPORT_SUFFIXES``, plus
-    module-level ``X = TypedDict(...)`` assignments with such a name.
-    """
+    """Return public ``_DATASET_EXPORT_SUFFIXES``-suffixed classes and ``TypedDict``
+    assignments defined in *module_path* (AST only)."""
     tree = ast.parse(module_path.read_text(encoding="utf-8"), filename=str(module_path))
 
     names: list[str] = []
@@ -79,14 +76,7 @@ def _scan_dataset_exports(module_path: Path) -> list[str]:
 
 
 def _discover_dataset_exports() -> dict[str, str]:
-    """Map each export name to the module ``__getattr__`` should import it from.
-
-    Both passes share one scanner, so they cannot drift apart on what counts as an
-    export. ``scripts/sync_package_stubs.py`` reimplements this scan deliberately —
-    the stub generator must not import the package it generates stubs for — so the
-    two implementations have to agree for the generated ``.pyi`` to match runtime
-    resolution.
-    """
+    """Map each export name to the module ``__getattr__`` should import it from."""
     export_to_module: dict[str, str] = {}
 
     def _register(export_name: str, module_name: str) -> None:
@@ -103,13 +93,11 @@ def _discover_dataset_exports() -> dict[str, str]:
         for name in _scan_dataset_exports(module_path):
             _register(name, module_path.stem)
 
-    # 2) Subpackage .py modules — mapped as "subpkg.module_stem", matching
-    # sieval/tasks/__init__.py. Resolving straight to the defining module means the
-    # registry does not depend on the subpackage's __init__ re-exporting anything
-    # (sieval/tasks/CLAUDE.md requires that __init__ be empty), and it keeps the
-    # duplicate guard below effective *within* a subpackage — attributing every
-    # module to the bare subpackage name made two same-named exports collide
-    # silently, since the guard only fires when the recorded module differs.
+    # 2) Subpackage .py modules — "subpkg.module_stem", matching sieval/tasks/
+    # __init__.py. Resolving to the defining module keeps the registry independent of
+    # what the subpackage's __init__ re-exports, and keeps _register's guard effective
+    # within a subpackage (the bare subpackage name made same-named exports collide
+    # silently). scripts/sync_package_stubs.py must agree.
     for subpkg_dir in _iter_subpackage_dirs():
         for module_path in _iter_module_paths_in(subpkg_dir):
             for name in _scan_dataset_exports(module_path):

--- a/sieval/datasets/__init__.pyi
+++ b/sieval/datasets/__init__.pyi
@@ -117,7 +117,7 @@ from .openbookqa import (
     OpenBookQADataset,
     OpenBookQADatasetSample,
 )
-from .ruler import (
+from .ruler.ruler import (
     RulerDataset,
     RulerDatasetSample,
 )

--- a/sieval/datasets/ruler/__init__.py
+++ b/sieval/datasets/ruler/__init__.py
@@ -1,7 +1,5 @@
 from ._shared import (
-    RulerTaskSpec,
     len_tag,
-    ruler_task,
     thinking_prefill,
     tokens_to_generate,
 )
@@ -10,9 +8,7 @@ from .ruler import RulerDataset, RulerDatasetSample
 __all__ = [
     "RulerDataset",
     "RulerDatasetSample",
-    "RulerTaskSpec",
     "len_tag",
-    "ruler_task",
-    "tokens_to_generate",
     "thinking_prefill",
+    "tokens_to_generate",
 ]

--- a/sieval/datasets/ruler/__init__.py
+++ b/sieval/datasets/ruler/__init__.py
@@ -1,14 +1,8 @@
-from ._shared import (
-    len_tag,
-    thinking_prefill,
-    tokens_to_generate,
-)
-from .ruler import RulerDataset, RulerDatasetSample
+from ._shared import len_tag, thinking_prefill
+from .ruler import RulerDatasetSample
 
 __all__ = [
-    "RulerDataset",
     "RulerDatasetSample",
     "len_tag",
     "thinking_prefill",
-    "tokens_to_generate",
 ]

--- a/sieval/tasks/CLAUDE.md
+++ b/sieval/tasks/CLAUDE.md
@@ -23,7 +23,7 @@ Class: `<Benchmark><ShotType><Mode>Task` — words for shot count (`ZeroShot`, `
 
 ## Key Rules
 
-- ≥ 5 task files per benchmark → subdirectory with an empty `__init__.py` (lazy loading is handled by the top-level `tasks/__init__.py`).
+- ≥ 5 task files per benchmark → subdirectory with an empty `__init__.py` (lazy loading is handled by the top-level `tasks/__init__.py`). Empty on purpose: nothing imports a task class by name — the registry resolves it through the top-level package — so the subpackage needs no type surface of its own, and leaving it empty keeps exactly one import path per task. Contrast `sieval/datasets/`, whose subpackages do re-export, because tasks import them directly.
 - Subpackage shared base module: file named `_base.py` (private module), classes inside without underscore prefix (package-internal public API, e.g. `from ._base import XxxTask`).
 - General code-quality + layer rules live in `.claude/rules/tasks.md`.
 

--- a/tests/unit/datasets/test_ruler.py
+++ b/tests/unit/datasets/test_ruler.py
@@ -7,7 +7,7 @@ group (tiktoken / wonderwords / scipy) — they are skipped when unavailable.
 
 import pytest
 
-from sieval.datasets.ruler import tokens_to_generate
+from sieval.datasets.ruler._shared import tokens_to_generate
 
 try:
     import tiktoken as _tiktoken  # noqa: F401
@@ -21,8 +21,12 @@ _needs_ruler_deps = pytest.mark.skipif(
 )
 
 if _ruler_deps:
-    from sieval.datasets.ruler import RulerDataset, RulerDatasetSample
-    from sieval.datasets.ruler.ruler import _stamp, _subtask_data_path
+    from sieval.datasets.ruler.ruler import (
+        RulerDataset,
+        RulerDatasetSample,
+        _stamp,
+        _subtask_data_path,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_lazy_exports.py
+++ b/tests/unit/test_lazy_exports.py
@@ -146,6 +146,22 @@ def test_access_export_triggers_lazy_import(
     assert package.__dict__[sample_export] is dummy_value
 
 
+def _read_stub_import_map(stub_path: Path) -> dict[str, str]:
+    """Map each name the stub exports to the relative module it imports it from."""
+    module_ast = ast.parse(
+        stub_path.read_text(encoding="utf-8"),
+        filename=str(stub_path),
+    )
+    import_map: dict[str, str] = {}
+    for node in module_ast.body:
+        if isinstance(node, ast.ImportFrom) and node.level == 1 and node.module:
+            for alias in node.names:
+                import_map[alias.asname or alias.name] = node.module
+    if not import_map:
+        raise AssertionError(f"{stub_path} declares no relative imports")
+    return import_map
+
+
 @pytest.mark.parametrize("package_name", ["sieval.tasks", "sieval.datasets"])
 def test_stub_exports_match_runtime_exports(package_name: str) -> None:
     package = importlib.import_module(package_name)
@@ -153,3 +169,33 @@ def test_stub_exports_match_runtime_exports(package_name: str) -> None:
     assert package_file is not None
     stub_exports = _read_stub_all(Path(package_file).with_suffix(".pyi"))
     assert stub_exports == package.__all__
+
+
+@pytest.mark.parametrize("package_name", ["sieval.tasks", "sieval.datasets"])
+def test_stub_import_targets_match_runtime_module_map(package_name: str) -> None:
+    """The stub's per-name import target must match the runtime map's values.
+
+    Two mechanisms already guard neighbouring halves of this contract, and both
+    miss module *attribution*:
+
+    - ``test_stub_exports_match_runtime_exports`` compares only the export
+      *names* (both sides render them from their own scan's keys).
+    - ``check_preflight``'s ``check_tasks`` / ``check_datasets`` build their fqn
+      from the runtime map alone, so they never see the stub's opinion.
+
+    So a stub attributing an export to the wrong module ships silently: ty then
+    resolves ``from sieval.datasets import X`` through a module that does not
+    define ``X``, while runtime resolution is fine. The stub generator
+    reimplements the discovery scan on purpose (it must not import the package it
+    generates stubs for), which is exactly what makes the two able to drift.
+    """
+    package = importlib.import_module(package_name)
+    package_file = package.__file__
+    assert package_file is not None
+
+    stub_map = _read_stub_import_map(Path(package_file).with_suffix(".pyi"))
+    # Read through __dict__: it is a module-level global, and the .pyi deliberately
+    # does not declare it, so plain attribute access would not type-check.
+    runtime_map = dict(package.__dict__["_EXPORT_TO_MODULE"])
+
+    assert stub_map == runtime_map

--- a/tests/unit/test_lazy_exports.py
+++ b/tests/unit/test_lazy_exports.py
@@ -147,7 +147,7 @@ def test_access_export_triggers_lazy_import(
 
 
 def _read_stub_import_map(stub_path: Path) -> dict[str, str]:
-    """Map each name the stub exports to the relative module it imports it from."""
+    """Map each name the stub imports to the relative module it comes from."""
     module_ast = ast.parse(
         stub_path.read_text(encoding="utf-8"),
         filename=str(stub_path),

--- a/tests/unit/test_lazy_exports.py
+++ b/tests/unit/test_lazy_exports.py
@@ -175,27 +175,17 @@ def test_stub_exports_match_runtime_exports(package_name: str) -> None:
 def test_stub_import_targets_match_runtime_module_map(package_name: str) -> None:
     """The stub's per-name import target must match the runtime map's values.
 
-    Two mechanisms already guard neighbouring halves of this contract, and both
-    miss module *attribution*:
-
-    - ``test_stub_exports_match_runtime_exports`` compares only the export
-      *names* (both sides render them from their own scan's keys).
-    - ``check_preflight``'s ``check_tasks`` / ``check_datasets`` build their fqn
-      from the runtime map alone, so they never see the stub's opinion.
-
-    So a stub attributing an export to the wrong module ships silently: ty then
-    resolves ``from sieval.datasets import X`` through a module that does not
-    define ``X``, while runtime resolution is fine. The stub generator
-    reimplements the discovery scan on purpose (it must not import the package it
-    generates stubs for), which is exactly what makes the two able to drift.
+    Nothing else compares them: the test above checks only export *names*, and
+    preflight builds its fqn from the runtime map alone. So a stub pointing an
+    export at the wrong module ships silently, and ty resolves
+    ``from sieval.datasets import X`` through a module that never defines it.
     """
     package = importlib.import_module(package_name)
     package_file = package.__file__
     assert package_file is not None
 
     stub_map = _read_stub_import_map(Path(package_file).with_suffix(".pyi"))
-    # Read through __dict__: it is a module-level global, and the .pyi deliberately
-    # does not declare it, so plain attribute access would not type-check.
+    # Via __dict__ because the .pyi deliberately does not declare this global.
     runtime_map = dict(package.__dict__["_EXPORT_TO_MODULE"])
 
     assert stub_map == runtime_map


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Type

- fix — resolve a three-way disagreement on subpackage export attribution, and
  pin it with the test that would have caught it

## Summary

Three sites resolve subpackage exports for the lazy registries, and they did
not agree:

| Site | Recorded module |
| --- | --- |
| `sieval/tasks/__init__.py:76` (runtime) | `subpkg.module_stem` |
| `scripts/sync_package_stubs.py:99` (top-level task stub) | bare `subpkg` |
| `sieval/datasets/__init__.py` + `sync_package_stubs.py:169` | bare `subpkg` |

Rows 1 and 2 are a **real divergence within the task side** — latent only
because no task subpackage is currently registered. The first one to land
would have put `from .subpkg import X` in the stub while runtime imports
`sieval.tasks.subpkg.<module>`.

Settle on `subpkg.module_stem` everywhere. That is the form the documented
rule requires: `sieval/tasks/CLAUDE.md` mandates an **empty** subpackage
`__init__.py`, and an empty `__init__` cannot re-export anything, so the
registry must resolve to the defining module. The dataset side had **no**
documented subpackage convention, which is how the opposite form arrived with
the first real dataset subpackage (`datasets/ruler/`, #11) — so this adds one.

Two concrete bugs fixed:

1. **Silent overwrite.** The duplicate-export guard only fires when the
   recorded module differs, so attributing every module in a subpackage to the
   bare subpackage name let two same-named exports collide with no error.
2. **The stub↔runtime attribution gap had no test.** `test_stub_exports_match_runtime_exports`
   compares only export *names* (each side renders those from its own scan's
   keys), and preflight's `check_tasks`/`check_datasets` build their fqn from
   the *runtime* map alone — so neither ever compares the stub's opinion. A
   stub attributing an export to the wrong module shipped silently, and `ty`
   would resolve `from sieval.datasets import X` through a module that does not
   define `X`.

### Why neither package generates per-subpackage `__init__.pyi`

Only a lazy package has a runtime export map for a stub to mirror. A subpackage is
an ordinary package, so a generated stub describes nothing real — and because a stub
**shadows** the real `__init__.py` instead of supplementing it, it becomes the
authoritative type surface while contradicting runtime. On the dataset side that
breaks two independent ways (both reproduced):

- `datasets/ruler/__init__.py` re-exports from the private `_shared.py`, invisible
  to suffix-based discovery. The generated stub lists only the class exports →
  `len_tag`/`thinking_prefill` become unresolved imports at
  `tasks/ruler_0shot_gen.py:39`.
- `datasets/downloaders/` is infrastructure, not a benchmark, and none of its API
  carries a dataset suffix. The generated stub comes out `__all__ = []`, hiding
  `resolve()` → breaks `cli/_readiness.py` and `cli/dataset/commands.py`.

The task side had the same defect in the opposite direction, so **the loop that
generated those stubs is now deleted** rather than documented. Under the empty
subpackage `__init__.py` that `sieval/tasks/CLAUDE.md` prescribes, the stub promised
names the `__init__` never binds — verified with a scratch subpackage,
`sieval.tasks.<sub>.XTask` type-checks but raises AttributeError while top-level
`sieval.tasks.XTask` resolves correctly. It was inert (zero task subpackages exist,
so no stub was ever emitted and none needed deleting from disk) but armed for the
first one to land. `discover_subpackage_tasks`, which had no other caller, went with it.

`sieval/tasks/CLAUDE.md` now also records *why* that `__init__.py` is empty, which
was stated without a reason and so read as an oversight next to the dataset side:
nothing imports a task class by name — the registry resolves it through the
top-level package — so a task subpackage needs no type surface of its own, and
staying empty keeps exactly one import path per task. Datasets differ because tasks
import them directly (`sieval.datasets` is imported 50× in production, 39 of those
from `sieval/tasks/`; there is no `from sieval.tasks import X` anywhere in production).

### `datasets/ruler/` re-exports narrowed to three

Since the registry no longer depends on them, the 7 names were audited against real
consumers and 4 dropped:

| Dropped | Consumers outside `datasets/ruler/` |
| --- | --- |
| `RulerTaskSpec`, `ruler_task` | none at all — not a task, not the CLI, not a test, not a non-Python file |
| `RulerDataset` | production reads it off the top-level registry; only `tests/unit/datasets/test_ruler.py` took the subpackage path |
| `tokens_to_generate` | test-only, and the other two ruler test modules already import it from `._shared` |

What remains is exactly the three names `tasks/ruler_0shot_gen.py:39` imports:
`RulerDatasetSample`, `len_tag`, `thinking_prefill`. Two test imports were pointed
at the defining module, matching what the sibling ruler test modules already do.

This trim is only safe *because* of the attribution fix above: replaying the old
bare-subpackage attribution against the trimmed tree raises `module
'sieval.datasets.ruler' has no attribute 'RulerDataset'`, so the same trim would
have broken the registry before this PR.

## Related Issues

<!-- none -->

## Test Plan

### Automated

- [x] Lint/format clean (`ruff check && ruff format --check`)
- [x] Type check clean (`ty check sieval scripts tests` → All checks passed)
- [x] Unit tests pass — `pdm run pytest tests/unit -m "not stress"` →
  **2662 passed**
- [x] `sync_package_stubs.py --check` and `sync_meta_index.py --check` clean
- [x] `check_preflight.py` → 19 PASS, 0 FAIL/WARN. Meaningful here:
  `check_datasets` now builds `sieval.datasets.ruler.ruler` from the new map
  and `getattr`s the class, so the dotted fqn is exercised end-to-end.

### Manual

- [x] **Attribution is consistent after the change.** Stub emits
  `from .ruler.ruler import (...)`; runtime map reads
  `{'RulerDataset': 'ruler.ruler', 'RulerDatasetSample': 'ruler.ruler'}`;
  `sieval.datasets.RulerDataset` / `RulerDatasetSample` both resolve.
- [x] **New test is discriminating (mutation).** Repointing one stub import
  line while leaving the exported name set untouched fails **only** the new
  test, with `test_stub_exports_match_runtime_exports` still passing. Verified
  both for a flat module (`.aime_2024` → `.aime_2025`) and for the subpackage
  (`.ruler` → `.ruler.ruler`) — the latter is exactly the half-migrated state
  this PR could have produced.
- [x] **Silent-overwrite hole is really closed.** Added a second module under
  `datasets/ruler/` exporting `RulerDataset`: now raises
  `Duplicate dataset export 'RulerDataset' found in 'ruler.ruler' and
  'ruler.ztmp_dup'`. Replaying the old bare-subpackage logic on the same tree
  overwrites silently. Temp module removed.
- [x] **Subpackage-stub removal is inert.** `sync_package_stubs.py --check` still
  passes and both top-level stubs are byte-identical; `find sieval -name
  __init__.pyi` returns only the two top-level files, before and after.
- [x] **Duplicate-export diagnostics now match runtime.** Two modules in one
  scratch subpackage exporting the same name: generator and runtime both report
  `found in 'ztmpsub.a_0shot_gen' and 'ztmpsub.b_0shot_gen'` (the generator used
  to print bare stems). `discover_subpackage_tasks`' bare-stem contract was
  preserved until its removal.

## Checklist

### Required (all PRs)

- [x] PR title follows conventional format (`type(scope): description`)
- [x] No internal paths, credentials, or personal info in committed files
- [x] AI-generated code has `AI-Generated Code - <model> (<provider>)` in
  module docstring — extends existing marked files, markers unchanged
- [x] No new upper-layer dependencies added to `core/`
- [x] Deleted code verified — `discover_subpackage_tasks` and the per-subpackage
  stub loop are deleted; grepped for dangling references (none in `sieval/`,
  `scripts/`, `tests/`, `docs/`, `.pre-commit-config.yaml`) and confirmed no
  subpackage `__init__.pyi` existed on disk to clean up. The four dropped
  `datasets/ruler/` re-exports were each checked for consumers first.

### If: Breaking Change

- [x] Not breaking for users: `_EXPORT_TO_MODULE` and the generated `.pyi` are
  internal to lazy loading. Public access (`from sieval.datasets import
  RulerDataset`) is unchanged, and both packages' `__all__` are byte-identical
  before and after.
- [x] Existing tests updated to reflect new behavior — only import paths:
  `tests/unit/datasets/test_ruler.py` now takes `RulerDataset` from
  `.ruler.ruler` and `tokens_to_generate` from `._shared`. No assertion changed;
  **2662 passed** throughout, which is the point of the new test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

