### PR TITLE
ci: run integration + acceptance tests, stabilize a flaky perf gate

### DIFF
--- a/.claude/commands/sieval-release.md
+++ b/.claude/commands/sieval-release.md
@@ -39,28 +39,19 @@ ty check
 gh pr list --state open --limit 20     # list for user review
 ```
 
-`-m "not benchmark"` holds the wall-clock gates back for the next step. They
-assert on elapsed time, so running them beside `ruff` / `ty` / another pytest
-process would measure this batch's load rather than the code.
-
-Then run the benchmark gate on its own — serially, nothing else in flight:
+Then the wall-clock gates, alone — CI deselects `benchmark`, so this is the only
+place they run. Serially and without `--cov`: both other load and the coverage
+tracer distort what they measure.
 
 ```bash
 SIEVAL_BENCHMARK_ARTIFACT_DIR=./outputs/benchmarks \
 python -m pytest -m benchmark -q -s
 ```
 
-This is where the throughput gate is enforced: CI deselects `benchmark`, because
-its thresholds are calibrated on a dedicated box and a shared runner cannot hold
-them. The release is therefore the only place they get checked — do not skip it,
-and do not add `--cov` (the tracer skews the latency being measured).
-`outputs/` is gitignored, so the artifact does not dirty the release tree.
-
-Report the `SiEval Benchmark Summary` table, which prints at the very end of the
-run (engine `INFO`/`WARNING` lines come first — read the tail, or filter with
-`grep -vE 'INFO|WARNING'`). `outputs/benchmarks/benchmark_summary.json` holds the
-same numbers machine-readably; quote its per-scenario SPS/efficiency in the
-release report so the release has a recorded performance baseline.
+Report the `SiEval Benchmark Summary` table (printed last, after the engine's log
+lines) as the release's performance baseline; the same numbers land in
+gitignored `outputs/benchmarks/benchmark_summary.json`. A breach can just mean a
+busy box — re-run idle before calling it a regression.
 
 On failure, re-run on an idle machine before concluding regression: a breach can
 mean the box was busy rather than that the code got slower. See `tests/README.md`

--- a/.claude/commands/sieval-release.md
+++ b/.claude/commands/sieval-release.md
@@ -32,12 +32,39 @@ git fetch origin main
 # local main must match remote
 [ "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)" ]
 
-python -m pytest tests/unit tests/integration tests/acceptance --tb=short -q
+python -m pytest tests/unit tests/integration tests/acceptance -m "not benchmark" --tb=short -q
 ruff check .
 ty check
 
 gh pr list --state open --limit 20     # list for user review
 ```
+
+`-m "not benchmark"` holds the wall-clock gates back for the next step. They
+assert on elapsed time, so running them beside `ruff` / `ty` / another pytest
+process would measure this batch's load rather than the code.
+
+Then run the benchmark gate on its own — serially, nothing else in flight:
+
+```bash
+SIEVAL_BENCHMARK_ARTIFACT_DIR=./outputs/benchmarks \
+python -m pytest -m benchmark -q -s
+```
+
+This is where the throughput gate is enforced: CI deselects `benchmark`, because
+its thresholds are calibrated on a dedicated box and a shared runner cannot hold
+them. The release is therefore the only place they get checked — do not skip it,
+and do not add `--cov` (the tracer skews the latency being measured).
+`outputs/` is gitignored, so the artifact does not dirty the release tree.
+
+Report the `SiEval Benchmark Summary` table, which prints at the very end of the
+run (engine `INFO`/`WARNING` lines come first — read the tail, or filter with
+`grep -vE 'INFO|WARNING'`). `outputs/benchmarks/benchmark_summary.json` holds the
+same numbers machine-readably; quote its per-scenario SPS/efficiency in the
+release report so the release has a recorded performance baseline.
+
+On failure, re-run on an idle machine before concluding regression: a breach can
+mean the box was busy rather than that the code got slower. See `tests/README.md`
+for the marker's contract.
 
 Also collect changes since last tag:
 
