### PR TITLE
refactor(mmmlu): sample via stratified_sample instead of a private sampler

### DIFF
--- a/sieval/cli/leaderboard/session.py
+++ b/sieval/cli/leaderboard/session.py
@@ -1342,6 +1342,20 @@ class EvalSession:
                             f"Dataset '{dataset_name}': 'stratified_sample' "
                             f"'min_per_group' cannot be combined with 'per_group'"
                         )
+                    # Checked here as well as in the transform so the message
+                    # names the offending dataset, like the guards above. `bool`
+                    # is an `int` subclass, so `fraction: true` would otherwise
+                    # pass the range test and silently keep every row.
+                    if fraction is not None and (
+                        isinstance(fraction, bool)
+                        or not isinstance(fraction, int | float)
+                        or not 0 < fraction <= 1
+                    ):
+                        raise ValueError(
+                            f"Dataset '{dataset_name}': 'stratified_sample' "
+                            f"'fraction' must be a number in the interval (0, 1]; "
+                            f"got {fraction!r}"
+                        )
                     seed = op_args.get("seed", 0)
                     split = op_args.get("split", "test")
                     dataset = dataset.stratified_sample(
@@ -1356,11 +1370,11 @@ class EvalSession:
                     if per_group is not None:
                         budget_desc = f"per_group={per_group}"
                     elif fraction is not None:
-                        budget_desc = (
-                            f"fraction={fraction}, min_per_group={min_per_group}"
-                        )
+                        budget_desc = f"fraction={fraction}"
                     else:
-                        budget_desc = f"num={num}, min_per_group={min_per_group}"
+                        budget_desc = f"num={num}"
+                    if min_per_group is not None:
+                        budget_desc += f", min_per_group={min_per_group}"
                     logger.debug(
                         "Dataset '{}': stratified-sampled by '{}' ({}, seed={})",
                         dataset_name,

--- a/sieval/cli/leaderboard/session.py
+++ b/sieval/cli/leaderboard/session.py
@@ -1323,16 +1323,19 @@ class EvalSession:
                     by = op_args.get("by")
                     num = op_args.get("num", op_args.get("n"))
                     per_group = op_args.get("per_group")
+                    fraction = op_args.get("fraction")
                     min_per_group = op_args.get("min_per_group")
                     if by is None:
                         raise ValueError(
                             f"Dataset '{dataset_name}': 'stratified_sample' "
                             f"requires 'by'"
                         )
-                    if (num is None) == (per_group is None):
+                    budgets = [num, per_group, fraction]
+                    if sum(budget is not None for budget in budgets) != 1:
                         raise ValueError(
                             f"Dataset '{dataset_name}': 'stratified_sample' "
-                            f"requires exactly one of 'num' or 'per_group'"
+                            f"requires exactly one of 'num', 'per_group' or "
+                            f"'fraction'"
                         )
                     if per_group is not None and min_per_group is not None:
                         raise ValueError(
@@ -1345,19 +1348,24 @@ class EvalSession:
                         by,
                         num=num,
                         per_group=per_group,
+                        fraction=fraction,
                         min_per_group=min_per_group,
                         seed=seed,
                         split=split,
                     )
+                    if per_group is not None:
+                        budget_desc = f"per_group={per_group}"
+                    elif fraction is not None:
+                        budget_desc = (
+                            f"fraction={fraction}, min_per_group={min_per_group}"
+                        )
+                    else:
+                        budget_desc = f"num={num}, min_per_group={min_per_group}"
                     logger.debug(
                         "Dataset '{}': stratified-sampled by '{}' ({}, seed={})",
                         dataset_name,
                         by,
-                        (
-                            f"per_group={per_group}"
-                            if per_group is not None
-                            else f"num={num}, min_per_group={min_per_group}"
-                        ),
+                        budget_desc,
                         seed,
                     )
 

--- a/sieval/core/datasets/dataset.py
+++ b/sieval/core/datasets/dataset.py
@@ -1,6 +1,7 @@
 """Abstract Dataset base class backed by HuggingFace DatasetDict."""
 
 import copy
+import math
 import random
 from abc import ABC, abstractmethod
 from collections.abc import Iterator
@@ -151,6 +152,7 @@ class Dataset[TSample](ABC):
         *,
         num: int | None = None,
         per_group: int | None = None,
+        fraction: float | None = None,
         min_per_group: int | None = None,
         seed: int = 0,
         split: str = "test",
@@ -161,30 +163,45 @@ class Dataset[TSample](ABC):
         name, or a list whose values form a composite key). Exactly one budget
         must be given:
 
-        * ``num`` — **proportional** allocation. Each stratum gets a floor of
-          ``min(min_per_group, stratum_size)`` (``min_per_group`` defaults to 1);
-          the remaining budget toward *num* is distributed proportionally to
-          stratum size (capped by availability). If the floors already sum above
-          *num*, the total rises to honour them and a warning is logged.
+        * ``num`` — **proportional** allocation toward a *total*. Each stratum
+          gets a floor of ``min(min_per_group, stratum_size)`` (``min_per_group``
+          defaults to 1); the remaining budget toward *num* is distributed
+          proportionally to stratum size (capped by availability). If the floors
+          already sum above *num*, the total rises to honour them and a warning
+          is logged.
         * ``per_group`` — **equal** allocation. Each stratum keeps exactly
           ``min(per_group, stratum_size)`` rows; strata smaller than *per_group*
           keep all their rows and a single summary warning is logged.
+        * ``fraction`` — **share of each stratum**, in ``(0, 1]``. Each stratum
+          keeps ``ceil(stratum_size * fraction)`` rows, never fewer than the
+          floor. Unlike ``num`` this needs no total, so it states a protocol
+          ("10% of every locale") directly and stays correct when the dataset
+          grows. The resulting total is whatever the per-stratum ceilings sum to.
 
-        ``min_per_group`` applies only to the proportional (``num``) path and may
-        not be combined with ``per_group``. Within each stratum rows are chosen by
-        a deterministic *seed*-driven shuffle, so the selection reproduces across
+        ``min_per_group`` applies to the ``num`` and ``fraction`` paths, which
+        both allocate per stratum, and may not be combined with ``per_group``
+        (which already fixes the count). Within each stratum rows are chosen by a
+        deterministic *seed*-driven shuffle, so the selection reproduces across
         runs and processes.
 
         Returns ``self`` unchanged if *split* is absent or empty.
         """
-        if (num is None) == (per_group is None):
+        budgets = [num, per_group, fraction]
+        if sum(budget is not None for budget in budgets) != 1:
             raise ValueError(
-                "stratified_sample: provide exactly one of 'num' or 'per_group'"
+                "stratified_sample: provide exactly one of 'num', 'per_group' "
+                "or 'fraction'"
             )
         if per_group is not None and min_per_group is not None:
             raise ValueError(
-                "stratified_sample: 'min_per_group' applies only to proportional "
-                "('num') sampling and cannot be combined with 'per_group'"
+                "stratified_sample: 'min_per_group' applies to the per-stratum "
+                "('num' / 'fraction') paths and cannot be combined with "
+                "'per_group'"
+            )
+        if fraction is not None and not 0 < fraction <= 1:
+            raise ValueError(
+                "stratified_sample: 'fraction' must be in the interval (0, 1]; "
+                f"got {fraction!r}"
             )
 
         if split not in self._dataset_dict:
@@ -230,9 +247,19 @@ class Dataset[TSample](ABC):
                     len(keys),
                     sum(per_group - sizes[key] for key in short),
                 )
+        elif fraction is not None:
+            # Share of each stratum, rounded up so a small stratum still
+            # contributes; the floor applies as it does on the `num` path. No
+            # total is involved, so nothing has to be redistributed.
+            floor = 1 if min_per_group is None else min_per_group
+            alloc = {
+                key: min(sizes[key], max(floor, math.ceil(sizes[key] * fraction)))
+                for key in keys
+            }
         else:
             # Proportional allocation toward num, honouring the floor.
-            # num is non-None here (the per_group is None branch guarantees it).
+            # num is non-None here: it is the only budget left once per_group and
+            # fraction are ruled out, and exactly one was required.
             assert num is not None
             floor = 1 if min_per_group is None else min_per_group
             total = len(hf)

--- a/sieval/core/datasets/dataset.py
+++ b/sieval/core/datasets/dataset.py
@@ -180,9 +180,14 @@ class Dataset[TSample](ABC):
 
         ``min_per_group`` applies to the ``num`` and ``fraction`` paths, which
         both allocate per stratum, and may not be combined with ``per_group``
-        (which already fixes the count). Within each stratum rows are chosen by a
-        deterministic *seed*-driven shuffle, so the selection reproduces across
-        runs and processes.
+        (which already fixes the count). It behaves differently on the two,
+        because rounding up already keeps every non-empty stratum: on ``num`` the
+        floor decides whether a small stratum survives at all (``min_per_group=0``
+        lets one drop to zero), while on ``fraction`` it can only *raise* a
+        stratum's share above its ceiling — a stratum there always keeps at least
+        one row. Within each stratum rows are chosen by a deterministic
+        *seed*-driven shuffle, so the selection reproduces across runs and
+        processes.
 
         Returns ``self`` unchanged if *split* is absent or empty.
         """
@@ -198,10 +203,19 @@ class Dataset[TSample](ABC):
                 "('num' / 'fraction') paths and cannot be combined with "
                 "'per_group'"
             )
