### PR TITLE
fix(deps): lock the hle extra, refresh stale test fixtures

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 
 [metadata]
-groups = ["default", "dev", "drop", "ifbench", "ifeval", "math", "ruler", "ruler-gen", "t-eval", "test"]
+groups = ["default", "dev", "drop", "hle", "ifbench", "ifeval", "math", "ruler", "ruler-gen", "t-eval", "test"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
 content_hash = "sha256:899bce963a336ff3a384964c4b3ea00e426acb8e06249892f7adfa918f4de64e"
@@ -1674,7 +1674,7 @@ name = "numpy"
 version = "2.2.0"
 requires_python = ">=3.10"
 summary = "Fundamental package for array computing in Python"
-groups = ["default", "drop", "ruler", "t-eval"]
+groups = ["default", "drop", "hle", "ruler", "t-eval"]
 files = [
     {file = "numpy-2.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:cff210198bb4cae3f3c100444c5eaa573a823f05c253e7188e1362a5555235b3"},
     {file = "numpy-2.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:58b92a5828bd4d9aa0952492b7de803135038de47343b2aa3cc23f3b71a3dc4e"},

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -894,7 +894,11 @@ def require_available_memory_gb(min_gb: float) -> None:
 async def write_completed_samples(
     root: Path, n_completed: int, shard_samples: int = 256
 ) -> None:
-    """Write n_completed FINAL contexts to disk via TaskSaver."""
+    """Write n_completed FINAL contexts to disk via TaskSaver.
+
+    Stamps ``meta.json`` first, as a real run does at start, so the partial
+    run this fabricates is resumable under the resume version gate.
+    """
     saver = TaskSaver(
         root_dir=root,
         shard_samples=shard_samples,
@@ -902,6 +906,7 @@ async def write_completed_samples(
         write_buffer_size=max(n_completed + 1, 64),
         write_buffer_flush_interval=9999.0,
     )
+    await saver.write_run_meta()
     for i in range(n_completed):
         ctx = _make_bench_ctx(i, TaskStage.FINAL)
         saver._update_manifest_entry(ctx)

--- a/tests/performance/test_dataset_loading.py
+++ b/tests/performance/test_dataset_loading.py
@@ -166,10 +166,10 @@ class TestLargePayloadSamples:
 
 
 class TestDatasetOperations:
-    """Benchmark select/shuffle operations."""
+    """Benchmark slice/shuffle operations."""
 
-    def test_dataset_select_and_shuffle(self) -> None:
-        """select() and shuffle() on 50k-sample dataset."""
+    def test_dataset_slice_and_shuffle(self) -> None:
+        """slice() and shuffle() on 50k-sample dataset."""
         n = 50000
         samples = [{"question": f"Q{i}", "answer": f"A{i}"} for i in range(n)]
         hf_ds = HFDataset.from_list(samples)
@@ -177,19 +177,19 @@ class TestDatasetOperations:
         dataset = PerfMockDataset.__new__(PerfMockDataset)
         dataset._dataset_dict = ds_dict
 
-        timer_select = PerfTimer()
-        with timer_select:
-            dataset.select(1000)
+        timer_slice = PerfTimer()
+        with timer_slice:
+            dataset.slice(1000)
 
         timer_shuffle = PerfTimer()
         with timer_shuffle:
             dataset.shuffle(seed=42)
 
         print(
-            f"PERF: select={timer_select.elapsed:.4f}s, "
+            f"PERF: slice={timer_slice.elapsed:.4f}s, "
             f"shuffle={timer_shuffle.elapsed:.4f}s"
         )
-        total = timer_select.elapsed + timer_shuffle.elapsed
+        total = timer_slice.elapsed + timer_shuffle.elapsed
         assert total < 3.0, f"Dataset operations too slow: {total:.3f}s"
 
 


### PR DESCRIPTION
## Type

- fix — bug fix or alignment correction

## Summary

Three blockers surfaced by the 0.7.0 release preflight. None were caught by CI, which runs only `tests/unit` ([ci.yml:107](../blob/main/.github/workflows/ci.yml#L107)).

- **`pdm.lock` was missing the `hle` group** — user-facing install break. `pyproject.toml` declares `hle = ["numpy<=2.2"]` (landed with HLE in #43) but the lock's `[metadata] groups` omitted it, so `pdm install -G hle` failed with `Requested groups not in lockfile: hle`. Anyone installing `sieval[hle]` to run the HLE task hit this.
- **`write_completed_samples()` fabricated a partial run with no `meta.json`**, so every resume fixture built on it tripped the resume version gate (#37) and aborted fail-closed. It now calls `TaskSaver.write_run_meta()` first, exactly as a real run does at start — the fabricated run becomes indistinguishable from a genuinely interrupted one. The gate was behaving correctly; the fixture predated it.
- **`test_dataset_select_and_shuffle` still called `Dataset.select()`**, renamed to `slice()` in #7. Renamed the call and its labels.

## Related Issues

Refs #43, #37, #7.

## Test Plan

### Automated

- [x] Lint/format clean (`ruff check && ruff format --check`) — only complaint is generated, gitignored `sieval/_version.py`
- [x] Type check clean (`ty check`)
- [x] Unit tests pass — `tests/unit tests/integration tests/acceptance`: **2724 passed**, was 1 failed / 2723 passed
- [x] `tests/performance`: **66 passed**, was 1 failed / 65 passed
- [x] `check_preflight.py --level deep`: zero `[FAIL]`, was 1 `[FAIL]` on `check_deps -G hle`

### Manual

- [x] Verified the `pdm.lock` diff per `.claude/rules/deps.md`: only the two `groups` lists changed. `numpy` was already locked via other groups and did not drift; no packages added or bumped.

## Checklist

### Required (all PRs)

- [x] PR title follows conventional format (`type(scope): description`)
- [x] No internal paths, credentials, or personal info in committed files
- [x] AI-generated code has `AI-Generated Code - <model> (<provider>)` in module docstring — n/a, no new modules
- [x] No new upper-layer dependencies added to `core/`
- [x] Deleted code verified — no remaining call sites depend on it (grepped `.select(` across `tests/`; no stale callers remain)

### If: New Dependency

- [x] Added to correct PDM dependency group — no new dependency; locks an already-declared group

## Note for reviewers

One unrelated flake is left untouched: `test_io_overhead.py::test_dependency_loading_overhead` asserts a wall-clock overhead ratio and fails under machine load, but passes 3/3 in isolation. It is pre-existing, outside CI and outside the release test command, so it is not folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)