@@ -47,7 +74,7 @@ git log $PREV_TAG..HEAD --format="%h %s" --no-merges
 git diff $PREV_TAG..HEAD --stat
 ```
 
-If working tree is dirty, not on main, tests/lint fail — stop and report.
+If working tree is dirty, not on main, tests/lint/benchmark fail — stop and report.
 If there are open PRs — list them and ask the user whether to include or defer.
 
 ### 2. ReferenceImpl Sanity Check

--- a/.claude/commands/sieval-release.md
+++ b/.claude/commands/sieval-release.md
@@ -53,10 +53,6 @@ lines) as the release's performance baseline; the same numbers land in
 gitignored `outputs/benchmarks/benchmark_summary.json`. A breach can just mean a
 busy box — re-run idle before calling it a regression.
 
-On failure, re-run on an idle machine before concluding regression: a breach can
-mean the box was busy rather than that the code got slower. See `tests/README.md`
-for the marker's contract.
-
 Also collect changes since last tag:
 
 ```bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,9 +102,8 @@ jobs:
         run: pdm install --check --frozen-lockfile ${{ env.INSTALL_GROUPS }}
       - name: Preflight (registration, version, deps, links, meta-drift)
         run: pdm run python scripts/check_preflight.py
-      # `benchmark` is deselected because those gates assert wall-clock
-      # throughput calibrated on a dedicated box; a shared runner cannot hold
-      # them. Everything else here is deterministic.
+      # `benchmark` deselected: shared runners cannot hold wall-clock
+      # thresholds calibrated on a dedicated box. The rest is deterministic.
       - name: Unit + integration + acceptance tests + coverage
         run: >-
           pdm run python -m pytest tests/unit tests/integration tests/acceptance

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,9 +102,13 @@ jobs:
         run: pdm install --check --frozen-lockfile ${{ env.INSTALL_GROUPS }}
       - name: Preflight (registration, version, deps, links, meta-drift)
         run: pdm run python scripts/check_preflight.py
-      - name: Unit tests + coverage
+      # `benchmark` is deselected because those gates assert wall-clock
+      # throughput calibrated on a dedicated box; a shared runner cannot hold
+      # them. Everything else here is deterministic.
+      - name: Unit + integration + acceptance tests + coverage
         run: >-