-        if fraction is not None and not 0 < fraction <= 1:
+        # Budgets arrive from YAML, so the annotation is not a guarantee. `bool`
+        # is rejected explicitly because it is an `int` subclass: `fraction: true`
+        # would otherwise pass `0 < f <= 1` and silently keep every row. The
+        # message matches the one `EvalSession` raises, so the same bad value
+        # reads the same whether it came from YAML or a direct call.
+        if fraction is not None and (
+            isinstance(fraction, bool)
+            or not isinstance(fraction, int | float)
+            or not 0 < fraction <= 1
+        ):
             raise ValueError(
-                "stratified_sample: 'fraction' must be in the interval (0, 1]; "
-                f"got {fraction!r}"
+                "stratified_sample: 'fraction' must be a number in the interval "
+                f"(0, 1]; got {fraction!r}"
             )
 
         if split not in self._dataset_dict:

--- a/sieval/tasks/mmmlu_kshot_clp.py
+++ b/sieval/tasks/mmmlu_kshot_clp.py
@@ -20,12 +20,23 @@ Deviations from those references:
       not a task argument — the task used to carry its own stratified sampler::
 
           operations:
-            - stratified_sample: {by: [Locale, Subject], fraction: 0.1, seed: 0}
+            - stratified_sample:
+                {by: [Locale, Subject], fraction: 0.1, min_per_group: 6, seed: 0}
 
