### PR TITLE
fix(tasks): stop indexing a rollout key that is absent on disk

### DIFF
--- a/.claude/commands/sieval-preflight.md
+++ b/.claude/commands/sieval-preflight.md
@@ -8,7 +8,7 @@ description: Run preflight checks on the sieval codebase (link validation, depen
 
 $ARGUMENTS
 
-Accepts: `deep`, `quick` (default), or a specific check name (e.g., `check_links`, `check_deps`, `check_dep_coverage`, `check_tasks`, `check_datasets`, `check_examples`, `check_imports`, `check_meta_index_sync`, `check_version`).
+Accepts: `deep`, `quick` (default), or a specific check name (e.g., `check_links`, `check_deps`, `check_dep_coverage`, `check_tasks`, `check_task_shot_knobs`, `check_record_key_access`, `check_datasets`, `check_examples`, `check_imports`, `check_meta_index_sync`, `check_version`).
 
 ## Process
 

--- a/scripts/check_preflight.py
+++ b/scripts/check_preflight.py
@@ -197,6 +197,116 @@ def _n_shot_sources(fn: ast.FunctionDef | ast.AsyncFunctionDef) -> list[set[str]
     return sources
 
 
+#: Rollout keys whose absence is a *runtime* outcome, so `[]` on them is a
+#: latent KeyError no type checker reports. Only `prediction` qualifies today:
+#: extraction failure is not under the task author's control, and the record
+#: builder spells that failure as `None`, which never reaches disk.
+_GATED_ROLLOUT_KEYS = frozenset({"prediction"})
+
+#: Rollout keys deliberately left ungated, with the reason each is different in
+#: kind from `prediction`. Listed rather than ignored so `check_record_key_access`
+#: can fail when `records.py` grows a key belonging to neither set.
+_UNGATED_ROLLOUT_KEYS = frozenset(
+    {
+        # Absence is an authoring choice, not a runtime outcome: the task that
+        # reads `r["extra"]["grade"]` is the same task that wrote that extra,
+        # unconditionally. And every read is *nested*, so the mechanical `.get()`
+        # fix would turn a KeyError into `NoneType is not subscriptable` —
+        # strictly worse. Needs a per-site pass, not a sweep.
+        "extra",
+        # Same authoring-choice argument. "Absent is not zero" (RolloutJudgement),
+        # so a `.get()` returning None here would silently become a wrong metric
+        # rather than a loud failure.
+        "score",
+        "metrics",
+    }
+)
+
+
+def _rollout_container(node: ast.expr) -> bool:
+    """True for an expression that yields a record's rollout list.
+
+    Either ``<record>["rollouts"]`` or ``<maybe-record>.get("rollouts", ...)``.
+    """
+    if isinstance(node, ast.Subscript):
+        key = node.slice
+        return isinstance(key, ast.Constant) and key.value == "rollouts"
+    if (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "get"
+        and node.args
+    ):
+        first = node.args[0]
+        return isinstance(first, ast.Constant) and first.value == "rollouts"
+    return False
+
+
+def _rollout_bound_names(tree: ast.Module) -> set[str]:
+    """Names bound by iterating a rollout container (`for r in post["rollouts"]`).
+
+    This is what keeps the check structural rather than name-based. A task-local
+    dict that merely happens to carry a ``prediction`` key -- t_eval's
+    ``datum["prediction"]``, whose sibling is ``ground_truth`` -- is not a record
+    and must not be flagged.
+    """
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        pairs: list[tuple[ast.expr, ast.expr]] = []
+        if isinstance(node, (ast.For, ast.AsyncFor)):
+            pairs.append((node.target, node.iter))
+        elif isinstance(
+            node, (ast.ListComp, ast.SetComp, ast.GeneratorExp, ast.DictComp)
+        ):
+            pairs.extend((gen.target, gen.iter) for gen in node.generators)
+        for target, iterable in pairs:
+            if isinstance(target, ast.Name) and _rollout_container(iterable):
+                names.add(target.id)
+    return names
+
+
+def _gated_rollout_subscripts(tree: ast.Module) -> list[tuple[int, str, str]]:
+    """Every ``<rollout>[<gated key>]`` in *tree*, as ``(lineno, key, source)``."""
+    bound = _rollout_bound_names(tree)
+    out: list[tuple[int, str, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Subscript):
+            continue
+        key = node.slice
+        if not (isinstance(key, ast.Constant) and key.value in _GATED_ROLLOUT_KEYS):
+            continue
+        base = node.value
+        is_rollout = (isinstance(base, ast.Name) and base.id in bound) or (
+            isinstance(base, ast.Subscript) and _rollout_container(base.value)
+        )
+        if is_rollout:
+            out.append((node.lineno, str(key.value), ast.unparse(node)))
+    return out
+
+
+def _not_required_rollout_keys(records_py: Path) -> set[str] | None:
+    """``NotRequired`` field names on the rollout TypedDicts, or None if unreadable."""
+    try:
+        tree = ast.parse(records_py.read_text(encoding="utf-8"))
+    except (OSError, SyntaxError):
+        return None
+    keys: set[str] = set()
+    for node in ast.walk(tree):
+        if not (
+            isinstance(node, ast.ClassDef)
+            and node.name in ("RolloutPrediction", "RolloutJudgement")
+        ):
+            continue
+        for stmt in node.body:
+            if (
+                isinstance(stmt, ast.AnnAssign)
+                and isinstance(stmt.target, ast.Name)
+                and ast.unparse(stmt.annotation).startswith("NotRequired[")
+            ):
+                keys.add(stmt.target.id)
+    return keys
+
+
 def _docstring_constant_ids(cls: ast.ClassDef) -> set[int]:
     """``id()`` of every docstring Constant in *cls* (its own and its methods').
 
@@ -413,6 +523,7 @@ class PreflightRunner:
         "check_dep_coverage",
         "check_tasks",
         "check_task_shot_knobs",
+        "check_record_key_access",
         "check_datasets",
         "check_imports",
         "check_examples",
@@ -1267,6 +1378,112 @@ class PreflightRunner:
                 "check_task_shot_knobs",
                 f"all {checked} task constructor(s) spell and wire the "
                 "shot knob correctly",
+            )
+        ]
+
+    def check_record_key_access(self) -> list[CheckResult]:
+        """Forbid ``[]`` on a rollout key whose absence is a runtime outcome.
+
+        ``build_prediction_record`` spells "could not extract" as
+        ``prediction=None``, and ``obj_to_dict`` drops ``None``-valued keys, so
+        the key is *absent* on disk -- not null, gone. On resume the loader
+        hydrates ``postprocess_result`` from disk and hands it to ``feedback``,
+        where ``rollout["prediction"]`` raises ``KeyError`` for exactly the
+        samples whose extraction failed. The same line is fine on a fresh run,
+        which is why this survives every in-memory test.
+
+        Nothing else catches it. The contract is already stated three times over
+        -- ``RolloutPrediction.prediction`` is declared ``NotRequired``, its
+        docstring says "absent on disk in that case, so read ``extracted``
+        instead", and ``test_records.py::TestSerializationRoundTrip`` pins the
+        behaviour -- yet neither ``ty`` nor ``mypy --strict`` reports a ``[]``
+        subscript of a ``NotRequired`` key (both accept it by design; the typing
+        spec leaves that diagnostic optional). A correctly-declared,
+        correctly-documented, unit-tested contract with no enforcement at the
+        call site is how 39 modules drifted off it while CI stayed green.
+
+        Structural, not name-based: a key is only flagged when its base
+        provably comes from a record's ``rollouts`` -- indexed
+        (``post["rollouts"][0][...]``) or iterated (``for r in post["rollouts"]``).
+        A task-local dict that merely carries a ``prediction`` key is not a
+        record and is left alone.
+
+        Scope is :data:`_GATED_ROLLOUT_KEYS`; :data:`_UNGATED_ROLLOUT_KEYS`
+        records why the other ``NotRequired`` rollout keys are different in kind.
+        A key in neither set fails the check rather than being silently skipped,
+        so adding one to ``records.py`` forces the classification.
+        """
+        records_py = self.project_root / "sieval" / "core" / "tasks" / "records.py"
+        declared = _not_required_rollout_keys(records_py)
+        if declared is None:
+            return [
+                CheckResult(
+                    "SKIP",
+                    "check_record_key_access",
+                    f"{records_py.relative_to(self.project_root)} not readable",
+                )
+            ]
+
+        unclassified = sorted(declared - _GATED_ROLLOUT_KEYS - _UNGATED_ROLLOUT_KEYS)
+        if unclassified:
+            return [
+                CheckResult(
+                    "FAIL",
+                    "check_record_key_access",
+                    f"{len(unclassified)} unclassified NotRequired rollout key(s)",
+                    [
+                        f"records.py declares {k!r} NotRequired on a rollout but "
+                        "check_preflight lists it in neither _GATED_ROLLOUT_KEYS "
+                        "nor _UNGATED_ROLLOUT_KEYS — decide whether `[]` on it is "
+                        "a latent KeyError and say so in one of the two"
+                        for k in unclassified
+                    ],
+                )
+            ]
+
+        py_files = [
+            f
+            for f in self._git_tracked_files(".py")
+            if str(f.relative_to(self.project_root)).startswith("sieval/")
+        ]
+        if not py_files:
+            return [CheckResult("SKIP", "check_record_key_access", "no sieval modules")]
+
+        violations: list[str] = []
+        for py_file in py_files:
+            rel = py_file.relative_to(self.project_root)
+            try:
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore", SyntaxWarning)
+                    tree = ast.parse(
+                        py_file.read_text(encoding="utf-8"), filename=str(py_file)
+                    )
+            except (OSError, SyntaxError) as e:
+                violations.append(f"{rel}: could not parse ({e})")
+                continue
+            for lineno, key, source in _gated_rollout_subscripts(tree):
+                violations.append(
+                    f"{rel}:{lineno}: {source} — {key!r} is NotRequired and "
+                    f"absent on disk when it was None, so this raises KeyError "
+                    f"on resume; use .get({key!r}) (same value, and the resumed "
+                    "path then matches the fresh one)"
+                )
+
+        if violations:
+            return [
+                CheckResult(
+                    "FAIL",
+                    "check_record_key_access",
+                    f"{len(violations)} unsafe rollout-key access(es)",
+                    violations,
+                )
+            ]
+        return [
+            CheckResult(
+                "PASS",
+                "check_record_key_access",
+                f"no unsafe `[]` access to {sorted(_GATED_ROLLOUT_KEYS)} "
+                f"across {len(py_files)} module(s)",
             )
         ]
 

--- a/scripts/check_preflight.py
+++ b/scripts/check_preflight.py
@@ -204,10 +204,9 @@ def _n_shot_sources(fn: ast.FunctionDef | ast.AsyncFunctionDef) -> list[set[str]
 _GATED_ROLLOUT_KEYS = frozenset({"prediction"})
 
 #: Every *other* `NotRequired` key on a record TypedDict, with the reason it is
-#: different in kind from `prediction`. Listed rather than ignored so
-#: `check_record_key_access` can fail when `records.py` grows a key belonging to
-#: neither set. Spans all the record classes, not just the rollout ones, so a key
-#: added to `PromptRecord` / `JudgementRecord` forces the same decision.
+#: different in kind from `prediction`. Listed rather than ignored so a key in
+#: neither set fails the check. Covers all five record classes, so a key added to
+#: `PromptRecord` / `JudgementRecord` forces the same decision.
 _UNGATED_RECORD_KEYS = frozenset(
     {
         # Absence is an authoring choice, not a runtime outcome: the task that
@@ -221,30 +220,20 @@ _UNGATED_RECORD_KEYS = frozenset(
         # rather than a loud failure.
         "score",
         "metrics",
-        # Absence is an authoring *property*: `reference` is None iff the task's
-        # ground truth is a procedure (a test suite, a rubric) rather than a
-        # value, which is fixed for the whole task and known to the same author
-        # who reads it back. `JudgementRecord.reference` does share
-        # `prediction`'s shape -- `build_judgement_record` writes it
-        # unconditionally, so None is present in memory and dropped on disk --
-        # but the one `[]` read (ruler's report) consumes it as an iterable, so a
-        # mechanical `.get()` would swap KeyError for a `list(None)` TypeError:
-        # the same trap as `extra`'s nested reads. `PromptRecord.reference` is
-        # milder still, since `build_prompt_record` omits it when None, so it is
-        # absent in memory too and fresh and resumed runs fail identically
-        # instead of diverging. What is missing for `reference` is not a `.get()`
-        # sweep but a durable signal of *which* of those two cases applies —
-        # tracked in https://github.com/scitix/sieval/issues/71.
+        # Absence is an authoring *property*: None iff the task's ground truth is
+        # a procedure (a test suite, a rubric), which is fixed per task. Shares
+        # `prediction`'s shape on JudgementRecord, but the one `[]` read (ruler's
+        # report) consumes it as an iterable, so `.get()` would swap KeyError for
+        # `list(None)` TypeError — `extra`'s trap again. What it needs is a
+        # durable signal of *which* absence this is: scitix/sieval#71.
         "reference",
     }
 )
 
 
-#: Builtins that pass a rollout list through to the loop: iterating the result
-#: still walks rollouts, either directly (`list`/`reversed`/`sorted`) or as one
-#: element of a per-item tuple (`enumerate`/`zip`). Unwrapped so that
-#: `for i, r in enumerate(post["rollouts"])` -- the natural way to write feedback
-#: for a task that needs the rollout index -- is not a blind spot.
+#: Builtins that pass a rollout list through to the loop, directly or inside a
+#: per-item tuple. Unwrapped so `for i, r in enumerate(post["rollouts"])` -- the
+#: natural way to write feedback needing the rollout index -- is not a blind spot.
 _ROLLOUT_ITER_WRAPPERS = frozenset({"enumerate", "zip", "reversed", "list", "sorted"})
 
 
@@ -276,12 +265,10 @@ def _rollout_container(node: ast.expr) -> bool:
 def _iteration_target_names(target: ast.expr) -> set[str]:
     """Names bound by a ``for``/comprehension target: ``r``, or ``i, r``.
 
-    For a tuple target every ``Name`` element is bound, not just the one holding
-    the rollout. That over-approximates ``enumerate``/``zip`` -- ``i`` is an int,
-    not a rollout -- but only produces a false positive if something subscripts a
-    non-rollout element with a *gated* key, and no gated key is a plausible key on
-    an index or a judgement. Tracking which tuple position came from which
-    ``zip`` argument would buy nothing.
+    A tuple target binds every ``Name`` element, not just the rollout one. That
+    over-approximates ``enumerate``/``zip``, but misfires only if something
+    subscripts a non-rollout element with a *gated* key -- and no gated key is
+    plausible on an index or a judgement.
     """
     if isinstance(target, ast.Name):
         return {target.id}
@@ -298,13 +285,10 @@ def _rollout_bound_names(tree: ast.Module) -> set[str]:
     ``datum["prediction"]``, whose sibling is ``ground_truth`` -- is not a record
     and must not be flagged.
 
-    Known limits, all of which need the rollout list to travel through a *name*
-    before being subscripted: ``rs = post["rollouts"]``, ``r =
-    post["rollouts"][0]``, and a helper taking a ``RolloutPrediction`` parameter.
-    Following those needs dataflow rather than a syntactic walk; the value of
-    staying syntactic is that the check cannot invent a rollout that is not
-    provably one. ``.pop(<gated key>)`` is likewise not flagged -- it raises the
-    same KeyError, but mutating a hydrated record is not a pattern here.
+    Not followed, because each needs dataflow rather than a syntactic walk:
+    ``rs = post["rollouts"]``, ``r = post["rollouts"][0]``, and a helper taking a
+    ``RolloutPrediction`` parameter. Nor ``.pop(<gated key>)`` -- same KeyError,
+    but mutating a hydrated record is not a pattern here.
     """
     names: set[str] = set()
     for node in ast.walk(tree):
@@ -340,10 +324,8 @@ def _gated_rollout_subscripts(tree: ast.Module) -> list[tuple[int, str, str]]:
     return out
 
 
-#: The record TypedDicts whose ``NotRequired`` keys must all be classified. All
-#: five, not just the two rollout ones: gating only ever *flags* a rollout
-#: subscript, but a key left out of the classification is a key nobody had to
-#: think about -- which is how `prediction` drifted in the first place.
+#: The record TypedDicts whose ``NotRequired`` keys must all be classified. A key
+#: left out is a key nobody had to think about -- how `prediction` drifted.
 _RECORD_CLASSES = (
     "PromptRecord",
     "RolloutPrediction",
@@ -1468,30 +1450,26 @@ class PreflightRunner:
         correctly-documented, unit-tested contract with no enforcement at the
         call site is how 39 modules drifted off it while CI stayed green.
 
-        Structural, not name-based: a key is only flagged when its base
-        provably comes from a record's ``rollouts`` -- indexed
-        (``post["rollouts"][0][...]``) or iterated (``for r in post["rollouts"]``,
-        including through ``enumerate``/``zip`` and a tuple target). A task-local
-        dict that merely carries a ``prediction`` key is not a record and is left
-        alone. :func:`_rollout_bound_names` lists what it deliberately does not
-        follow.
+        Structural, not name-based: a key is only flagged when its base provably
+        comes from a record's ``rollouts`` -- indexed (``post["rollouts"][0]``) or
+        iterated (``for r in post["rollouts"]``, including through
+        ``enumerate``/``zip``). A task-local dict that merely carries a
+        ``prediction`` key is left alone; :func:`_rollout_bound_names` lists what
+        is deliberately not followed.
 
-        What gets *flagged* is :data:`_GATED_ROLLOUT_KEYS`, which is rollout-scoped
-        by construction. What gets *classified* is every ``NotRequired`` key on
-        every record TypedDict (:data:`_RECORD_CLASSES`): a key in neither
-        :data:`_GATED_ROLLOUT_KEYS` nor :data:`_UNGATED_RECORD_KEYS` fails the
-        check rather than being silently skipped, so adding one to ``records.py``
-        forces the classification. The two scopes differ on purpose -- gating a
-        key whose reads are not rollout subscripts (``reference``) would be inert
+        Flagging is rollout-scoped (:data:`_GATED_ROLLOUT_KEYS`); *classification*
+        covers every ``NotRequired`` key on every record TypedDict
+        (:data:`_RECORD_CLASSES`), and a key in neither set fails the check, so
+        adding one to ``records.py`` forces the decision. The scopes differ on
+        purpose: gating a key not read off a rollout (``reference``) would be inert
         and would read as coverage the check does not have.
         """
         records_py = self.project_root / "sieval" / "core" / "tasks" / "records.py"
         declared = _not_required_record_keys(records_py)
         if declared is None:
             # FAIL, not SKIP: records.py is this check's subject, not an optional
-            # input. Moving or renaming it would otherwise narrow the gate to
-            # nothing with preflight still green -- the same silent narrowing the
-            # unclassified-key branch below exists to prevent.
+            # input. Renaming it would otherwise narrow the gate to nothing with
+            # preflight still green.
             return [
                 CheckResult(
                     "FAIL",

--- a/scripts/check_preflight.py
+++ b/scripts/check_preflight.py
@@ -233,8 +233,8 @@ _UNGATED_RECORD_KEYS = frozenset(
         # milder still, since `build_prompt_record` omits it when None, so it is
         # absent in memory too and fresh and resumed runs fail identically
         # instead of diverging. What is missing for `reference` is not a `.get()`
-        # sweep but a durable signal of *which* of those two cases applies; see
-        # the issue linked from `check_record_key_access`.
+        # sweep but a durable signal of *which* of those two cases applies —
+        # tracked in https://github.com/scitix/sieval/issues/71.
         "reference",
     }
 )

--- a/scripts/check_preflight.py
+++ b/scripts/check_preflight.py
@@ -203,10 +203,12 @@ def _n_shot_sources(fn: ast.FunctionDef | ast.AsyncFunctionDef) -> list[set[str]
 #: builder spells that failure as `None`, which never reaches disk.
 _GATED_ROLLOUT_KEYS = frozenset({"prediction"})
 
-#: Rollout keys deliberately left ungated, with the reason each is different in
-#: kind from `prediction`. Listed rather than ignored so `check_record_key_access`
-#: can fail when `records.py` grows a key belonging to neither set.
-_UNGATED_ROLLOUT_KEYS = frozenset(
+#: Every *other* `NotRequired` key on a record TypedDict, with the reason it is
+#: different in kind from `prediction`. Listed rather than ignored so
+#: `check_record_key_access` can fail when `records.py` grows a key belonging to
+#: neither set. Spans all the record classes, not just the rollout ones, so a key
+#: added to `PromptRecord` / `JudgementRecord` forces the same decision.
+_UNGATED_RECORD_KEYS = frozenset(
     {
         # Absence is an authoring choice, not a runtime outcome: the task that
         # reads `r["extra"]["grade"]` is the same task that wrote that extra,
@@ -219,27 +221,73 @@ _UNGATED_ROLLOUT_KEYS = frozenset(
         # rather than a loud failure.
         "score",
         "metrics",
+        # Absence is an authoring *property*: `reference` is None iff the task's
+        # ground truth is a procedure (a test suite, a rubric) rather than a
+        # value, which is fixed for the whole task and known to the same author
+        # who reads it back. `JudgementRecord.reference` does share
+        # `prediction`'s shape -- `build_judgement_record` writes it
+        # unconditionally, so None is present in memory and dropped on disk --
+        # but the one `[]` read (ruler's report) consumes it as an iterable, so a
+        # mechanical `.get()` would swap KeyError for a `list(None)` TypeError:
+        # the same trap as `extra`'s nested reads. `PromptRecord.reference` is
+        # milder still, since `build_prompt_record` omits it when None, so it is
+        # absent in memory too and fresh and resumed runs fail identically
+        # instead of diverging. What is missing for `reference` is not a `.get()`
+        # sweep but a durable signal of *which* of those two cases applies; see
+        # the issue linked from `check_record_key_access`.
+        "reference",
     }
 )
+
+
+#: Builtins that pass a rollout list through to the loop: iterating the result
+#: still walks rollouts, either directly (`list`/`reversed`/`sorted`) or as one
+#: element of a per-item tuple (`enumerate`/`zip`). Unwrapped so that
+#: `for i, r in enumerate(post["rollouts"])` -- the natural way to write feedback
+#: for a task that needs the rollout index -- is not a blind spot.
+_ROLLOUT_ITER_WRAPPERS = frozenset({"enumerate", "zip", "reversed", "list", "sorted"})
 
 
 def _rollout_container(node: ast.expr) -> bool:
     """True for an expression that yields a record's rollout list.
 
-    Either ``<record>["rollouts"]`` or ``<maybe-record>.get("rollouts", ...)``.
+    ``<record>["rollouts"]``, ``<maybe-record>.get("rollouts", ...)``, or either
+    of those behind a pass-through builtin (:data:`_ROLLOUT_ITER_WRAPPERS`) or a
+    walrus.
     """
+    if isinstance(node, ast.NamedExpr):
+        return _rollout_container(node.value)
     if isinstance(node, ast.Subscript):
         key = node.slice
         return isinstance(key, ast.Constant) and key.value == "rollouts"
-    if (
-        isinstance(node, ast.Call)
-        and isinstance(node.func, ast.Attribute)
-        and node.func.attr == "get"
-        and node.args
-    ):
-        first = node.args[0]
-        return isinstance(first, ast.Constant) and first.value == "rollouts"
+    if isinstance(node, ast.Call):
+        if isinstance(node.func, ast.Name) and node.func.id in _ROLLOUT_ITER_WRAPPERS:
+            return any(_rollout_container(arg) for arg in node.args)
+        if (
+            isinstance(node.func, ast.Attribute)
+            and node.func.attr == "get"
+            and node.args
+        ):
+            first = node.args[0]
+            return isinstance(first, ast.Constant) and first.value == "rollouts"
     return False
+
+
+def _iteration_target_names(target: ast.expr) -> set[str]:
+    """Names bound by a ``for``/comprehension target: ``r``, or ``i, r``.
+
+    For a tuple target every ``Name`` element is bound, not just the one holding
+    the rollout. That over-approximates ``enumerate``/``zip`` -- ``i`` is an int,
+    not a rollout -- but only produces a false positive if something subscripts a
+    non-rollout element with a *gated* key, and no gated key is a plausible key on
+    an index or a judgement. Tracking which tuple position came from which
+    ``zip`` argument would buy nothing.
+    """
+    if isinstance(target, ast.Name):
+        return {target.id}
+    if isinstance(target, (ast.Tuple, ast.List)):
+        return {e.id for e in target.elts if isinstance(e, ast.Name)}
+    return set()
 
 
 def _rollout_bound_names(tree: ast.Module) -> set[str]:
@@ -249,6 +297,14 @@ def _rollout_bound_names(tree: ast.Module) -> set[str]:
     dict that merely happens to carry a ``prediction`` key -- t_eval's
     ``datum["prediction"]``, whose sibling is ``ground_truth`` -- is not a record
     and must not be flagged.
+
+    Known limits, all of which need the rollout list to travel through a *name*
+    before being subscripted: ``rs = post["rollouts"]``, ``r =
+    post["rollouts"][0]``, and a helper taking a ``RolloutPrediction`` parameter.
+    Following those needs dataflow rather than a syntactic walk; the value of
+    staying syntactic is that the check cannot invent a rollout that is not
+    provably one. ``.pop(<gated key>)`` is likewise not flagged -- it raises the
+    same KeyError, but mutating a hydrated record is not a pattern here.
     """
     names: set[str] = set()
     for node in ast.walk(tree):
@@ -260,8 +316,8 @@ def _rollout_bound_names(tree: ast.Module) -> set[str]:
         ):
             pairs.extend((gen.target, gen.iter) for gen in node.generators)
         for target, iterable in pairs:
-            if isinstance(target, ast.Name) and _rollout_container(iterable):
-                names.add(target.id)
+            if _rollout_container(iterable):
+                names |= _iteration_target_names(target)
     return names
 
 
@@ -284,18 +340,28 @@ def _gated_rollout_subscripts(tree: ast.Module) -> list[tuple[int, str, str]]:
     return out
 
 
-def _not_required_rollout_keys(records_py: Path) -> set[str] | None:
-    """``NotRequired`` field names on the rollout TypedDicts, or None if unreadable."""
+#: The record TypedDicts whose ``NotRequired`` keys must all be classified. All
+#: five, not just the two rollout ones: gating only ever *flags* a rollout
+#: subscript, but a key left out of the classification is a key nobody had to
+#: think about -- which is how `prediction` drifted in the first place.
+_RECORD_CLASSES = (
+    "PromptRecord",
+    "RolloutPrediction",
+    "PredictionRecord",
+    "RolloutJudgement",
+    "JudgementRecord",
+)
+
+
+def _not_required_record_keys(records_py: Path) -> set[str] | None:
+    """``NotRequired`` field names on the record TypedDicts, or None if unreadable."""
     try:
         tree = ast.parse(records_py.read_text(encoding="utf-8"))
     except (OSError, SyntaxError):
         return None
     keys: set[str] = set()
     for node in ast.walk(tree):
-        if not (
-            isinstance(node, ast.ClassDef)
-            and node.name in ("RolloutPrediction", "RolloutJudgement")
-        ):
+        if not (isinstance(node, ast.ClassDef) and node.name in _RECORD_CLASSES):
             continue
         for stmt in node.body:
             if (
@@ -1404,37 +1470,52 @@ class PreflightRunner:
 
         Structural, not name-based: a key is only flagged when its base
         provably comes from a record's ``rollouts`` -- indexed
-        (``post["rollouts"][0][...]``) or iterated (``for r in post["rollouts"]``).
-        A task-local dict that merely carries a ``prediction`` key is not a
-        record and is left alone.
+        (``post["rollouts"][0][...]``) or iterated (``for r in post["rollouts"]``,
+        including through ``enumerate``/``zip`` and a tuple target). A task-local
+        dict that merely carries a ``prediction`` key is not a record and is left
+        alone. :func:`_rollout_bound_names` lists what it deliberately does not
+        follow.
 
-        Scope is :data:`_GATED_ROLLOUT_KEYS`; :data:`_UNGATED_ROLLOUT_KEYS`
-        records why the other ``NotRequired`` rollout keys are different in kind.
-        A key in neither set fails the check rather than being silently skipped,
-        so adding one to ``records.py`` forces the classification.
+        What gets *flagged* is :data:`_GATED_ROLLOUT_KEYS`, which is rollout-scoped
+        by construction. What gets *classified* is every ``NotRequired`` key on
+        every record TypedDict (:data:`_RECORD_CLASSES`): a key in neither
+        :data:`_GATED_ROLLOUT_KEYS` nor :data:`_UNGATED_RECORD_KEYS` fails the
+        check rather than being silently skipped, so adding one to ``records.py``
+        forces the classification. The two scopes differ on purpose -- gating a
+        key whose reads are not rollout subscripts (``reference``) would be inert
+        and would read as coverage the check does not have.
         """
         records_py = self.project_root / "sieval" / "core" / "tasks" / "records.py"
-        declared = _not_required_rollout_keys(records_py)
+        declared = _not_required_record_keys(records_py)
         if declared is None:
+            # FAIL, not SKIP: records.py is this check's subject, not an optional
+            # input. Moving or renaming it would otherwise narrow the gate to
+            # nothing with preflight still green -- the same silent narrowing the
+            # unclassified-key branch below exists to prevent.
             return [
                 CheckResult(
-                    "SKIP",
+                    "FAIL",
                     "check_record_key_access",
                     f"{records_py.relative_to(self.project_root)} not readable",
+                    [
+                        "the record TypedDicts are this check's subject — if they "
+                        "moved, point check_record_key_access at the new path "
+                        "rather than leaving the gate unenforced"
+                    ],
                 )
             ]
 
-        unclassified = sorted(declared - _GATED_ROLLOUT_KEYS - _UNGATED_ROLLOUT_KEYS)
+        unclassified = sorted(declared - _GATED_ROLLOUT_KEYS - _UNGATED_RECORD_KEYS)
         if unclassified:
             return [
                 CheckResult(
                     "FAIL",
                     "check_record_key_access",
-                    f"{len(unclassified)} unclassified NotRequired rollout key(s)",
+                    f"{len(unclassified)} unclassified NotRequired record key(s)",
                     [
-                        f"records.py declares {k!r} NotRequired on a rollout but "
+                        f"records.py declares {k!r} NotRequired on a record but "
                         "check_preflight lists it in neither _GATED_ROLLOUT_KEYS "
-                        "nor _UNGATED_ROLLOUT_KEYS — decide whether `[]` on it is "
+                        "nor _UNGATED_RECORD_KEYS — decide whether `[]` on it is "
                         "a latent KeyError and say so in one of the two"
                         for k in unclassified
                     ],

--- a/sieval/tasks/CLAUDE.md
+++ b/sieval/tasks/CLAUDE.md
@@ -74,7 +74,7 @@ Records are named by **content**, not by the stage that emits them — a shard l
 Vocabulary — these denote **different layers**, keep them distinct:
 
 - **judgement** — the verdict record, mechanism-agnostic: string-compare, math-verify, test-suite *or* LLM verdicts all produce one.
-- **prediction** — the model's extracted answer. `None` means "could not extract" — never `""` or `-1`.
+- **prediction** — the model's extracted answer. `None` means "could not extract" — never `""` or `-1`. **Read it with `.get("prediction")`, never `["prediction"]`**: a `None` value is dropped by serialization, so on resume the key is *absent* and `[]` raises `KeyError` for exactly the samples whose extraction failed — on a fresh run the same line is fine, which is why in-memory tests never see it. `extracted` is the durable companion flag. Enforced by `scripts/check_preflight.py --check check_record_key_access`; neither `ty` nor `mypy --strict` reports it.
 - **reference** — ground truth; `None` when it is a *procedure* (test suite, rubric).
 - **correct** / **score** — the headline verdict. `correct` is the only axis comparable across tasks.
 - **metrics** — every metric measured, by name. A task with *co-equal* metrics (IFEval strict + loose, HellaSwag `acc` + `acc_norm`) records them all here and derives the headline from them; a metric parked in `extra` is hidden from any reader that doesn't already know the task.

--- a/sieval/tasks/aa_lcr_0shot_gen.py
+++ b/sieval/tasks/aa_lcr_0shot_gen.py
@@ -201,7 +201,7 @@ class AALCRZeroShotGenTask(
 
         rollouts: list[RolloutJudgement] = []
         for rollout in post["rollouts"]:
-            predicted = rollout["prediction"]
+            predicted = rollout.get("prediction")
             # Defensive, aa_lcr-specific by design (simpleqa_verified/browsecomp
             # omit it): the checker returns CORRECT on an empty candidate, which
             # would inflate accuracy. Not observed in the 4x300 validation runs

--- a/sieval/tasks/aime_2024_0shot_gen.py
+++ b/sieval/tasks/aime_2024_0shot_gen.py
@@ -91,7 +91,7 @@ class AIME2024ZeroShotGenTask(
         rollouts = []
         ground_truth = ctx.raw_sample["answer"]
         for rollout in post["rollouts"]:
-            pred = rollout["prediction"]
+            pred = rollout.get("prediction")
             if pred is None:
                 rollouts.append(build_rollout_judgement(rollout["index"], False))
                 continue

--- a/sieval/tasks/aime_2025_0shot_gen.py
+++ b/sieval/tasks/aime_2025_0shot_gen.py
@@ -91,7 +91,7 @@ class AIME2025ZeroShotGenTask(
         rollouts = []
         ground_truth = ctx.raw_sample["answer"]
         for rollout in post["rollouts"]:
-            pred = rollout["prediction"]
+            pred = rollout.get("prediction")
             if pred is None:
                 rollouts.append(build_rollout_judgement(rollout["index"], False))
                 continue

--- a/sieval/tasks/aime_2026_0shot_gen.py
+++ b/sieval/tasks/aime_2026_0shot_gen.py
@@ -101,7 +101,7 @@ class AIME2026ZeroShotGenTask(
         rollouts = []
         ground_truth = ctx.raw_sample["answer"]
         for rollout in post["rollouts"]:
-            pred = rollout["prediction"]
+            pred = rollout.get("prediction")
             if pred is None:
                 rollouts.append(build_rollout_judgement(rollout["index"], False))
                 continue

--- a/sieval/tasks/arc/arc_challenge_kshot_clp.py
+++ b/sieval/tasks/arc/arc_challenge_kshot_clp.py
@@ -159,7 +159,7 @@ class ARCChallengeFewShotClpTask(
     @override
     async def feedback(self, post, ctx):
         return True, arc_judgement_record(
-            post["rollouts"][0]["prediction"], ctx.raw_sample
+            post["rollouts"][0].get("prediction"), ctx.raw_sample
         )
 
     @override

--- a/sieval/tasks/arc/arc_challenge_kshot_ppl.py
+++ b/sieval/tasks/arc/arc_challenge_kshot_ppl.py
@@ -175,7 +175,7 @@ class ARCChallengeFewShotPplTask(
     @override
     async def feedback(self, post, ctx):
         return True, arc_judgement_record(
-            post["rollouts"][0]["prediction"], ctx.raw_sample
+            post["rollouts"][0].get("prediction"), ctx.raw_sample
         )
 
     @override

--- a/sieval/tasks/arc/arc_easy_kshot_clp.py
+++ b/sieval/tasks/arc/arc_easy_kshot_clp.py
@@ -158,7 +158,7 @@ class ARCEasyFewShotClpTask(
     @override
     async def feedback(self, post, ctx):
         return True, arc_judgement_record(
-            post["rollouts"][0]["prediction"], ctx.raw_sample
+            post["rollouts"][0].get("prediction"), ctx.raw_sample
         )
 
     @override

--- a/sieval/tasks/arc/arc_easy_kshot_ppl.py
+++ b/sieval/tasks/arc/arc_easy_kshot_ppl.py
@@ -176,7 +176,7 @@ class ARCEasyFewShotPplTask(
     @override
     async def feedback(self, post, ctx):
         return True, arc_judgement_record(
-            post["rollouts"][0]["prediction"], ctx.raw_sample
+            post["rollouts"][0].get("prediction"), ctx.raw_sample
         )
 
     @override

--- a/sieval/tasks/browsecomp_0shot_gen.py
+++ b/sieval/tasks/browsecomp_0shot_gen.py
@@ -182,7 +182,7 @@ class BrowseCompZeroShotGenTask(
 
         rollouts: list[RolloutJudgement] = []
         for rollout in post["rollouts"]:
-            predicted = rollout["prediction"] or ""
+            predicted = rollout.get("prediction") or ""
             prompt = GRADER_TEMPLATE.format(
                 question=question,
                 correct_answer=gold,

--- a/sieval/tasks/c_eval_kshot_clp.py
+++ b/sieval/tasks/c_eval_kshot_clp.py
@@ -294,7 +294,7 @@ class CEvalFewShotCLPTask(
     async def feedback(self, post, ctx):
         raw = ctx.raw_sample
         answer = raw["answer"]
-        prediction = post["rollouts"][0]["prediction"]
+        prediction = post["rollouts"][0].get("prediction")
         return True, build_judgement_record(
             answer,
             [build_rollout_judgement(0, prediction == answer)],

--- a/sieval/tasks/cmmlu_kshot_clp.py
+++ b/sieval/tasks/cmmlu_kshot_clp.py
@@ -418,7 +418,7 @@ class CMMLUFewShotClpTask(
 
     @override
     async def feedback(self, post, ctx):
-        prediction = post["rollouts"][0]["prediction"]
+        prediction = post["rollouts"][0].get("prediction")
         raw = ctx.raw_sample
         if raw is None:
             # No sample to compare against: the verdict is wrong-by-default, and

--- a/sieval/tasks/drop_kshot_gen.py
+++ b/sieval/tasks/drop_kshot_gen.py
@@ -146,7 +146,7 @@ class DROPFewShotGenTask(
 
         ref = ctx.raw_sample["ref_text"]
         answers = ref.split("|")
-        prediction = post["rollouts"][0]["prediction"] or ""
+        prediction = post["rollouts"][0].get("prediction") or ""
         em, f1 = drop_metric(prediction, answers)
         # DROP's two published metrics fit the headline natively -- exact match is
         # the binary verdict, F1 the partial credit -- but both are also named in

--- a/sieval/tasks/gpqa_diamond_0shot_gen.py
+++ b/sieval/tasks/gpqa_diamond_0shot_gen.py
@@ -108,7 +108,7 @@ class GPQADiamondZeroShotGenTask(
     @override
     async def feedback(self, post, ctx):
         reference = ctx.preprocess_result["reference"]
-        prediction = post["rollouts"][0]["prediction"]
+        prediction = post["rollouts"][0].get("prediction")
         return True, build_judgement_record(
             reference,
             [build_rollout_judgement(0, prediction == reference)],

--- a/sieval/tasks/gsm8k_0shot_gen.py
+++ b/sieval/tasks/gsm8k_0shot_gen.py
@@ -140,7 +140,7 @@ class GSM8KZeroShotGenTask(
 
         gold = _gold_answer(ctx.raw_sample["answer"])
         # `or ""` restores exactly what the grader saw pre-migration.
-        prediction = post["rollouts"][0]["prediction"] or ""
+        prediction = post["rollouts"][0].get("prediction") or ""
         correct = is_correct({"prediction": prediction, "answer": gold})
         return True, build_judgement_record(gold, [build_rollout_judgement(0, correct)])
 

--- a/sieval/tasks/gsm8k_kshot_base_gen.py
+++ b/sieval/tasks/gsm8k_kshot_base_gen.py
@@ -186,7 +186,7 @@ class GSM8KFewShotBaseGenTask(
         # Strict and flexible extraction are co-equal published metrics over one
         # response, so both are named in `metrics`; `correct` is DERIVED from the
         # strict one (the headline `exact_match`) so the two cannot drift.
-        prediction = post["rollouts"][0]["prediction"] or ""
+        prediction = post["rollouts"][0].get("prediction") or ""
         metrics: dict[str, bool | float] = {
             "exact_match": prediction == answer,
             "flexible_exact_match": post["extra"]["flexible_prediction"] == answer,

--- a/sieval/tasks/hellaswag_kshot_ppl.py
+++ b/sieval/tasks/hellaswag_kshot_ppl.py
@@ -259,7 +259,7 @@ class HellaSwagFewShotPPLTask(
         # mapping rather than recomputed -- the two cannot drift.
         metrics: dict[str, bool | float] = {
             "acc": post["extra"]["prediction_acc"] == gold,
-            "acc_norm": post["rollouts"][0]["prediction"] == gold,
+            "acc_norm": post["rollouts"][0].get("prediction") == gold,
         }
         return True, build_judgement_record(
             gold,

--- a/sieval/tasks/hendrycks_math_kshot_base_gen.py
+++ b/sieval/tasks/hendrycks_math_kshot_base_gen.py
@@ -125,7 +125,7 @@ class HendrycksMathFewShotBaseGenTask(
         reference = extract_math_answer(
             ctx.raw_sample["problem"], ctx.raw_sample["solution"], "cot"
         )
-        prediction = post["rollouts"][0]["prediction"] or ""
+        prediction = post["rollouts"][0].get("prediction") or ""
         correct = bool(eval_math({"prediction": prediction, "answer": reference}))
         return True, build_judgement_record(
             reference, [build_rollout_judgement(0, correct)]

--- a/sieval/tasks/hle_0shot_gen.py
+++ b/sieval/tasks/hle_0shot_gen.py
@@ -224,7 +224,7 @@ class HLEZeroShotGenTask(
 
         rollouts: list[RolloutJudgement] = []
         for rollout in post["rollouts"]:
-            predicted = rollout["prediction"] or ""
+            predicted = rollout.get("prediction") or ""
             prompt = JUDGE_PROMPT.format(
                 question=question,
                 correct_answer=gold,

--- a/sieval/tasks/hmmt_feb_2025_0shot_gen.py
+++ b/sieval/tasks/hmmt_feb_2025_0shot_gen.py
@@ -101,7 +101,7 @@ class HMMTFeb2025ZeroShotGenTask(
         rollouts = []
         ground_truth = ctx.raw_sample["answer"]
         for rollout in post["rollouts"]:
-            pred = rollout["prediction"]
+            pred = rollout.get("prediction")
             if pred is None:
                 rollouts.append(build_rollout_judgement(rollout["index"], False))
                 continue

--- a/sieval/tasks/hmmt_feb_2026_0shot_gen.py
+++ b/sieval/tasks/hmmt_feb_2026_0shot_gen.py
@@ -101,7 +101,7 @@ class HMMTFeb2026ZeroShotGenTask(
         rollouts = []
         ground_truth = ctx.raw_sample["answer"]
         for rollout in post["rollouts"]:
-            pred = rollout["prediction"]
+            pred = rollout.get("prediction")
             if pred is None:
                 rollouts.append(build_rollout_judgement(rollout["index"], False))
                 continue

--- a/sieval/tasks/hmmt_nov_2025_0shot_gen.py
+++ b/sieval/tasks/hmmt_nov_2025_0shot_gen.py
@@ -109,7 +109,7 @@ class HMMTNov2025ZeroShotGenTask(
         rollouts = []
         ground_truth = ctx.raw_sample["answer"]
         for rollout in post["rollouts"]:
-            pred = rollout["prediction"]
+            pred = rollout.get("prediction")
             if pred is None:
                 rollouts.append(build_rollout_judgement(rollout["index"], False))
                 continue

--- a/sieval/tasks/human_eval_0shot_base_gen.py
+++ b/sieval/tasks/human_eval_0shot_base_gen.py
@@ -143,7 +143,7 @@ class HumanEvalZeroShotBaseGenTask(
             # pre-protocol behaviour, and a real verdict rather than a skip.
             check_program = (
                 ctx.raw_sample["prompt"]
-                + (rollout["prediction"] or "")
+                + (rollout.get("prediction") or "")
                 + "\n"
                 + ctx.raw_sample["test"]
                 + "\n"

--- a/sieval/tasks/human_eval_0shot_gen.py
+++ b/sieval/tasks/human_eval_0shot_gen.py
@@ -106,7 +106,7 @@ class HumanEvalZeroShotGenTask(
             # pre-protocol behaviour, and a real verdict rather than a skip.
             check_program = (
                 ctx.raw_sample["prompt"]
-                + (rollout["prediction"] or "")
+                + (rollout.get("prediction") or "")
                 + "\n"
                 + ctx.raw_sample["test"]
                 + "\n"

--- a/sieval/tasks/ifbench_0shot_gen.py
+++ b/sieval/tasks/ifbench_0shot_gen.py
@@ -136,7 +136,7 @@ class IFBenchZeroShotGenTask(
         raw = ctx.raw_sample
         prompt = raw["prompt"]
         instruction_ids = list(raw["instruction_id_list"])
-        response = post["rollouts"][0]["prediction"] or ""
+        response = post["rollouts"][0].get("prediction") or ""
         inp = InputExample(
             key=raw["key"],
             instruction_id_list=instruction_ids,

--- a/sieval/tasks/ifeval_0shot_gen.py
+++ b/sieval/tasks/ifeval_0shot_gen.py
@@ -98,7 +98,7 @@ class IFEvalZeroShotGenTask(
         raw = ctx.raw_sample
         prompt = raw["prompt"]
         instruction_ids = list(raw["instruction_id_list"])
-        response = post["rollouts"][0]["prediction"] or ""
+        response = post["rollouts"][0].get("prediction") or ""
         inp = InputExample(
             key=raw["key"],
             instruction_id_list=instruction_ids,

--- a/sieval/tasks/imo_answer_bench_0shot_gen.py
+++ b/sieval/tasks/imo_answer_bench_0shot_gen.py
@@ -176,7 +176,7 @@ class IMOAnswerBenchZeroShotGenTask(
         ground_truth = ctx.raw_sample["answer"]
         gold = normalize_answer(ground_truth)
         for rollout in post["rollouts"]:
-            pred = rollout["prediction"]
+            pred = rollout.get("prediction")
             if pred is None or gold is None:
                 rollouts.append(build_rollout_judgement(rollout["index"], False))
                 continue

--- a/sieval/tasks/livecodebench_code_generation_0shot_gen.py
+++ b/sieval/tasks/livecodebench_code_generation_0shot_gen.py
@@ -164,7 +164,7 @@ class LiveCodeBenchCodeGenerationZeroShotGenTask(
                         # so the evaluator still runs it and reports a compile
                         # error -- the pre-protocol behaviour, and a real verdict
                         # rather than a skipped rollout.
-                        "code": rollout["prediction"] or "",
+                        "code": rollout.get("prediction") or "",
                         "test": {
                             "inputs": inputs,
                             "outputs": outputs,

--- a/sieval/tasks/livecodebench_code_generation_kshot_base_gen.py
+++ b/sieval/tasks/livecodebench_code_generation_kshot_base_gen.py
@@ -235,7 +235,7 @@ class LiveCodeBenchCodeGenerationFewShotBaseGenTask(
                         # An unextractable answer is None here but "" on the wire,
                         # so the evaluator still runs it and reports a compile
                         # error -- a real verdict rather than a skipped rollout.
-                        "code": rollout["prediction"] or "",
+                        "code": rollout.get("prediction") or "",
                         "test": {
                             "inputs": inputs,
                             "outputs": outputs,

--- a/sieval/tasks/math_500_0shot_gen.py
+++ b/sieval/tasks/math_500_0shot_gen.py
@@ -97,7 +97,7 @@ class MATH500ZeroShotGenTask(
         rollouts = []
         ground_truth = ctx.raw_sample["answer"]
         for rollout in post["rollouts"]:
-            pred = rollout["prediction"]
+            pred = rollout.get("prediction")
             if pred is None:
                 rollouts.append(build_rollout_judgement(rollout["index"], False))
                 continue

--- a/sieval/tasks/mbpp_kshot_base_gen.py
+++ b/sieval/tasks/mbpp_kshot_base_gen.py
@@ -197,7 +197,7 @@ class MBPPFewShotBaseGenTask(
                 # An unextractable completion is None here but "" on the wire, so
                 # the evaluator still runs the tests alone and reports a real
                 # verdict -- the pre-protocol behaviour, not a skipped rollout.
-                pred = rollout["prediction"] or ""
+                pred = rollout.get("prediction") or ""
                 check_program = "\n".join(p for p in (pred, tests) if p).strip()
                 resp = await self._http_client.post(
                     self._code_eval_api,

--- a/sieval/tasks/mmlu_0shot_gen.py
+++ b/sieval/tasks/mmlu_0shot_gen.py
@@ -102,7 +102,7 @@ class MMLUZeroShotGenTask(
         answer = "ABCD"[ctx.raw_sample["answer"]]
         subject = ctx.raw_sample.get("subject", "unknown")
         category = subject2category.get(subject, "other")
-        prediction = post["rollouts"][0]["prediction"]
+        prediction = post["rollouts"][0].get("prediction")
         return True, build_judgement_record(
             answer,
             [build_rollout_judgement(0, prediction == answer)],

--- a/sieval/tasks/mmlu_kshot_clp.py
+++ b/sieval/tasks/mmlu_kshot_clp.py
@@ -240,7 +240,7 @@ class MMLUFewShotCLPTask(
         answer = CHOICES[ctx.raw_sample["answer"]]
         subject = ctx.raw_sample.get("subject", "unknown")
         category = subject2category.get(subject, "other")
-        prediction = post["rollouts"][0]["prediction"]
+        prediction = post["rollouts"][0].get("prediction")
         return True, build_judgement_record(
             answer,
             [build_rollout_judgement(0, prediction == answer)],

--- a/sieval/tasks/mmlu_pro_0shot_gen.py
+++ b/sieval/tasks/mmlu_pro_0shot_gen.py
@@ -80,7 +80,7 @@ class MMLUProZeroShotGenTask(
     async def feedback(self, post, ctx):
         answer = ctx.raw_sample["answer"]
         category = ctx.raw_sample["category"]
-        prediction = post["rollouts"][0]["prediction"]
+        prediction = post["rollouts"][0].get("prediction")
         return True, build_judgement_record(
             answer,
             [build_rollout_judgement(0, prediction == answer)],

--- a/sieval/tasks/mmmlu_kshot_clp.py
+++ b/sieval/tasks/mmmlu_kshot_clp.py
@@ -325,7 +325,7 @@ class MMMLUKShotClpTask(
         ],
     ) -> tuple[bool, JudgementRecord]:
         raw = ctx.raw_sample
-        prediction = post["rollouts"][0]["prediction"]
+        prediction = post["rollouts"][0].get("prediction")
         if raw is None:
             # No sample to grade against. The empty grouping keys are what the
             # pre-migration shape recorded, and report() maps them to "unknown".

--- a/sieval/tasks/openbookqa_kshot_gen.py
+++ b/sieval/tasks/openbookqa_kshot_gen.py
@@ -173,7 +173,7 @@ class OpenBookQAFewShotGenTask(
     @override
     async def feedback(self, post, ctx):
         answer = ctx.raw_sample["answerKey"]
-        prediction = post["rollouts"][0]["prediction"]
+        prediction = post["rollouts"][0].get("prediction")
         return True, build_judgement_record(
             answer, [build_rollout_judgement(0, prediction == answer)]
         )

--- a/sieval/tasks/ruler_0shot_gen.py
+++ b/sieval/tasks/ruler_0shot_gen.py
@@ -218,7 +218,7 @@ class RulerZeroShotGenTask(
         per-sample term is computed here and report() averages the stored values.
         Same arithmetic, same floats, and now every row is inspectable.
         """
-        prediction = post["rollouts"][0]["prediction"] or ""
+        prediction = post["rollouts"][0].get("prediction") or ""
         references = list(ctx.raw_sample["outputs"])
         subtask = ctx.raw_sample["subtask"]
         lowered = prediction.lower()

--- a/sieval/tasks/simpleqa_verified_0shot_gen.py
+++ b/sieval/tasks/simpleqa_verified_0shot_gen.py
@@ -180,7 +180,7 @@ class SimpleQAVerifiedZeroShotGenTask(
 
         rollouts: list[RolloutJudgement] = []
         for rollout in post["rollouts"]:
-            predicted = rollout["prediction"] or ""
+            predicted = rollout.get("prediction") or ""
             prompt = GRADER_TEMPLATE.format(
                 question=question,
                 target=gold,

--- a/sieval/tasks/t_eval_before_calling_0shot_gen.py
+++ b/sieval/tasks/t_eval_before_calling_0shot_gen.py
@@ -142,7 +142,7 @@ class TEvalBeforeCallingZeroShotGenTask(
         `parse_error` is a count of unparseable segments, not a measurement of the
         answer, so it stays in `extra`.
         """
-        prediction = post["rollouts"][0]["prediction"] or ""
+        prediction = post["rollouts"][0].get("prediction") or ""
         resp_data_sample, error = self._process_response(
             {
                 "template": ctx.raw_sample["template"],

--- a/sieval/tasks/theoremqa_kshot_base_gen.py
+++ b/sieval/tasks/theoremqa_kshot_base_gen.py
@@ -488,7 +488,7 @@ class TheoremQAKShotBaseGenTask(
     async def feedback(self, post, ctx):
         answer, groundtruth_num = _groundtruth_args(ctx.raw_sample)
         # `or ""` restores exactly what the comparator saw pre-migration.
-        prediction = post["rollouts"][0]["prediction"] or ""
+        prediction = post["rollouts"][0].get("prediction") or ""
         return True, build_judgement_record(
             answer,
             [

--- a/tests/unit/scripts/test_check_preflight.py
+++ b/tests/unit/scripts/test_check_preflight.py
@@ -2350,9 +2350,8 @@ class TestCheckRecordKeyAccess:
         assert "confidence" in r.details[0]
 
     def test_unclassified_key_on_non_rollout_record_fails(self, tmp_path: Path):
-        # The classification spans all five record classes, not just the rollout
-        # ones: a key added to JudgementRecord must be decided on too. This is the
-        # hole `reference` sat in -- outside the gate without anyone saying so.
+        # Classification spans all five record classes, so a key added to
+        # JudgementRecord must be decided on too -- the hole `reference` sat in.
         r = self._run(
             tmp_path,
             "x = 1\n",

--- a/tests/unit/scripts/test_check_preflight.py
+++ b/tests/unit/scripts/test_check_preflight.py
@@ -2136,18 +2136,37 @@ class TestCheckTaskShotKnobs:
 class TestCheckRecordKeyAccess:
     """The guard on `[]` access to a rollout key that is absent on disk."""
 
-    #: Minimal stand-in for sieval/core/tasks/records.py. Only the NotRequired
-    #: annotations on the two rollout TypedDicts are read.
+    #: Minimal stand-in for sieval/core/tasks/records.py. The NotRequired
+    #: annotations on all five record TypedDicts are read, not just the rollout
+    #: ones -- a key on PromptRecord/JudgementRecord must be classified too.
     RECORDS = (
+        "class PromptRecord(TypedDict):\n"
+        "    prompt: JSONValue\n"
+        "    reference: NotRequired[JSONValue | None]\n"
+        "    extra: NotRequired[dict]\n"
+        "\n"
         "class RolloutPrediction(TypedDict):\n"
         "    index: int\n"
         "    prediction: NotRequired[JSONValue | None]\n"
         "    extracted: bool\n"
         "    extra: NotRequired[dict]\n"
         "\n"
+        "class PredictionRecord(TypedDict):\n"
+        "    rollouts: list[RolloutPrediction]\n"
+        "    extra: NotRequired[dict]\n"
+        "\n"
         "class RolloutJudgement(TypedDict):\n"
         "    index: int\n"
         "    correct: bool\n"
+        "    score: NotRequired[float]\n"
+        "    metrics: NotRequired[dict[str, bool | float]]\n"
+        "    extra: NotRequired[dict]\n"
+        "\n"
+        "class JudgementRecord(TypedDict):\n"
+        "    reference: NotRequired[JSONValue | None]\n"
+        "    rollouts: list[RolloutJudgement]\n"
+        "    n_rollouts: int\n"
+        "    n_correct: int\n"
         "    score: NotRequired[float]\n"
         "    metrics: NotRequired[dict[str, bool | float]]\n"
         "    extra: NotRequired[dict]\n"
@@ -2208,6 +2227,47 @@ class TestCheckRecordKeyAccess:
         )
         assert r.status == "FAIL"
 
+    def test_enumerate_tuple_target_flagged(self, tmp_path: Path):
+        # The natural way to write feedback for a task that needs the rollout
+        # index. Needs both a tuple target and unwrapping the enumerate() call.
+        r = self._run(
+            tmp_path,
+            "async def feedback(self, post, ctx):\n"
+            "    for i, rollout in enumerate(post['rollouts']):\n"
+            "        print(i, rollout['prediction'])\n",
+        )
+        assert r.status == "FAIL"
+        assert len(r.details) == 1
+
+    def test_zip_tuple_target_flagged(self, tmp_path: Path):
+        # The rollout list is the second zip argument, so every argument has to
+        # be considered, not just the first.
+        r = self._run(
+            tmp_path,
+            "async def feedback(self, post, ctx):\n"
+            "    for gold, rollout in zip(golds, post['rollouts']):\n"
+            "        print(gold, rollout['prediction'])\n",
+        )
+        assert r.status == "FAIL"
+
+    def test_passthrough_builtin_flagged(self, tmp_path: Path):
+        r = self._run(
+            tmp_path,
+            "async def feedback(self, post, ctx):\n"
+            "    for rollout in reversed(post['rollouts']):\n"
+            "        print(rollout['prediction'])\n",
+        )
+        assert r.status == "FAIL"
+
+    def test_walrus_flagged(self, tmp_path: Path):
+        r = self._run(
+            tmp_path,
+            "async def feedback(self, post, ctx):\n"
+            "    for rollout in (rs := post['rollouts']):\n"
+            "        print(rollout['prediction'], len(rs))\n",
+        )
+        assert r.status == "FAIL"
+
     # --- what must NOT be flagged ------------------------------------------
 
     def test_get_access_passes(self, tmp_path: Path):
@@ -2250,6 +2310,28 @@ class TestCheckRecordKeyAccess:
         )
         assert r.status == "PASS"
 
+    def test_reference_not_flagged(self, tmp_path: Path):
+        # `reference` is classified but ungated: it is not read off a rollout, so
+        # gating it would be inert. ruler's `list(fb["reference"])` stays valid.
+        r = self._run(
+            tmp_path,
+            "async def report(self, finals, fails):\n"
+            "    fb = finals[0].feedback_result\n"
+            "    return list(fb['reference'])\n",
+        )
+        assert r.status == "PASS"
+
+    def test_known_limit_aliased_rollout_not_flagged(self, tmp_path: Path):
+        # Documented limit: following a rollout through a local name needs
+        # dataflow. Pinned so the gap is a decision, not a surprise.
+        r = self._run(
+            tmp_path,
+            "async def feedback(self, post, ctx):\n"
+            "    rollout = post['rollouts'][0]\n"
+            "    return rollout['prediction']\n",
+        )
+        assert r.status == "PASS"
+
     # --- the self-maintaining half -----------------------------------------
 
     def test_unclassified_notrequired_key_fails(self, tmp_path: Path):
@@ -2267,16 +2349,29 @@ class TestCheckRecordKeyAccess:
         assert r.status == "FAIL"
         assert "confidence" in r.details[0]
 
-    def test_every_declared_key_is_classified(self):
-        """The real records.py declares no key the check cannot place."""
-        results = PreflightRunner().check_record_key_access()
-        assert [r.status for r in results] == ["PASS"]
+    def test_unclassified_key_on_non_rollout_record_fails(self, tmp_path: Path):
+        # The classification spans all five record classes, not just the rollout
+        # ones: a key added to JudgementRecord must be decided on too. This is the
+        # hole `reference` sat in -- outside the gate without anyone saying so.
+        r = self._run(
+            tmp_path,
+            "x = 1\n",
+            records=self.RECORDS.replace(
+                "    n_rollouts: int\n",
+                "    n_rollouts: int\n    rubric: NotRequired[str]\n",
+            ),
+        )
+        assert r.status == "FAIL"
+        assert "rubric" in r.details[0]
 
-    def test_missing_records_module_skips(self, tmp_path: Path):
+    def test_missing_records_module_fails(self, tmp_path: Path):
+        # FAIL, not SKIP: records.py is the check's subject. A rename must not
+        # silently narrow the gate to nothing while preflight stays green.
         (tmp_path / "sieval" / "tasks").mkdir(parents=True)
         results = PreflightRunner(project_root=tmp_path).check_record_key_access()
         assert len(results) == 1
-        assert results[0].status == "SKIP"
+        assert results[0].status == "FAIL"
+        assert "not readable" in results[0].message
 
     def test_unparsable_module_reported_not_raised(self, tmp_path: Path):
         r = self._run(tmp_path, "def broken(:\n")
@@ -2284,6 +2379,10 @@ class TestCheckRecordKeyAccess:
         assert "could not parse" in r.details[0]
 
     def test_real_modules_pass(self):
-        """Integration: no shipped module indexes a gated rollout key."""
+        """Integration: the shipped tree satisfies both halves of the check.
+
+        No module indexes a gated rollout key, and the real ``records.py``
+        declares no ``NotRequired`` key the check cannot place.
+        """
         results = PreflightRunner().check_record_key_access()
         assert [r.status for r in results] == ["PASS"]

--- a/tests/unit/scripts/test_check_preflight.py
+++ b/tests/unit/scripts/test_check_preflight.py
@@ -127,12 +127,13 @@ class TestPreflightRunner:
     """Runner orchestration."""
 
     def test_all_checks_listed(self):
-        assert len(PreflightRunner.ALL_CHECKS) == 10
+        assert len(PreflightRunner.ALL_CHECKS) == 11
         assert "check_links" in PreflightRunner.ALL_CHECKS
         assert "check_examples" in PreflightRunner.ALL_CHECKS
         assert "check_meta_index_sync" in PreflightRunner.ALL_CHECKS
         assert "check_version" in PreflightRunner.ALL_CHECKS
         assert "check_task_shot_knobs" in PreflightRunner.ALL_CHECKS
+        assert "check_record_key_access" in PreflightRunner.ALL_CHECKS
 
     def test_run_all_returns_results(self):
         runner = PreflightRunner()
@@ -2129,4 +2130,160 @@ class TestCheckTaskShotKnobs:
     def test_real_tasks_pass(self):
         """Integration: the shipped tasks satisfy all three rules."""
         results = PreflightRunner().check_task_shot_knobs()
+        assert [r.status for r in results] == ["PASS"]
+
+
+class TestCheckRecordKeyAccess:
+    """The guard on `[]` access to a rollout key that is absent on disk."""
+
+    #: Minimal stand-in for sieval/core/tasks/records.py. Only the NotRequired
+    #: annotations on the two rollout TypedDicts are read.
+    RECORDS = (
+        "class RolloutPrediction(TypedDict):\n"
+        "    index: int\n"
+        "    prediction: NotRequired[JSONValue | None]\n"
+        "    extracted: bool\n"
+        "    extra: NotRequired[dict]\n"
+        "\n"
+        "class RolloutJudgement(TypedDict):\n"
+        "    index: int\n"
+        "    correct: bool\n"
+        "    score: NotRequired[float]\n"
+        "    metrics: NotRequired[dict[str, bool | float]]\n"
+        "    extra: NotRequired[dict]\n"
+    )
+
+    def _run(
+        self, tmp_path: Path, source: str, records: str | None = None
+    ) -> CheckResult:
+        records_dir = tmp_path / "sieval" / "core" / "tasks"
+        records_dir.mkdir(parents=True)
+        (records_dir / "records.py").write_text(
+            self.RECORDS if records is None else records
+        )
+        tasks_dir = tmp_path / "sieval" / "tasks"
+        tasks_dir.mkdir(parents=True)
+        (tasks_dir / "demo_0shot_gen.py").write_text(source)
+        results = PreflightRunner(project_root=tmp_path).check_record_key_access()
+        assert len(results) == 1
+        return results[0]
+
+    # --- the two shapes a rollout reaches a task through -------------------
+
+    def test_indexed_rollout_access_flagged(self, tmp_path: Path):
+        r = self._run(
+            tmp_path,
+            "async def feedback(self, post, ctx):\n"
+            "    return post['rollouts'][0]['prediction']\n",
+        )
+        assert r.status == "FAIL"
+        assert len(r.details) == 1
+        assert "demo_0shot_gen.py:2" in r.details[0]
+
+    def test_iterated_rollout_access_flagged(self, tmp_path: Path):
+        r = self._run(
+            tmp_path,
+            "async def feedback(self, post, ctx):\n"
+            "    for rollout in post['rollouts']:\n"
+            "        print(rollout['prediction'])\n",
+        )
+        assert r.status == "FAIL"
+        assert len(r.details) == 1
+
+    def test_comprehension_binding_flagged(self, tmp_path: Path):
+        r = self._run(
+            tmp_path,
+            "async def report(self, finals, fails):\n"
+            "    return [r['prediction'] for r in finals[0]['rollouts']]\n",
+        )
+        assert r.status == "FAIL"
+
+    def test_get_rollouts_binding_flagged(self, tmp_path: Path):
+        # `(f.feedback_result or {}).get("rollouts", [])` is the report-stage idiom.
+        r = self._run(
+            tmp_path,
+            "async def report(self, finals, fails):\n"
+            "    for r in (finals[0] or {}).get('rollouts', []):\n"
+            "        print(r['prediction'])\n",
+        )
+        assert r.status == "FAIL"
+
+    # --- what must NOT be flagged ------------------------------------------
+
+    def test_get_access_passes(self, tmp_path: Path):
+        r = self._run(
+            tmp_path,
+            "async def feedback(self, post, ctx):\n"
+            "    return post['rollouts'][0].get('prediction')\n",
+        )
+        assert r.status == "PASS"
+
+    def test_non_record_dict_not_flagged(self, tmp_path: Path):
+        # t_eval's `datum` carries a `prediction` key beside `ground_truth`; it is
+        # a task-local payload, not a PredictionRecord. Name-based matching would
+        # flag it and force a `.get()` that turns a real bug into a silent None.
+        r = self._run(
+            tmp_path,
+            "def _process(self, datum: dict):\n"
+            "    return datum['prediction'], datum['ground_truth']\n",
+        )
+        assert r.status == "PASS"
+
+    def test_required_rollout_keys_not_flagged(self, tmp_path: Path):
+        # `index` / `correct` are Required, so `[]` on them is safe.
+        r = self._run(
+            tmp_path,
+            "async def feedback(self, post, ctx):\n"
+            "    for rollout in post['rollouts']:\n"
+            "        print(rollout['index'], rollout['extracted'])\n",
+        )
+        assert r.status == "PASS"
+
+    def test_ungated_keys_not_flagged(self, tmp_path: Path):
+        # `extra` is NotRequired but deliberately ungated: every read is nested,
+        # so a mechanical `.get()` would swap KeyError for TypeError.
+        r = self._run(
+            tmp_path,
+            "async def report(self, finals, fails):\n"
+            "    for r in finals[0]['rollouts']:\n"
+            "        print(r['extra']['grade'], r['score'], r['metrics'])\n",
+        )
+        assert r.status == "PASS"
+
+    # --- the self-maintaining half -----------------------------------------
+
+    def test_unclassified_notrequired_key_fails(self, tmp_path: Path):
+        # A NotRequired rollout key in neither _GATED nor _UNGATED must fail
+        # rather than be silently skipped: that is what forces whoever adds a
+        # key to records.py to decide whether `[]` on it is a latent KeyError.
+        r = self._run(
+            tmp_path,
+            "x = 1\n",
+            records=self.RECORDS.replace(
+                "    extracted: bool\n",
+                "    extracted: bool\n    confidence: NotRequired[float]\n",
+            ),
+        )
+        assert r.status == "FAIL"
+        assert "confidence" in r.details[0]
+
+    def test_every_declared_key_is_classified(self):
+        """The real records.py declares no key the check cannot place."""
+        results = PreflightRunner().check_record_key_access()
+        assert [r.status for r in results] == ["PASS"]
+
+    def test_missing_records_module_skips(self, tmp_path: Path):
+        (tmp_path / "sieval" / "tasks").mkdir(parents=True)
+        results = PreflightRunner(project_root=tmp_path).check_record_key_access()
+        assert len(results) == 1
+        assert results[0].status == "SKIP"
+
+    def test_unparsable_module_reported_not_raised(self, tmp_path: Path):
+        r = self._run(tmp_path, "def broken(:\n")
+        assert r.status == "FAIL"
+        assert "could not parse" in r.details[0]
+
+    def test_real_modules_pass(self):
+        """Integration: no shipped module indexes a gated rollout key."""
+        results = PreflightRunner().check_record_key_access()
         assert [r.status for r in results] == ["PASS"]


### PR DESCRIPTION
## Type

- fix — bug fix or alignment correction

## Summary

- **`rollout["prediction"]` raises `KeyError` on resume.** `build_prediction_record` spells "could not extract" as `prediction=None`; `obj_to_dict` drops `None`-valued keys; so on disk the key is *absent*, not null. The loader hydrates `postprocess_result` from disk and hands it to `feedback`, which then `KeyError`s for exactly the samples whose extraction failed. The identical line is fine on a fresh run — which is why every in-memory test passes.
- **39 sites across 39 task modules** were indexing it. All become `.get("prediction")`: exactly equivalent when the key is present, and otherwise yielding the same `None` the fresh path produced. **No behaviour change on a fresh run** — the resumed path simply stops diverging from it.
- **The real fix is the enforcer.** The contract was already correct in three places and still nothing stopped the drift (below), so this adds `check_preflight.py --check check_record_key_access`.
- Scope is deliberately `prediction` only; `_UNGATED_ROLLOUT_KEYS` records why `extra` / `score` / `metrics` are different in kind.

## Related Issues

Surfaced while reviewing #65 (PlatinumBench), whose task uses `.get("prediction")` with a three-line comment explaining why. It is not the first: `sieval/tasks/ruler_0shot_gen.py:261-264` is **already on `main`** with the same `.get()` and the same three-line explanation, on its resume-report path. That sharpens the argument rather than softening it — the hazard was documented in prose inside a *merged* module, and 39 other modules drifted off it anyway. Documentation of the mechanism is not enforcement of it. Refs #65.

**Suggested merge order: this PR before #65.** #65 is unaffected either way (it is already compliant), but landing the guard first means it merges into a tree where the rule is enforced rather than one where it is a comment.

## Why nothing caught this

This is the part worth reviewing, more than the 39 one-line edits.

The contract was already stated three times over:

1. `RolloutPrediction.prediction` is declared `NotRequired[JSONValue | None]` — the type does **not** lie.
2. Its docstring: *"absent on disk in that case, so read `extracted` instead"*, and `extracted` is labelled *"The durable signal."*
3. `test_records.py::TestSerializationRoundTrip::test_none_prediction_is_absent_but_extracted_survives` already pins the exact behaviour, and passes.

`records.py` is *also* defensive about the same hazard elsewhere: `_checked_metrics` hard-rejects a `None` metric because "a `None` metric would be absent on disk, turning 'not measured' into 'never existed'".

And yet 38 modules drifted off it with CI green the whole time, because **neither type checker reports a `[]` subscript of a `NotRequired` key**:

```python
class Rollout(TypedDict):
    index: int
    prediction: NotRequired[str | None]

def unsafe(r: Rollout) -> object:
    return r["prediction"]      # may KeyError at runtime
```

- `ty` → `All checks passed!`
- `mypy --strict` → `Success: no issues found in 1 source file`

Both are behaving per spec — the typing spec leaves that diagnostic optional (pyright has `reportTypedDictNotRequiredAccess`, not used here). So the root cause is not the serializer dropping `None`, which is a deliberate, documented, tested design. It is that a correctly declared, correctly documented, unit-tested contract had **no enforcement at the call site**. Documentation and a test of the *mechanism* did not stop 38 violations of it.

## The check

`check_record_key_access` is **structural, not name-based**: a key is flagged only when its base provably comes from a record's `rollouts` — either indexed (`post["rollouts"][0][...]`) or iterated (`for r in post["rollouts"]`, comprehensions, and the `.get("rollouts", [])` report-stage idiom). That precision matters: `t_eval_before_calling_0shot_gen.py` has a task-local `datum["prediction"]` whose sibling key is `ground_truth`. It is not a record, absence there is a genuine bug, and a name-based rule would have forced a `.get()` that silently swallows it. It is correctly left untouched.

Gated set is `prediction` alone. `_UNGATED_ROLLOUT_KEYS` names the rest with reasons rather than ignoring them:

- **`extra`** — absence is an *authoring* choice, not a runtime outcome: the task reading `r["extra"]["grade"]` is the same task that wrote that extra, unconditionally. And all 11 reads are **nested**, so a mechanical `.get()` would turn `KeyError` into `NoneType is not subscriptable` — strictly worse. Needs a per-site pass, not a sweep.
- **`score` / `metrics`** — same authoring argument, plus `RolloutJudgement` states "absent is not zero", so a `.get()` returning `None` becomes a wrong metric instead of a loud failure.

A `NotRequired` rollout key in **neither** set makes the check FAIL rather than be silently skipped, so adding one to `records.py` forces the classification. That is what keeps the gate from quietly narrowing over time.

## Test Plan

### Automated

- [x] Lint/format clean (`ruff check && ruff format --check`, 370 files)
- [x] Type check clean (`ty check`)
- [x] Unit + integration + acceptance: **2999 passed** (13 new)
- [x] Full preflight clean (`scripts/check_preflight.py`, exit 0), including the new `check_record_key_access`

New tests cover both rollout shapes (indexed / iterated / comprehension / `.get("rollouts")`), the `.get()` form passing, Required keys not being flagged, the ungated keys not being flagged, the non-record `datum` false-positive case, an unparsable module, a missing `records.py`, and the unclassified-key failure.

### Manual

- [x] **Reproduced the bug against production code**, not a mock: feeding `GSM8KZeroShotGenTask.feedback` a prediction record that has been through the real serializer raises `KeyError('prediction')`, while the in-memory record scores normally.

  ```
  fresh (in-memory) record : {'rollouts': [{'index': 0, 'prediction': None, 'extracted': False}]}
  resumed (from disk)      : {'rollouts': [{'index': 0, 'extracted': False}]}
  fresh run   -> feedback ok, finalize=True
  resumed run -> KeyError('prediction') raised out of feedback
  ```

- [x] **The guard discriminates**: it reports exactly **39** violations on the parent commit and **PASS** after the edits. Not a check that trivially passes.
- [x] Confirmed on a real run's shard data that the key is genuinely absent on disk — a stored `postprocessed` record for a truncated sample reads `{"index": 0, "extracted": false}`.
- [x] Trigger window characterised (narrower than "any resume"): needs a sample that both failed extraction *and* was interrupted between its `postprocess` and `feedback` records landing. Reachable in normal operation — at interruption, samples are spread across stages — and likeliest on tasks that truncate often, which are also the long-running ones most likely to be interrupted.

## Checklist

### Required (all PRs)

- [x] PR title follows conventional format (`type(scope): description`)
- [x] No internal paths, credentials, or personal info in committed files
- [x] AI-generated code has `AI-Generated Code - <model> (<provider>)` in module docstring — touched files already carry theirs; no new modules added
- [x] No new upper-layer dependencies added to `core/` (`core/` is untouched)
- [x] Deleted code verified — nothing deleted

### If: Breaking Change

Not a breaking change. `.get()` returns the same value whenever `[]` would have succeeded; it only replaces a crash with the value the fresh path already produced.

### If: New Dependency

Not applicable — no new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review follow-ups — `289756d3`

Second commit, all on the guard itself; the 39 call-site fixes are unchanged.

- **`enumerate` / `zip` were blind spots.** `_rollout_bound_names` only bound a name when the `for` target was a bare `ast.Name` *and* the iterable was directly a rollout container, so `for i, r in enumerate(post["rollouts"])` — the natural way to write feedback for a task needing the rollout index — passed the check while reintroducing the identical `KeyError`. Tuple targets now bind every `Name` element, and `_rollout_container` unwraps the pass-through builtins (`enumerate`/`zip`/`reversed`/`list`/`sorted`) and a walrus. Probe of twelve shapes: **5 flagged before, 8 now.** The remaining four all need the rollout list to pass through a *name* first (`rs = post["rollouts"]`, a helper parameter) — dataflow, not a syntactic walk — and are documented as deliberate limits, with one pinned by a test.
- **Classification widened to all five record TypedDicts.** `JudgementRecord.reference` shares `prediction`'s exact shape (`build_judgement_record` writes it unconditionally, so `None` is present in memory and dropped on disk) yet sat in *neither* set — nothing forced a decision on it, and nothing would have forced one for a key added to `PromptRecord` either. Now classified **ungated**, with the reason recorded: the single `[]` read (ruler's report) consumes it as an iterable, so a mechanical `.get()` would swap `KeyError` for a `list(None)` `TypeError` — the same trap as `extra`'s nested reads. Gating a key whose reads are not rollout subscripts would be inert and would read as coverage the check does not have.
- **An unreadable `records.py` now FAILs instead of SKIPping.** It is the check's subject, not an optional input: renaming it would otherwise narrow the gate to nothing with preflight still green — the same silent narrowing the unclassified-key branch exists to prevent.
- Dropped a duplicate integration test whose body was identical to its sibling.

What `reference` actually lacks is a durable signal for *which* of its two absence causes applies (task truth is a procedure vs. this sample's gold is missing) — `prediction` has `extracted` plus `detect_extraction_failure` for exactly this, `reference` has nothing. Out of scope here; tracked in #71.

### Verification

- [x] Guard still reports **exactly 39** violations on the parent commit, **PASS** here — the widening did not cost detection.
- [x] New tests **fail** when the tuple-target handling is reverted (`assert 'PASS' == 'FAIL'` on both `enumerate`/`zip` cases).
- [x] `ruff check` + `ruff format` clean; `ty check` clean.
- [x] **3016 passed** (19 new here) after rebasing onto `ee30abe6` (#66), full `scripts/check_preflight.py` exit 0, `tests/performance` 66 passed.
- [x] Rebased onto `ee30abe6` (#66). #66 rewrote both livecodebench task modules; verified after the rebase that their `.get("prediction")` survived at the new line numbers, that #66's per-case timeout logic is intact, and that commit 1's stat is byte-identical to its pre-rebase form (43 files, 416/42). 39 task modules, 39 `.get("prediction")` sites, and the only remaining `["prediction"]` in the tree is t_eval's intentional task-local `datum`.