-          pdm run python -m pytest tests/unit -m "not stress"
+          pdm run python -m pytest tests/unit tests/integration tests/acceptance
+          -m "not stress and not benchmark"
           --cov --cov-report=xml -q
       - name: Upload coverage (advisory)
         if: always()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -228,10 +228,7 @@ also_copy = [
 [tool.pytest]
 markers = [
   "stress: resource-intensive tests (run with: pytest -m stress)",
-  # Wall-clock throughput gates. Their thresholds are calibrated on a dedicated
-  # box, so shared CI runners cannot hold them; CI deselects this marker while
-  # a plain local `pytest` still runs them.
-  "benchmark: wall-clock throughput benchmarks, excluded from CI",
+  "benchmark: wall-clock throughput gates, excluded from CI (see tests/README.md)",
 ]
 testpaths = [
   "tests/unit",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -226,7 +226,13 @@ also_copy = [
 ]
 
 [tool.pytest]
-markers = ["stress: resource-intensive tests (run with: pytest -m stress)"]
+markers = [
+  "stress: resource-intensive tests (run with: pytest -m stress)",
+  # Wall-clock throughput gates. Their thresholds are calibrated on a dedicated
+  # box, so shared CI runners cannot hold them; CI deselects this marker while
+  # a plain local `pytest` still runs them.
+  "benchmark: wall-clock throughput benchmarks, excluded from CI",
+]
 testpaths = [
   "tests/unit",
   "tests/integration",

--- a/tests/README.md
+++ b/tests/README.md
@@ -126,6 +126,10 @@ python -m pytest tests/acceptance/ -v -s
 SIEVAL_BENCHMARK_ARTIFACT_DIR=./outputs/benchmarks \
 python -m pytest tests/acceptance/ -v -s
 
+# What CI runs: everything deterministic, benchmarks deselected
+python -m pytest tests/unit tests/integration tests/acceptance \
+  -m "not stress and not benchmark" --cov -q
+
 # Performance diagnostic benchmarks (default excludes stress)
 python -m pytest tests/performance/ -v
 
@@ -135,6 +139,20 @@ python -m pytest tests/performance/ -m "not stress" -v
 # Run only stress tests (intentional profiling)
 python -m pytest tests/performance/ -m stress -v
 
+# Run only the wall-clock throughput gates
+python -m pytest -m benchmark -v -s
+```
+
+### Markers
+
+| Marker | Meaning |
+| --- | --- |
+| `stress` | Resource-intensive profiling runs. Excluded by default via `addopts`; opt in with `-m stress`. |
+| `benchmark` | Wall-clock throughput gates whose thresholds are calibrated on a dedicated box. A plain local `pytest` runs them; **CI deselects them**, because a shared runner cannot hold those thresholds and the coverage tracer skews the latency they measure. |
+
+A `benchmark`-marked test asserts on *time*, so treat a failure as "investigate on an idle machine" rather than an automatic regression. `tests/acceptance/` holds exactly one such test (`test_benchmark_scenarios`); its other nine are deterministic checks of the regression-detection helper and do run in CI.
+
+```bash
 # Single file
 python -m pytest tests/integration/resume/test_advanced.py -v
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -148,9 +148,9 @@ python -m pytest -m benchmark -v -s
 | Marker | Meaning |
 | --- | --- |
 | `stress` | Resource-intensive profiling runs. Excluded by default via `addopts`; opt in with `-m stress`. |
-| `benchmark` | Wall-clock throughput gates whose thresholds are calibrated on a dedicated box. A plain local `pytest` runs them; **CI deselects them**, because a shared runner cannot hold those thresholds and the coverage tracer skews the latency they measure. |
+| `benchmark` | Wall-clock throughput gates, calibrated on a dedicated box. A plain local `pytest` runs them; **CI deselects them** (a shared runner cannot hold the thresholds, and `--cov` skews the latency they measure), so `/sieval-release` is where they are enforced. |
 
-A `benchmark`-marked test asserts on *time*, so treat a failure as "investigate on an idle machine" rather than an automatic regression. `tests/acceptance/` holds exactly one such test (`test_benchmark_scenarios`); its other nine are deterministic checks of the regression-detection helper and do run in CI.
+Because these assert on *time*, treat a failure as "re-run idle" before calling it a regression. `tests/acceptance/` holds one (`test_benchmark_scenarios`); its other nine are deterministic and do run in CI.
 
 ```bash
 # Single file

--- a/tests/acceptance/performance/test_performance_acceptance.py
+++ b/tests/acceptance/performance/test_performance_acceptance.py
@@ -445,6 +445,7 @@ def _check_regressions(
 class TestBenchmarkSummary:
     """Acceptance tests: realistic scenarios with structured reporting."""
 
+    @pytest.mark.benchmark
     @pytest.mark.anyio
     async def test_benchmark_scenarios(self, tmp_path: Path) -> None:
         """Run all benchmark scenarios and produce summary report."""

--- a/tests/performance/test_io_overhead.py
+++ b/tests/performance/test_io_overhead.py
@@ -27,10 +27,7 @@ from tests.conftest import (
 # ===================================================================
 # Helpers
 # ===================================================================
-# How many times a timed hydration is repeated before its minimum is taken.
-# Relevant only where the metric is a ratio of two sub-100ms measurements,
-# which single-shot timing cannot measure stably. See
-# TestLoaderHydrationPerformance.test_dependency_loading_overhead.
+# Samples taken per timed arm, for metrics too short to measure single-shot.
 _TIMING_REPEATS = 5
 
 
@@ -239,12 +236,10 @@ class TestLoaderHydrationPerformance:
         Writes snapshots at each stage, then hydrates with all dependencies.
         Compares against single-stage-only hydration.
 
-        Each arm is hydrated ``_TIMING_REPEATS`` times and compared on its
-        minimum. One hydration takes ~20ms, so timing each arm once put any
-        transient scheduler stall straight into the ratio — a loaded machine
-        measured 876% against this 300% bound while an idle one measured 27%.
-        Contention can only ever add time, never remove it, so the per-arm
-        minimum is the stable estimator of hydration cost.
+        Arms are compared on their fastest of ``_TIMING_REPEATS`` hydrations.
+        One takes ~20ms, so a single sample each put any transient stall
+        straight into the ratio (idle 27% vs 876% under load); contention only
+        ever adds time, so the minimum is the stable estimator.
         """
         n_samples = 500
         stages = [
@@ -283,8 +278,8 @@ class TestLoaderHydrationPerformance:
             """Seconds taken by the fastest of _TIMING_REPEATS hydrations."""
             elapsed: list[float] = []
             for _ in range(_TIMING_REPEATS):
-                # Fresh loader each time: load_initial_state() populates the
-                # loader, so reusing one would not re-read the shards.
+                # Fresh loader: load_initial_state() populates it, so reusing
+                # one would not re-read the shards.
                 loader = TaskLoader(
                     task=_make_mock_task(n_samples),
                     root_dir=root,
@@ -293,8 +288,7 @@ class TestLoaderHydrationPerformance:
                 timer = PerfTimer()
                 with timer:
                     loaded = await loader.load_initial_state()
-                # Both arms must hydrate the same sample count, or the ratio
-                # below would be comparing two different amounts of work.
+                # Equal counts, or the ratio compares unequal work.
                 assert len(loaded) == n_samples
                 elapsed.append(timer.elapsed)
             return min(elapsed)

--- a/tests/performance/test_io_overhead.py
+++ b/tests/performance/test_io_overhead.py
@@ -24,10 +24,16 @@ from tests.conftest import (
     samples_per_second,
 )
 
-
 # ===================================================================
 # Helpers
 # ===================================================================
+# How many times a timed hydration is repeated before its minimum is taken.
+# Relevant only where the metric is a ratio of two sub-100ms measurements,
+# which single-shot timing cannot measure stably. See
+# TestLoaderHydrationPerformance.test_dependency_loading_overhead.
+_TIMING_REPEATS = 5
+
+
 async def _write_contexts_batch(
     root: Path,
     contexts: list[TaskContext],
@@ -232,6 +238,13 @@ class TestLoaderHydrationPerformance:
 
         Writes snapshots at each stage, then hydrates with all dependencies.
         Compares against single-stage-only hydration.
+
+        Each arm is hydrated ``_TIMING_REPEATS`` times and compared on its
+        minimum. One hydration takes ~20ms, so timing each arm once put any
+        transient scheduler stall straight into the ratio — a loaded machine
+        measured 876% against this 300% bound while an idle one measured 27%.
+        Contention can only ever add time, never remove it, so the per-arm
+        minimum is the stable estimator of hydration cost.
         """
         n_samples = 500
         stages = [
@@ -261,42 +274,39 @@ class TestLoaderHydrationPerformance:
                 saver._stage_queue.append(ctx)
             await saver.flush()
 
-        # Hydrate with dependencies
-        task_dep = _make_mock_task(n_samples)
-        loader_dep = TaskLoader(
-            task=task_dep,
-            root_dir=root_dep,
-            shard_read_concurrency=8,
-        )
-
-        timer_dep = PerfTimer()
-        with timer_dep:
-            _loaded_dep = await loader_dep.load_initial_state()
-
-        # Compare: hydrate without dependency stages (final only)
+        # Compare against hydration without dependency stages (final only)
         root_nodep = tmp_path / "nodep_bench"
         final_contexts = [_make_bench_ctx(i, TaskStage.FINAL) for i in range(n_samples)]
         await _write_contexts_batch(root_nodep, final_contexts, shard_samples=256)
 
-        task_nodep = _make_mock_task(n_samples)
-        loader_nodep = TaskLoader(
-            task=task_nodep,
-            root_dir=root_nodep,
-            shard_read_concurrency=8,
-        )
+        async def _fastest_hydration(root: Path) -> float:
+            """Seconds taken by the fastest of _TIMING_REPEATS hydrations."""
+            elapsed: list[float] = []
+            for _ in range(_TIMING_REPEATS):
+                # Fresh loader each time: load_initial_state() populates the
+                # loader, so reusing one would not re-read the shards.
+                loader = TaskLoader(
+                    task=_make_mock_task(n_samples),
+                    root_dir=root,
+                    shard_read_concurrency=8,
+                )
+                timer = PerfTimer()
+                with timer:
+                    loaded = await loader.load_initial_state()
+                # Both arms must hydrate the same sample count, or the ratio
+                # below would be comparing two different amounts of work.
+                assert len(loaded) == n_samples
+                elapsed.append(timer.elapsed)
+            return min(elapsed)
 
-        timer_nodep = PerfTimer()
-        with timer_nodep:
-            _loaded_nodep = await loader_nodep.load_initial_state()
+        dep_s = await _fastest_hydration(root_dep)
+        nodep_s = await _fastest_hydration(root_nodep)
 
-        overhead_pct = (
-            (timer_dep.elapsed - timer_nodep.elapsed) / timer_nodep.elapsed * 100
-            if timer_nodep.elapsed > 0
-            else 0
-        )
+        overhead_pct = (dep_s - nodep_s) / nodep_s * 100 if nodep_s > 0 else 0
         print(
             f"PERF: dep_loading overhead={overhead_pct:.1f}% "
-            f"(dep={timer_dep.elapsed:.4f}s, nodep={timer_nodep.elapsed:.4f}s)"
+            f"(dep={dep_s:.4f}s, nodep={nodep_s:.4f}s, "
+            f"best of {_TIMING_REPEATS})"
         )
         # Dependency loading adds cross-stage reads; overhead should be bounded
         # (4 stages means ~4x more reads, expect <300% overhead)


### PR DESCRIPTION
## Type

- chore — CI, tooling, dependencies, config

## Summary

CI ran only `tests/unit`, so the entire integration and acceptance layer went unverified on PRs. Two bugs shipped through that gap and had to be caught by hand during the 0.7.0 release (#55): a resume fixture that predated the version gate (#37), and a perf test still calling the pre-#7 `Dataset.select()`.

- **Add `tests/integration` + `tests/acceptance` to the matrix job**, deselecting a new `benchmark` marker.
- **The `benchmark` marker exists because `tests/acceptance` mixes two kinds of test.** Nine are deterministic checks of the regression-detection helper. One (`test_benchmark_scenarios`) is a wall-clock throughput gate whose thresholds are calibrated on a dedicated box — `long_output` holds only **1.10× headroom** there (0.771 measured vs 0.70 required), and the coverage tracer skews the very latency it measures. CI gains the nine; the gate stays a local tool that a plain `pytest` still runs.
- **Make `test_dependency_loading_overhead` robust.** It compares two ~20 ms hydrations *as a ratio*, so timing each arm once fed any transient stall straight into the metric. Each arm is now hydrated 5× and compared on its **minimum** — contention only ever adds time, never removes it.
- **Enforce the gate in the release flow** (`.claude/commands/sieval-release.md`). Since CI deselects `benchmark`, the release becomes the only place those thresholds get checked, so the step is now explicit. It also fixes a latent defect: the gates already ran there, but inside the batch the doc says to *run in parallel* — a wall-clock assertion sharing a box with `ruff`, `ty`, and a 2723-test pytest run measures that load, not the code, which is the very contention that produced the 876% reading. They are now held back with `-m "not benchmark"` and run alone afterwards, writing `benchmark_summary.json` to gitignored `outputs/` so each release records a performance baseline.
- Document both markers in `tests/README.md`, including why a `benchmark` failure means "retry on an idle machine" rather than "regression".

## Related Issues

Refs #55, #37, #7.

## Test Plan

### Automated

- [x] Lint/format clean (`ruff check && ruff format --check`)
- [x] Type check clean (`ty check` on both changed test modules: "All checks passed")
- [x] The exact new CI command passes locally: **2723 passed, 1 deselected**
- [x] `tests/performance`: 66 passed, 5 deselected
- [x] Plain local `pytest tests/acceptance` still collects all 10 (marker does not hide it locally)
- [x] `pytest -m benchmark` selects exactly the 1 gate
- [x] markdownlint clean on `tests/README.md` and `.claude/commands/sieval-release.md`
- [x] Both new release-flow commands run as documented: the batch reports `2723 passed, 1 deselected`; the serial gate reports `1 passed, 2794 deselected` and writes the artifact without dirtying the tree

### Manual

Flakiness fix verified empirically, not just reasoned about.

- [x] **Idle:** 27.5% before → 25.1% after (same measurement, so the bound still means what it meant).
- [x] **Under the same concurrent-suite load that originally produced 876%:** six consecutive runs now land in an **18–37%** band, all passing.
- [x] **Estimator comparison in one process, 8 paired trials:** single-shot spread **7–107%** vs min-of-5 spread **2–16%** — a ~7× reduction in spread, which is the property that stops the 300% bound being breached by noise.

Measured acceptance headroom on a dedicated box, the basis for excluding the gate from CI:

| scenario | metric | threshold | measured | headroom |
| --- | --- | --- | --- | --- |
| long_output | efficiency | 0.70 | 0.771 | **1.10×** |
| single_turn | efficiency | 0.70 | 0.936 | 1.34× |
| high_concurrency | efficiency | 0.65 | 0.859 | 1.32× |
| multi_iteration | efficiency | 0.60 | 0.895 | 1.49× |
| framework_overhead | sps | 500 | 1630 | 3.26× |
| resume_90pct | elapsed | 5.0 s | 0.199 s | 27.9× |

## Checklist

### Required (all PRs)

- [x] PR title follows conventional format (`type(scope): description`)
- [x] No internal paths, credentials, or personal info in committed files
- [x] AI-generated code has `AI-Generated Code - <model> (<provider>)` in module docstring — n/a, no new modules
- [x] No new upper-layer dependencies added to `core/`
- [x] Deleted code verified — no remaining call sites depend on it (the removed `timer_dep`/`timer_nodep` locals were test-local)

## Notes for reviewers

- CI wall-clock cost: the new command takes ~70s locally vs ~40s for `tests/unit` alone. No new install groups needed — everything `tests/integration` and `tests/acceptance` import (`anyio`, `datasets`, `orjson`, `loguru` in default; `psutil`, `pytest` in `test`) is already covered by `INSTALL_GROUPS`.
- `addopts` is deliberately left at `-m "not stress"`, so `benchmark` tests keep running on a plain local `pytest`. Only the CI invocation deselects them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