-      Group by ``[Locale]`` alone for a per-language share.  Operations run when
-      the dataset is built, so the subsample still precedes few-shot reservation
-      exactly as before, and scoring, reservation and aggregation stay identical
-      between full and sampled runs.
+      Stratify by ``[Locale, Subject]``, the same key few-shot reservation uses.
+      Reservation needs *more* than ``n_shot`` rows in every ``(Locale, Subject)``
+      cell, so the budget has to keep at least ``n_shot + 1`` per cell — hence
+      ``min_per_group``, and a *fraction* large enough for the smallest subject
+      (MMLU's smallest test subjects hold 100 rows, so ``0.1`` clears the default
+      ``n_shot=5``; ``0.05`` does not, and fails loudly).  Stratifying by
+      ``[Locale]`` alone applies no per-subject floor: it can leave a cell short
+      (a hard error) or drop one entirely, which is *silent* — the subject simply
+      never reaches the scored split and vanishes from the size-weighted
+      aggregation.  Do not sample this task that way.
+
+      Operations run when the dataset is built, so the subsample still precedes
+      few-shot reservation exactly as before, and the scoring, reservation and
+      aggregation *mechanism* is identical for full and sampled runs.
 
 Reproduction decoding: greedy ``temperature=0`` with ``max_tokens=1`` and
 top-``logprobs`` scoring.  These are structural to ``alogprobs`` (next-token

--- a/sieval/tasks/mmmlu_kshot_clp.py
+++ b/sieval/tasks/mmmlu_kshot_clp.py
@@ -15,11 +15,17 @@ Deviations from those references:
       ``args.locales`` (e.g. ``[zh_cn]`` for a Chinese run).  There is no
       separate ZH-CN task; Chinese evaluation is this protocol restricted to
       one locale.
-    - The references define no sampling protocol.  Optional efficient
-      evaluation (e.g. the Qwen3 technical report's 10% MMMLU setting) is
-      offered via ``sample_fraction``/``sample_seed``/``sample_by``, applied in
-      ``setup()`` before few-shot reservation so scoring, reservation, and
-      aggregation are identical for full and sampled runs.
+    - The references define no sampling protocol.  Efficient evaluation (e.g.
+      the Qwen3 technical report's 10% MMMLU setting) is a *dataset* operation,
+      not a task argument — the task used to carry its own stratified sampler::
+
+          operations:
+            - stratified_sample: {by: [Locale, Subject], fraction: 0.1, seed: 0}
+
+      Group by ``[Locale]`` alone for a per-language share.  Operations run when
+      the dataset is built, so the subsample still precedes few-shot reservation
+      exactly as before, and scoring, reservation and aggregation stay identical
+      between full and sampled runs.
 
 Reproduction decoding: greedy ``temperature=0`` with ``max_tokens=1`` and
 top-``logprobs`` scoring.  These are structural to ``alogprobs`` (next-token
@@ -36,7 +42,6 @@ AI-Generated Code - GPT-5-Codex (OpenAI)
 """
 
 import math
-import random
 from collections.abc import Sequence
 from typing import TypedDict, cast, override
 
@@ -63,7 +68,6 @@ from sieval.datasets import MMMLUDatasetSample
 CHOICES = ("A", "B", "C", "D")
 DEFAULT_N_SHOT = 5
 OFFICIAL_MISSING_LOGPROB = -100.0
-MMMLU_SAMPLE_BY = ("locale", "locale_subject")
 
 
 class OfficialScores(TypedDict):
@@ -132,37 +136,6 @@ def _add_metric(
         counts["correct"] += 1
 
 
-def _normalize_sample_fraction(sample_fraction: object) -> float | None:
-    if sample_fraction is None:
-        return None
-    if isinstance(sample_fraction, bool) or not isinstance(
-        sample_fraction, int | float
-    ):
-        raise ValueError(
-            "MMMLU sample_fraction must be a number in the interval (0, 1]."
-        )
-    fraction = float(sample_fraction)
-    if not 0.0 < fraction <= 1.0:
-        raise ValueError(
-            "MMMLU sample_fraction must be a number in the interval (0, 1]."
-        )
-    return fraction
-
-
-def _normalize_sample_seed(sample_seed: object) -> int:
-    if isinstance(sample_seed, bool) or not isinstance(sample_seed, int):
-        raise ValueError("MMMLU sample_seed must be an integer.")
-    return sample_seed
-
-
-def _normalize_sample_by(sample_by: str) -> str:
-    normalized = str(sample_by).strip().lower()
-    if normalized not in MMMLU_SAMPLE_BY:
-        allowed = ", ".join(MMMLU_SAMPLE_BY)
-        raise ValueError(f"MMMLU sample_by must be one of: {allowed}.")
-    return normalized
-
-
 @sieval_task(
     name="mmmlu_kshot_clp",
     display_name="MMMLU (k-shot, CLP)",
@@ -215,9 +188,6 @@ class MMMLUKShotClpTask(
         n_shot: int = DEFAULT_N_SHOT,
         fewshot_split: str = "test",
         logprobs: int = 100,
-        sample_fraction: float | None = None,
-        sample_seed: int = 0,
-        sample_by: str = "locale_subject",
     ):
         if n_shot < 0:
             raise ValueError(f"n_shot must be >= 0, got {n_shot}")
@@ -227,19 +197,14 @@ class MMMLUKShotClpTask(
         self.n_shot = n_shot
         self._fewshot_split = fewshot_split
         self._logprobs = logprobs
-        self._sample_fraction = _normalize_sample_fraction(sample_fraction)
-        self._sample_seed = _normalize_sample_seed(sample_seed)
-        self._sample_by = _normalize_sample_by(sample_by)
         self._fewshot_by_group: dict[tuple[str, str], list[MMMLUDatasetSample]] | None
         self._fewshot_by_group = None
         self._fewshot_source_indices: set[int] = set()
         self._eval_split_excludes_fewshot = False
-        self._sampling_applied = False
         self._prompt_cache: dict[tuple[str, str], str] = {}
 
     @override
     async def setup(self) -> None:
-        self._apply_sampling()
         if self.n_shot > 0:
             self._ensure_fewshot_pool()
 
@@ -436,41 +401,6 @@ class MMMLUKShotClpTask(
 
         self._prompt_cache[group] = prompt
         return prompt
-
-    def _apply_sampling(self) -> None:
-        # Idempotent like _ensure_fewshot_pool / _exclude_fewshot_examples: the
-        # runner calls setup() once, but a second call must not sample a sample.
-        if self._sampling_applied:
-            return
-        if self._sample_fraction is None:
-            return
-
-        test_split = self.dataset.dataset_dict.get("test")
-        if test_split is None or len(test_split) == 0:
-            return
-
-        groups: dict[tuple[str, ...], list[int]] = {}
-        for index, row in enumerate(test_split):
-            groups.setdefault(self._sample_key(row), []).append(index)
-
-        sampled_indices: list[int] = []
-        for key in sorted(groups):
-            indices = groups[key].copy()
-            rng = random.Random(
-                f"{self._sample_seed}:{self._sample_by}:{'|'.join(key)}"
-            )
-            rng.shuffle(indices)
-            sample_size = max(1, math.ceil(len(indices) * self._sample_fraction))
-            sampled_indices.extend(indices[:sample_size])
-
-        self.dataset.dataset_dict["test"] = test_split.select(sampled_indices)
-        self._sampling_applied = True
-
-    def _sample_key(self, row: dict[str, object]) -> tuple[str, ...]:
-        locale = str(row.get("Locale", "")).strip()
-        if self._sample_by == "locale":
-            return (locale,)
-        return (locale, str(row.get("Subject", "")).strip())
 
     def _ensure_fewshot_pool(self) -> None:
         if self.n_shot <= 0:

--- a/tests/unit/cli/leaderboard/test_session.py
+++ b/tests/unit/cli/leaderboard/test_session.py
@@ -444,6 +444,22 @@ class TestDatasetOperations:
             split="test",
         )
 
+    @pytest.mark.parametrize("bad", [True, False, "0.1", 0, 1.5, -0.5])
+    def test_stratified_sample_rejects_a_bad_fraction_naming_the_dataset(self, bad):
+        # Guarded at this layer too so the message names the offending dataset,
+        # like the 'by' and budget-count guards. `True` is the trap: an `int`
+        # subclass that passes a bare range test and keeps every row.
+        runner = self._make_runner()
+        ds = MagicMock()
+        ds.stratified_sample.return_value = ds
+        with pytest.raises(ValueError, match=r"test_ds.*'fraction' must be a number"):
+            runner._apply_dataset_operations(
+                ds,
+                [{"stratified_sample": {"by": "Subject", "fraction": bad}}],
+                "test_ds",
+            )
+        ds.stratified_sample.assert_not_called()
+
     def test_stratified_sample_defaults(self):
         runner = self._make_runner()
         ds = MagicMock()

--- a/tests/unit/cli/leaderboard/test_session.py
+++ b/tests/unit/cli/leaderboard/test_session.py
@@ -380,7 +380,68 @@ class TestDatasetOperations:
             "test_ds",
         )
         ds.stratified_sample.assert_called_once_with(
-            "Subject", num=800, per_group=None, min_per_group=5, seed=42, split="test"
+            "Subject",
+            num=800,
+            per_group=None,
+            fraction=None,
+            min_per_group=5,
+            seed=42,
+            split="test",
+        )
+
+    def test_stratified_sample_fraction_dispatch(self):
+        # MMMLU's efficient-eval setting: a share of every (Locale, Subject) cell.
+        runner = self._make_runner()
+        ds = MagicMock()
+        ds.stratified_sample.return_value = ds
+        runner._apply_dataset_operations(
+            ds,
+            [
+                {
+                    "stratified_sample": {
+                        "by": ["Locale", "Subject"],
+                        "fraction": 0.1,
+                        "seed": 0,
+                    }
+                }
+            ],
+            "test_ds",
+        )
+        ds.stratified_sample.assert_called_once_with(
+            ["Locale", "Subject"],
+            num=None,
+            per_group=None,
+            fraction=0.1,
+            min_per_group=None,
+            seed=0,
+            split="test",
+        )
+
+    def test_stratified_sample_fraction_accepts_min_per_group(self):
+        runner = self._make_runner()
+        ds = MagicMock()
+        ds.stratified_sample.return_value = ds
+        runner._apply_dataset_operations(
+            ds,
+            [
+                {
+                    "stratified_sample": {
+                        "by": "Subject",
+                        "fraction": 0.05,
+                        "min_per_group": 3,
+                    }
+                }
+            ],
+            "test_ds",
+        )
+        ds.stratified_sample.assert_called_once_with(
+            "Subject",
+            num=None,
+            per_group=None,
+            fraction=0.05,
+            min_per_group=3,
+            seed=0,
+            split="test",
         )
 
     def test_stratified_sample_defaults(self):
@@ -394,6 +455,7 @@ class TestDatasetOperations:
             "category",
             num=600,
             per_group=None,
+            fraction=None,
             min_per_group=None,
             seed=0,
             split="test",
@@ -409,18 +471,21 @@ class TestDatasetOperations:
         with pytest.raises(ValueError, match="requires 'by'"):
             runner._apply_dataset_operations(ds, [{"stratified_sample": {}}], "test_ds")
 
-    def test_stratified_sample_requires_exactly_one_budget(self):
+    @pytest.mark.parametrize(
+        "budgets",
+        [
+            {},
+            {"num": 5, "per_group": 2},
+            {"num": 5, "fraction": 0.5},
+            {"per_group": 2, "fraction": 0.5},
+        ],
+    )
+    def test_stratified_sample_requires_exactly_one_budget(self, budgets):
         runner = self._make_runner()
         ds = MagicMock()
-        with pytest.raises(ValueError, match="exactly one of 'num' or 'per_group'"):
+        with pytest.raises(ValueError, match="exactly one of 'num', 'per_group'"):
             runner._apply_dataset_operations(
-                ds, [{"stratified_sample": {"by": "Subject"}}], "test_ds"
-            )
-        with pytest.raises(ValueError, match="exactly one of 'num' or 'per_group'"):
-            runner._apply_dataset_operations(
-                ds,
-                [{"stratified_sample": {"by": "Subject", "num": 5, "per_group": 2}}],
-                "test_ds",
+                ds, [{"stratified_sample": {"by": "Subject", **budgets}}], "test_ds"
             )
 
     def test_stratified_sample_min_per_group_excludes_per_group(self):
@@ -462,6 +527,7 @@ class TestDatasetOperations:
             ["locale", "subject"],
             num=None,
             per_group=20,
+            fraction=None,
             min_per_group=None,
             seed=42,
             split="test",

--- a/tests/unit/core/test_datasets.py
+++ b/tests/unit/core/test_datasets.py
@@ -631,8 +631,26 @@ class TestStratifiedFraction:
     @pytest.mark.parametrize("bad", [0, 0.0, -0.5, 1.5, 2])
     def test_fraction_outside_the_unit_interval_raises(self, bad):
         ds = _make_grouped({"a": 5})
-        with pytest.raises(ValueError, match=r"'fraction' must be in the interval"):
+        with pytest.raises(ValueError, match=r"'fraction' must be a number"):
             ds.stratified_sample(by="subject", fraction=bad, seed=0)
+
+    @pytest.mark.parametrize("bad", [True, False, "0.1", [0.1]])
+    def test_non_numeric_fraction_raises(self, bad):
+        # Budgets come from YAML, so the annotation guarantees nothing. `True` is
+        # the trap: it is an `int` subclass, so it passes `0 < f <= 1` and would
+        # silently keep every row rather than sampling.
+        ds = _make_grouped({"a": 5})
+        with pytest.raises(ValueError, match=r"'fraction' must be a number"):
+            ds.stratified_sample(by="subject", fraction=bad, seed=0)
+
+    def test_min_per_group_zero_still_keeps_every_stratum(self):
+        # Asymmetry with the `num` path: rounding up already keeps every
+        # non-empty stratum, so a zero floor cannot drop one here.
+        ds = _make_grouped({"a": 100, "b": 1})
+        result = ds.stratified_sample(
+            by="subject", fraction=0.1, min_per_group=0, seed=0
+        )
+        assert _subject_counts(result) == {"a": 10, "b": 1}
 
     def test_no_test_set_returns_self(self):
         class _NoTestDataset(_ListDataset):

--- a/tests/unit/core/test_datasets.py
+++ b/tests/unit/core/test_datasets.py
@@ -1,8 +1,9 @@
 """
 Unit tests for sieval/core/datasets.py.
 
-Covers: Dataset.repeat, slice, shuffle, filter, retrieve_samples
-(random/fixed/lazy), _clone_with_new_dict, property accessors.
+Covers: Dataset.repeat, slice, shuffle, filter, stratified_sample
+(num / per_group / fraction), retrieve_samples (random/fixed/lazy),
+_clone_with_new_dict, property accessors.
 
 AI-Generated Code - Claude Opus 4.6 (Anthropic)
 """
@@ -515,12 +516,20 @@ class TestStratifiedSample:
         )
         assert ids1 == ids2
 
-    def test_requires_exactly_one_budget(self):
+    @pytest.mark.parametrize(
+        "budgets",
+        [
+            {},
+            {"num": 2, "per_group": 2},
+            {"num": 2, "fraction": 0.5},
+            {"per_group": 2, "fraction": 0.5},
+            {"num": 2, "per_group": 2, "fraction": 0.5},
+        ],
+    )
+    def test_requires_exactly_one_budget(self, budgets):
         ds = _make_grouped({"a": 5})
-        with pytest.raises(ValueError, match="exactly one of 'num' or 'per_group'"):
-            ds.stratified_sample(by="subject", seed=0)
-        with pytest.raises(ValueError, match="exactly one of 'num' or 'per_group'"):
-            ds.stratified_sample(by="subject", num=2, per_group=2, seed=0)
+        with pytest.raises(ValueError, match="exactly one of 'num', 'per_group'"):
+            ds.stratified_sample(by="subject", seed=0, **budgets)
 
     def test_min_per_group_excludes_per_group(self):
         ds = _make_grouped({"a": 5})
@@ -536,6 +545,109 @@ class TestStratifiedSample:
         ds = _make_grouped2({("en", "math"): 5})
         with pytest.raises(ValueError, match="nonexistent"):
             ds.stratified_sample(by=["locale", "nonexistent"], per_group=2, seed=0)
+
+
+# ===================================================================
+# stratified_sample — the `fraction` budget
+#
+# This is where MMMLU's efficient-eval subsampling lives now. It used to be
+# `sample_fraction`/`sample_seed`/`sample_by` on `mmmlu_kshot_clp`, applied by a
+# hand-rolled sampler; the cases below are the ones that carried its behaviour.
+# ===================================================================
+class TestStratifiedFraction:
+    def test_keeps_a_share_of_every_stratum(self):
+        ds = _make_grouped({"a": 100, "b": 50, "c": 10})
+        result = ds.stratified_sample(by="subject", fraction=0.1, seed=0)
+        assert _subject_counts(result) == {"a": 10, "b": 5, "c": 1}
+
+    def test_rounds_up_so_a_small_stratum_still_contributes(self):
+        # ceil, not round: at 10% a 12-row stratum yields 2, and a 1-row stratum
+        # survives on the floor rather than vanishing.
+        ds = _make_grouped({"big": 12, "tiny": 1})
+        result = ds.stratified_sample(by="subject", fraction=0.1, seed=0)
+        assert _subject_counts(result) == {"big": 2, "tiny": 1}
+
+    def test_fraction_one_keeps_everything(self):
+        ds = _make_grouped({"a": 7, "b": 3})
+        result = ds.stratified_sample(by="subject", fraction=1.0, seed=0)
+        assert _subject_counts(result) == {"a": 7, "b": 3}
+
+    def test_min_per_group_raises_the_floor(self):
+        ds = _make_grouped({"a": 100, "b": 4})
+        result = ds.stratified_sample(
+            by="subject", fraction=0.01, min_per_group=3, seed=0
+        )
+        # 'a' wants ceil(1.0)=1 but the floor lifts it to 3; 'b' is capped by size.
+        assert _subject_counts(result) == {"a": 3, "b": 3}
+
+    def test_min_per_group_capped_by_stratum_size(self):
+        ds = _make_grouped({"a": 10, "b": 2})
+        result = ds.stratified_sample(
+            by="subject", fraction=0.1, min_per_group=5, seed=0
+        )
+        assert _subject_counts(result) == {"a": 5, "b": 2}
+
+    def test_composite_key_matches_the_retired_mmmlu_case(self):
+        # The exact shape the task-level test used to assert: 4 cells x 4 rows at
+        # 50% -> 8 rows, 2 per (locale, subject).
+        cells = {
+            ("zh_cn", "abstract_algebra"): 4,
+            ("zh_cn", "business_ethics"): 4,
+            ("de_de", "abstract_algebra"): 4,
+            ("de_de", "business_ethics"): 4,
+        }
+        ds = _make_grouped2(cells)
+        result = ds.stratified_sample(by=["locale", "subject"], fraction=0.5, seed=42)
+        assert len(result.test_set) == 8
+        counts: dict = {}
+        for row in result.test_set:
+            key = (row["locale"], row["subject"])
+            counts[key] = counts.get(key, 0) + 1
+        assert counts == dict.fromkeys(cells, 2)
+
+    def test_same_seed_is_deterministic(self):
+        # Two independent calls must select the same rows — the property the
+        # retired idempotency test was protecting.
+        ds = _make_grouped2({("zh_cn", "algebra"): 4, ("zh_cn", "ethics"): 4})
+        first = ds.stratified_sample(by=["locale", "subject"], fraction=0.5, seed=42)
+        second = ds.stratified_sample(by=["locale", "subject"], fraction=0.5, seed=42)
+        assert [r["id"] for r in first.test_set] == [r["id"] for r in second.test_set]
+
+    def test_different_seed_changes_rows_not_counts(self):
+        ds = _make_grouped({"a": 40, "b": 40})
+        one = ds.stratified_sample(by="subject", fraction=0.25, seed=1)
+        two = ds.stratified_sample(by="subject", fraction=0.25, seed=2)
+        assert _subject_counts(one) == _subject_counts(two) == {"a": 10, "b": 10}
+        assert [r["id"] for r in one.test_set] != [r["id"] for r in two.test_set]
+
+    def test_row_order_is_preserved(self):
+        ds = _make_grouped({"a": 20, "b": 20})
+        ids = [
+            r["id"]
+            for r in ds.stratified_sample(by="subject", fraction=0.5, seed=0).test_set
+        ]
+        assert ids == sorted(ids)
+
+    @pytest.mark.parametrize("bad", [0, 0.0, -0.5, 1.5, 2])
+    def test_fraction_outside_the_unit_interval_raises(self, bad):
+        ds = _make_grouped({"a": 5})
+        with pytest.raises(ValueError, match=r"'fraction' must be in the interval"):
+            ds.stratified_sample(by="subject", fraction=bad, seed=0)
+
+    def test_no_test_set_returns_self(self):
+        class _NoTestDataset(_ListDataset):
+            def load(self, name_or_path, **kwargs):
+                return HFDatasetDict({"train": HFDataset.from_list([{"subject": "a"}])})
+
+        ds = _NoTestDataset([], None)
+        assert ds.stratified_sample(by="subject", fraction=0.5, seed=0) is ds
+
+    def test_missing_split_returns_self(self):
+        ds = _make_grouped({"a": 5})
+        assert (
+            ds.stratified_sample(by="subject", fraction=0.5, split="train", seed=0)
+            is ds
+        )
 
 
 # ===================================================================

--- a/tests/unit/tasks/test_mmmlu_kshot_clp.py
+++ b/tests/unit/tasks/test_mmmlu_kshot_clp.py
@@ -3,7 +3,6 @@
 AI-Generated Code - GPT-5-Codex (OpenAI)
 """
 
-from collections import Counter
 from typing import cast
 
 import pytest
@@ -302,100 +301,16 @@ async def test_test_split_fewshot_requires_held_out_examples_per_locale_subject(
         await task.setup()
 
 
-@pytest.mark.anyio
-async def test_setup_samples_deterministically_by_locale_subject():
-    samples = [
-        *[_sample(i, locale="zh_cn", subject="abstract_algebra") for i in range(4)],
-        *[_sample(i, locale="zh_cn", subject="business_ethics") for i in range(4)],
-        *[
-            _sample(
-                i,
-                locale="de_de",
-                locale_display_name="German",
-                subject="abstract_algebra",
-            )
-            for i in range(4)
-        ],
-        *[
-            _sample(
-                i,
-                locale="de_de",
-                locale_display_name="German",
-                subject="business_ethics",
-            )
-            for i in range(4)
-        ],
-    ]
-    task = _task(
-        samples,
-        n_shot=0,
-        sample_fraction=0.5,
-        sample_seed=42,
-        sample_by="locale_subject",
-    )
-    repeat = _task(
-        samples,
-        n_shot=0,
-        sample_fraction=0.5,
-        sample_seed=42,
-        sample_by="locale_subject",
-    )
-
-    await task.setup()
-    await repeat.setup()
-
-    test_set = task.dataset.test_set
-    repeat_test_set = repeat.dataset.test_set
-    assert test_set is not None
-    assert repeat_test_set is not None
-    assert len(test_set) == 8
-    assert [row["Question"] for row in test_set] == [
-        row["Question"] for row in repeat_test_set
-    ]
-    counts = Counter((row["Locale"], row["Subject"]) for row in test_set)
-    assert counts == {
-        ("de_de", "abstract_algebra"): 2,
-        ("de_de", "business_ethics"): 2,
-        ("zh_cn", "abstract_algebra"): 2,
-        ("zh_cn", "business_ethics"): 2,
-    }
-
-
-@pytest.mark.anyio
-async def test_setup_sampling_is_idempotent_under_repeated_calls():
-    samples = [
-        *[_sample(i, locale="zh_cn", subject="abstract_algebra") for i in range(4)],
-        *[_sample(i, locale="zh_cn", subject="business_ethics") for i in range(4)],
-    ]
-    task = _task(
-        samples,
-        n_shot=0,
-        sample_fraction=0.5,
-        sample_seed=42,
-        sample_by="locale_subject",
-    )
-
-    await task.setup()
-    first_set = task.dataset.test_set
-    assert first_set is not None
-    first = [row["Question"] for row in first_set]
-    # A second setup() must not sample a sample (0.5 of the already-sampled set).
-    await task.setup()
-    second_set = task.dataset.test_set
-    assert second_set is not None
-    second = [row["Question"] for row in second_set]
-
-    assert len(first) == 4
-    assert first == second
+# Subsampling used to be `sample_fraction`/`sample_seed`/`sample_by` on this task,
+# applied by a hand-rolled sampler in `setup()`. It is now a dataset operation
+# (`stratified_sample(by=[Locale, Subject], fraction=...)`), so its coverage lives
+# with the transform in tests/unit/core/test_datasets.py::TestStratifiedFraction —
+# including that the subsample stays deterministic across two identical calls.
 
 
 @pytest.mark.parametrize(
     ("kwargs", "match"),
     [
-        ({"sample_fraction": 0}, "sample_fraction"),
-        ({"sample_fraction": 1.5}, "sample_fraction"),
-        ({"sample_seed": "42"}, "sample_seed"),
-        ({"sample_by": "subject"}, "sample_by"),
         ({"n_shot": -1}, "n_shot must be >= 0"),
         ({"logprobs": 0}, "logprobs must be >= 1"),
     ],


### PR DESCRIPTION
## Type

- refactor — code restructuring

(Behaviour-affecting despite the label: see the breaking-change note below. Not `fix` — nothing was wrong; the sampler was a duplicate.)

## Summary

- `mmmlu_kshot_clp` carried its **own stratified sampler** behind `sample_fraction`/`sample_seed`/`sample_by`: group by `(Locale)` or `(Locale, Subject)`, shuffle each group under a key-derived seed, keep `ceil(size × fraction)` with a floor of 1. That is `Dataset.stratified_sample` with a budget it happened not to have.
- **Give the transform the missing budget, delete the copy.** `fraction` joins `num` and `per_group` as a third, mutually exclusive budget: each stratum keeps `ceil(stratum_size × fraction)`, never below the floor. Unlike `num` it needs no total, so it states a protocol ("10% of every locale") directly rather than a row count someone has to look up, and it stays correct as the dataset grows. `min_per_group` now applies to `num` **and** `fraction` — both allocate per stratum — and is still rejected with `per_group`, which already fixes the count.
- Subsampling becomes a dataset operation. Operations run while the dataset is built, so the subsample still **precedes few-shot reservation** exactly as `setup()` used to order them, and scoring, reservation and aggregation stay identical between full and sampled runs.

```yaml
datasets:
  mmmlu_10pct:
    class: MMMLUDataset
    operations:
      - stratified_sample: {by: [Locale, Subject], fraction: 0.1, seed: 0}
```

- **What this does not fix.** `_exclude_fewshot_examples_from_eval_split` still writes `dataset_dict["test"]` in place. It reserves the first `n_shot` rows of each group as exemplars and drops them from the scored split — that depends on task state (`_fewshot_source_indices`), so no dataset operation can express it, and `openai/MMMLU` ships **only** a `test` split so exemplars have nowhere else to come from. One of mmmlu's two in-place writes remains. **This is a deduplication, not a fix for the immutability contract**, and the PR shouldn't be read as the latter.

## Related Issues

Follow-up from the review of #65, which added `Dataset.filter` for the same reason (a bespoke knob where a shared transform belonged). Independent of it — this branch is cut from `main` and touches a different method.

## ⚠️ Breaking change and migration

`sample_fraction`, `sample_seed` and `sample_by` are **removed** from `mmmlu_kshot_clp`. A config passing them now fails with an unexpected-keyword error.

| before (task args) | after (dataset operation) |
| --- | --- |
| `sample_fraction: 0.1` | `fraction: 0.1` |
| `sample_seed: 42` | `seed: 42` |
| `sample_by: locale_subject` | `by: [Locale, Subject]` |
| `sample_by: locale` | `by: [Locale]` |

**The sampled rows change.** The two samplers seed their per-group shuffles differently — `f"{seed}:{sample_by}:{'|'.join(key)}"` versus `f"{seed}:{key}"` — so they draw independently. Measured exactly over MMMLU's real group sizes (798 `(Locale, Subject)` groups, 196,588 rows, `fraction=0.1`):

| | rows |
| --- | --- |
| old selection | 20,020 |
| new selection | **20,020** — same size, so the budget rule is reproduced |
| in both | **2,007 (10.0%)** |
| changed | 18,013 dropped, 18,013 newly included |

Row **order** differs too: the transform sorts its output where the old sampler emitted grouped order, so sample ids shift and a stored sampled run will not line up with a fresh one.

Nothing in the repo called `sample_fraction` — no `examples/` YAML, no `leaderboards/`, no docs — so there are no in-tree configs to migrate. It is still a public task argument, so **this delta needs to reach the changelog at release time** (`CHANGELOG.md` is only touched by release commits here, so it is not edited in this PR).

## Test Plan

### Automated

- [x] Lint/format clean (`ruff check` + `ruff format --check`: all checks passed)
- [x] Type check clean (`ty check`: all checks passed)
- [x] Unit tests pass: **2971 passed**
- [x] Integration + acceptance: **64 passed**
- [x] Full preflight: all PASS, including `check_meta_index_sync` **without regeneration** — the retired arguments were never named in `reference_impl.notes`, so `sieval/meta/index.json` is untouched
- [x] `scripts/sync_package_stubs.py --check`: in sync

Coverage **moved with the behaviour** rather than being deleted. The two task tests that pinned deterministic per-cell sampling and its idempotency are now `TestStratifiedFraction` in `tests/unit/core/test_datasets.py` — including the exact 4-cells-×-4-rows-at-50% shape the task test asserted, and a same-seed determinism case standing in for the idempotency one. `test_session.py` covers the operation dispatch with and without `min_per_group`, and the exactly-one-budget guard is parametrized over all four illegal combinations at both layers.

### Manual

- [x] `fraction` reproduces the retired sampler's per-group count rule exactly — `max(1, ceil(size × fraction))` — checked against uneven strata (100/37/9/1 rows) at `fraction` 0.1 / 0.25 / 1.0, including a size-1 stratum surviving on the floor and `min_per_group` capping at stratum size.
- [x] Selection is deterministic for a given seed, differs across seeds without changing counts, and preserves original row order.
- [x] Old-vs-new selection overlap measured exactly over real MMMLU group sizes (table above), derived from `cais/mmlu`'s per-subject test counts — MMMLU is that split translated, so every locale shares them.

## Checklist

### Required (all PRs)

- [x] PR title follows conventional format
- [x] No internal paths, credentials, or personal info in committed files
- [x] AI-generated code has `AI-Generated Code - <model> (<provider>)` in module docstring — both touched modules already carry theirs; no new module added
- [x] No new upper-layer dependencies added to `core/` — the `core/` change adds one stdlib import (`math`) and no sieval imports
- [x] Deleted code verified — `_apply_sampling`, `_sample_key`, the three `_normalize_sample_*` helpers and `MMMLU_SAMPLE_BY` have no remaining call sites (grepped); the now-unused `random` import is removed, `math` is kept for the softmax at `_softmax`

### If: Breaking Change

- [x] Described what breaks and migration path in Summary
- [x] Existing tests updated to reflect new behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)
