### PR TITLE
fix(tests): take the cyclic collector out of the serialize-vs-orjson ratio

### DIFF
--- a/tests/performance/test_serialization.py
+++ b/tests/performance/test_serialization.py
@@ -28,29 +28,24 @@ from tests.conftest import (
 def _gc_paused() -> Iterator[None]:
     """Take Python's cyclic collector out of a timed *ratio*.
 
-    A gen2 collection costs in proportion to the whole live heap -- ~0.3 ms at 5k
-    tracked objects, ~300 ms at 2.4M -- and by the time a suite run reaches here
-    that heap is thousands of other tests' fixtures, which this loop never touches.
-    What it does touch is the trigger: ``obj_to_dict`` builds a container per node
-    and the caller retains every result, so its net allocations drive gen0 -> gen1
-    -> gen2. ``orjson.dumps`` returns one untracked ``bytes`` and triggers almost
-    nothing, so the tax lands on the numerator alone and the ratio amplifies it:
-    the same code has measured 12x and 184x against a 50x bar, deciding only
-    whether one gen2 fell inside the window.
+    A gen2 collection costs in proportion to the whole live heap, which by the time
+    a suite run reaches here is thousands of other tests' fixtures. Only the
+    numerator pays it -- this loop retains every result, while ``orjson.dumps``
+    returns an untracked ``bytes`` -- so the same code has measured 12x and 184x
+    against a 50x bar, deciding only whether one gen2 fell inside the window.
 
-    Only the ratio needs this. The absolute bounds elsewhere in this file keep
-    enough headroom to absorb a collection, and they are the ones whose numbers
-    should stay comparable with a real run's.
-
-    Reference counting is untouched, so nothing accumulates but cycles made inside
-    the block.
+    Only the ratio needs this; the absolute bounds elsewhere have the headroom to
+    absorb a collection. Reference counting is untouched, and the collector is put
+    back as found, so a suite measured under ``gc.disable()`` stays that way.
     """
+    was_enabled = gc.isenabled()
     gc.collect()
     gc.disable()
     try:
         yield
     finally:
-        gc.enable()
+        if was_enabled:
+            gc.enable()
 
 
 class TestSerializeThroughput:
@@ -100,23 +95,24 @@ class TestSerializeThroughput:
         dicts: list[dict] = []
         timer_ser = PerfTimer()
         timer_json = PerfTimer()
-        # Both halves under one pause, so the comparison stays symmetric: leaving
-        # the collector on for the C half would let the deferred collections land
-        # there instead, inflating the denominator and masking a real regression.
+        # Both halves under one pause: re-enabling for the C half would land the
+        # deferred collections in the denominator and mask a real regression.
         with _gc_paused():
-            # Measure serialize (Python side)
             with timer_ser:
                 for ctx in contexts:
                     dicts.append(
                         ctx.serialize(store_type_metadata=True, include_meta=True)
                     )
 
-            # Measure orjson.dumps (C side)
             with timer_json:
                 for d in dicts:
                     orjson.dumps(d, option=orjson.OPT_SERIALIZE_NUMPY)
 
-        ratio = timer_ser.elapsed / timer_json.elapsed if timer_json.elapsed > 0 else 0
+        # Scoring a zero denominator 0 would sail past the bar below.
+        assert timer_json.elapsed > 0, (
+            "orjson.dumps measured 0s: the clock is too coarse to form a ratio"
+        )
+        ratio = timer_ser.elapsed / timer_json.elapsed
         print(
             f"PERF: serialize={timer_ser.elapsed:.4f}s, "
             f"orjson.dumps={timer_json.elapsed:.4f}s, "

--- a/tests/performance/test_serialization.py
+++ b/tests/performance/test_serialization.py
@@ -7,6 +7,10 @@ and with varying payload sizes.
 AI-Generated Code - Claude Opus 4.6 (Anthropic)
 """
 
+import gc
+from collections.abc import Iterator
+from contextlib import contextmanager
+
 import orjson
 import pytest
 
@@ -18,6 +22,35 @@ from tests.conftest import (
     _make_bench_ctx,
     samples_per_second,
 )
+
+
+@contextmanager
+def _gc_paused() -> Iterator[None]:
+    """Take Python's cyclic collector out of a timed *ratio*.
+
+    A gen2 collection costs in proportion to the whole live heap -- ~0.3 ms at 5k
+    tracked objects, ~300 ms at 2.4M -- and by the time a suite run reaches here
+    that heap is thousands of other tests' fixtures, which this loop never touches.
+    What it does touch is the trigger: ``obj_to_dict`` builds a container per node
+    and the caller retains every result, so its net allocations drive gen0 -> gen1
+    -> gen2. ``orjson.dumps`` returns one untracked ``bytes`` and triggers almost
+    nothing, so the tax lands on the numerator alone and the ratio amplifies it:
+    the same code has measured 12x and 184x against a 50x bar, deciding only
+    whether one gen2 fell inside the window.
+
+    Only the ratio needs this. The absolute bounds elsewhere in this file keep
+    enough headroom to absorb a collection, and they are the ones whose numbers
+    should stay comparable with a real run's.
+
+    Reference counting is untouched, so nothing accumulates but cycles made inside
+    the block.
+    """
+    gc.collect()
+    gc.disable()
+    try:
+        yield
+    finally:
+        gc.enable()
 
 
 class TestSerializeThroughput:
@@ -64,18 +97,24 @@ class TestSerializeThroughput:
         n = 1000
         contexts = [_make_bench_ctx(i, TaskStage.FINAL) for i in range(n)]
 
-        # Measure serialize (Python side)
         dicts: list[dict] = []
         timer_ser = PerfTimer()
-        with timer_ser:
-            for ctx in contexts:
-                dicts.append(ctx.serialize(store_type_metadata=True, include_meta=True))
-
-        # Measure orjson.dumps (C side)
         timer_json = PerfTimer()
-        with timer_json:
-            for d in dicts:
-                orjson.dumps(d, option=orjson.OPT_SERIALIZE_NUMPY)
+        # Both halves under one pause, so the comparison stays symmetric: leaving
+        # the collector on for the C half would let the deferred collections land
+        # there instead, inflating the denominator and masking a real regression.
+        with _gc_paused():
+            # Measure serialize (Python side)
+            with timer_ser:
+                for ctx in contexts:
+                    dicts.append(
+                        ctx.serialize(store_type_metadata=True, include_meta=True)
+                    )
+
+            # Measure orjson.dumps (C side)
+            with timer_json:
+                for d in dicts:
+                    orjson.dumps(d, option=orjson.OPT_SERIALIZE_NUMPY)
 
         ratio = timer_ser.elapsed / timer_json.elapsed if timer_json.elapsed > 0 else 0
         print(


### PR DESCRIPTION
## Type

- fix — bug fix or alignment correction

## Summary

`tests/performance/test_serialization.py::test_orjson_vs_serialize_breakdown` asserts Python `serialize` stays under **50x** `orjson.dumps`. Both halves are wall-clock timed with the cyclic collector left on, which makes the result a function of how much unrelated memory the rest of the suite happens to be holding. Seen across full-suite runs of one branch: **194.9x, 184.0x, then a pass** — flaky, with no change to the code under test.

- **It is GC, and only GC.** In a failing run `serialize` took **0.1981s**; with `gc.disable()` set for the whole session the identical code took **0.0073s**, which is also what it measures alone (0.0074s). The work did not get cheaper — a scan of unrelated objects went away.
- **The cost is the live heap, which this loop never touches.** One gen2 collection: **0.28 ms** at 5k tracked objects, **21 ms** at 405k, **127 ms** at 1.2M, **297 ms** at 2.4M. By the time the suite reaches this test, that heap is thousands of other tests' fixtures.
- **The trigger is the test's own allocations.** `obj_to_dict` builds a container per node and the test retains all 1000 results, so net allocations drive gen0 → gen1 → gen2. gen0/gen1 are cheap (55 + 5 of them measured at 0.9x); the whole effect is *one* gen2 landing inside the timed window — near a coin flip, which is why test count and ordering flip it.
- **A ratio amplifies it.** `orjson.dumps` returns a single `bytes`, which holds no references and so is not GC-tracked at all; it barely moves the allocation counter and triggers almost nothing. The tax lands on the numerator alone.

Scoped to the ratio rather than to `PerfTimer` (37 call sites, several wrapping whole pipeline runs and dataset loads, where suppressing collection would change what is measured and grow memory). The absolute bounds elsewhere in the file keep enough headroom to absorb a collection, and they are the ones whose numbers should stay comparable with a real run's.

Both halves share one pause: leaving the collector on for the C half would let the deferred collections land there, inflating the denominator and masking a real regression. Reference counting is untouched, so nothing accumulates but cycles created inside the block, and `finally` restores the collector even when the assertion fails.

## Related Issues

None filed — surfaced while reviewing #92, and is not caused by it (see Manual).

## Test Plan

### Automated

- [x] Lint/format clean (`ruff check && ruff format --check`)
- [x] Type check clean (`ty check` — all checks passed)
- [x] Unit tests pass — full suite **4,341 passed, 5 deselected**, 0 failures; `check_preflight.py` 24/24 PASS

### Manual

- [x] **Fixed test in place** — `ratio=10.3x` against the 50x bar.
- [x] **The measurement no longer tracks the heap.** Driving the real test body against a synthetic live heap, 12 reps per cell, min..max:

  | live tracked objects | before | after |
  |---|---|---|
  | 287,420 | 12.9 .. 17.2x | 9.5 .. 11.2x |
  | 2,687,414 | 15.1 .. **25.1x** | 8.2 .. 10.0x |
  | 6,287,414 | 15.0 .. 18.0x | 8.6 .. 10.1x |

  Lower and roughly 3x tighter. Note the synthetic ballast (uniform small dicts) does **not** reproduce the 184x tail even at 6.3M objects — a real suite heap is Arrow/dataset objects with far more references and far worse locality. The causal evidence for the tail is the whole-session `gc.disable()` result above, not this table.

- [x] **Not attributable to #92.** Whole-suite runs before this fix: `main` 3/3 pass, #92's branch 1 pass / 2 fail. #92 adds 59 tests, which shifts the allocation-counter phase the loop inherits; it does not make `serialize` slower — with GC off, `serialize` on that branch measures the same 0.0073s as in isolation.
- [x] **Five full-suite runs on the branch that actually flaked** (#92's `feat/iheval` + this fix cherry-picked), sequential, nothing else running:

  | run | `serialize` | `orjson.dumps` | ratio | result |
  |---|---|---|---|---|
  | 1 | 0.0090s | 0.0010s | 8.7x | 4400 passed |
  | 2 | 0.0090s | 0.0010s | 9.4x | 4400 passed |
  | 3 | 0.0093s | 0.0011s | 8.6x | 4400 passed |
  | 4 | 0.0088s | 0.0008s | 11.2x | 4400 passed |
  | 5 | 0.0088s | 0.0010s | 9.2x | 4400 passed |

  The absolute number is the point, not the pass: under full-suite load `serialize` now sits at **0.0088–0.0093s**, the same as it measures alone (0.0073–0.0092s), where the failing runs measured **0.1981s**. The 27x inflation is gone in the environment that produced it. Baseline on that same branch and machine before the fix: 1 pass / 2 fail.

  Caveat kept deliberately: 5/5 bounds the rate, it does not prove absence, and the pre-fix rate itself is estimated from only 3 runs. The load-bearing evidence remains mechanistic — `serialize` under full-suite load now matches its isolated cost.

## Checklist

### Required (all PRs)

- [x] PR title follows conventional format (`type(scope): description`)
- [x] No internal paths, credentials, or personal info in committed files
- [x] AI-generated code has `AI-Generated Code - <model> (<provider>)` in module docstring — the file's existing `Claude Opus 4.6 (Anthropic)` line stands; the repo keeps one attribution per module rather than appending per editor
- [x] No new upper-layer dependencies added to `core/` — test-only change, no `sieval/` file touched
- [x] Deleted code verified — nothing deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)