### PR TITLE
refactor(tasks): share auxiliary model-role resolution on Task

### DIFF
--- a/sieval/core/tasks/task.py
+++ b/sieval/core/tasks/task.py
@@ -229,26 +229,21 @@ class Task[
         )
 
     @classmethod
-    def _resolve_role_model(
+    def _resolve_role_model[T](
         cls,
         role: str,
-        configured: object,
+        configured: T,
         models_by_role: Mapping[str, Model] | None,
         *,
-        build: Callable[[], Model],
+        build: Callable[[T], Model],
     ) -> Model:
         """Resolve one auxiliary model role to the Model the task will call.
 
-        Two supply routes, and they are mutually exclusive. Composition injects
-        ``models_by_role`` for every role it reconciled, which is the pooled
-        path a YAML run takes. Direct construction (tests, programmatic use)
-        passes the role argument instead, and ``build`` is the task's own
-        constructor for it — task-specific because each role's "you must supply
-        one" message carries that task's reason.
-
-        Supplying both is a configuration error rather than a precedence
-        question: silently preferring either one would let a run score against
-        a model the config did not name.
+        ``models_by_role`` is the pooled path a YAML run takes; otherwise
+        ``build`` turns ``configured`` into the Model, so each task keeps its
+        own "you must supply one" message. Supplying both is an error rather
+        than a precedence question: silently preferring either would let a run
+        score against a model the config did not name.
         """
 
         if models_by_role is not None:
@@ -260,7 +255,7 @@ class Task[
                 raise ValueError(
                     f"models_by_role is missing the {role!r} model"
                 ) from exc
-        return build()
+        return build(configured)
 
     @classmethod
     def _bind_top_logprobs_requirements(

--- a/sieval/core/tasks/task.py
+++ b/sieval/core/tasks/task.py
@@ -5,7 +5,7 @@ AI-Generated Code - Claude Fable 5 (Anthropic)
 
 import re
 from abc import ABC, abstractmethod
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from collections.abc import Set as AbstractSet
 from dataclasses import replace
 from typing import ClassVar, Literal, Protocol, cast
@@ -227,6 +227,40 @@ class Task[
                 source_task=source_task,
             ),
         )
+
+    @classmethod
+    def _resolve_role_model(
+        cls,
+        role: str,
+        configured: object,
+        models_by_role: Mapping[str, Model] | None,
+        *,
+        build: Callable[[], Model],
+    ) -> Model:
+        """Resolve one auxiliary model role to the Model the task will call.
+
+        Two supply routes, and they are mutually exclusive. Composition injects
+        ``models_by_role`` for every role it reconciled, which is the pooled
+        path a YAML run takes. Direct construction (tests, programmatic use)
+        passes the role argument instead, and ``build`` is the task's own
+        constructor for it — task-specific because each role's "you must supply
+        one" message carries that task's reason.
+
+        Supplying both is a configuration error rather than a precedence
+        question: silently preferring either one would let a run score against
+        a model the config did not name.
+        """
+
+        if models_by_role is not None:
+            if configured is not None:
+                raise ValueError(f"{role} and models_by_role cannot both be supplied")
+            try:
+                return models_by_role[role]
+            except KeyError as exc:
+                raise ValueError(
+                    f"models_by_role is missing the {role!r} model"
+                ) from exc
+        return build()
 
     @classmethod
     def _bind_top_logprobs_requirements(

--- a/sieval/core/tasks/task.py
+++ b/sieval/core/tasks/task.py
@@ -168,8 +168,6 @@ class Task[
     ) -> tuple[TaskModelRequirement, ...]:
         if not isinstance(context, RequirementContext):
             raise TypeError("context must be a RequirementContext")
-        if not isinstance(requires, TaskRequirements):
-            raise TypeError("requires must be TaskRequirements")
 
         bindings = context.model_bindings
         if not bindings:
@@ -208,8 +206,6 @@ class Task[
             raise TypeError("context must be a RequirementContext")
         if not isinstance(role, str) or not role:
             raise TypeError("role must be a non-empty string")
-        if not isinstance(requires, TaskRequirements):
-            raise TypeError("requires must be TaskRequirements")
         try:
             binding = context.model_bindings[role]
         except KeyError as exc:

--- a/sieval/tasks/aa_lcr_0shot_gen.py
+++ b/sieval/tasks/aa_lcr_0shot_gen.py
@@ -175,24 +175,12 @@ class AALCRZeroShotGenTask(
     ):
         super().__init__(dataset=dataset, model=model, name=name)
         self._n = n
-        self._grader = self._resolve_grader(grader, models_by_role)
-
-    @classmethod
-    def _resolve_grader(
-        cls,
-        grader: Mapping | Model | None,
-        models_by_role: Mapping[str, Model] | None,
-    ) -> Model:
-        if models_by_role is not None:
-            if grader is not None:
-                raise ValueError("grader and models_by_role cannot both be supplied")
-            try:
-                return models_by_role["grader"]
-            except KeyError as exc:
-                raise ValueError(
-                    "models_by_role is missing the 'grader' model"
-                ) from exc
-        return cls._build_grader(grader)
+        self._grader = self._resolve_role_model(
+            "grader",
+            grader,
+            models_by_role,
+            build=lambda: self._build_grader(grader),
+        )
 
     @staticmethod
     def _build_grader(grader: Mapping | Model | None) -> Model:

--- a/sieval/tasks/aa_lcr_0shot_gen.py
+++ b/sieval/tasks/aa_lcr_0shot_gen.py
@@ -179,7 +179,7 @@ class AALCRZeroShotGenTask(
             "grader",
             grader,
             models_by_role,
-            build=lambda: self._build_grader(grader),
+            build=self._build_grader,
         )
 
     @staticmethod

--- a/sieval/tasks/advanced_if_0shot_gen.py
+++ b/sieval/tasks/advanced_if_0shot_gen.py
@@ -219,30 +219,18 @@ class AdvancedIFZeroShotGenTask(
     ):
         super().__init__(dataset=dataset, model=model, name=name)
         self._n = n
-        self._grader = self._resolve_grader(grader, models_by_role)
+        self._grader = self._resolve_role_model(
+            "grader",
+            grader,
+            models_by_role,
+            build=lambda: self._build_grader(grader),
+        )
         # Validate the checkout here, not at the first grade. Discovered in
         # feedback() it costs a whole generation pass to learn: every grade then
         # raises, and a wholly failed grading stage still reports 0.0 -- the
         # floor that reads as a score. `@cache`d, so this is one read per run,
         # and construction already fails without a grader anyway.
         load_judge_prompts()
-
-    @classmethod
-    def _resolve_grader(
-        cls,
-        grader: Mapping | Model | None,
-        models_by_role: Mapping[str, Model] | None,
-    ) -> Model:
-        if models_by_role is not None:
-            if grader is not None:
-                raise ValueError("grader and models_by_role cannot both be supplied")
-            try:
-                return models_by_role["grader"]
-            except KeyError as exc:
-                raise ValueError(
-                    "models_by_role is missing the 'grader' model"
-                ) from exc
-        return cls._build_grader(grader)
 
     @staticmethod
     def _build_grader(grader: Mapping | Model | None) -> Model:

--- a/sieval/tasks/advanced_if_0shot_gen.py
+++ b/sieval/tasks/advanced_if_0shot_gen.py
@@ -223,7 +223,7 @@ class AdvancedIFZeroShotGenTask(
             "grader",
             grader,
             models_by_role,
-            build=lambda: self._build_grader(grader),
+            build=self._build_grader,
         )
         # Validate the checkout here, not at the first grade. Discovered in
         # feedback() it costs a whole generation pass to learn: every grade then

--- a/sieval/tasks/agieval_0shot_gen.py
+++ b/sieval/tasks/agieval_0shot_gen.py
@@ -247,29 +247,12 @@ class AGIEvalZeroShotGenTask(
         models_by_role: Mapping[str, Model] | None = None,
     ):
         super().__init__(dataset=dataset, model=model, name=name)
-        self._extractor = self._resolve_extractor(
+        self._extractor = self._resolve_role_model(
+            "extractor",
             extractor,
-            model,
             models_by_role,
+            build=lambda: self._build_extractor(extractor, model),
         )
-
-    @classmethod
-    def _resolve_extractor(
-        cls,
-        extractor: Mapping | Model | str | None,
-        model: Model,
-        models_by_role: Mapping[str, Model] | None,
-    ) -> Model:
-        if models_by_role is not None:
-            if extractor is not None:
-                raise ValueError("extractor and models_by_role cannot both be supplied")
-            try:
-                return models_by_role["extractor"]
-            except KeyError as exc:
-                raise ValueError(
-                    "models_by_role is missing the 'extractor' model"
-                ) from exc
-        return cls._build_extractor(extractor, model)
 
     @staticmethod
     def _build_extractor(

--- a/sieval/tasks/agieval_0shot_gen.py
+++ b/sieval/tasks/agieval_0shot_gen.py
@@ -251,7 +251,7 @@ class AGIEvalZeroShotGenTask(
             "extractor",
             extractor,
             models_by_role,
-            build=lambda: self._build_extractor(extractor, model),
+            build=lambda cfg: self._build_extractor(cfg, model),
         )
 
     @staticmethod

--- a/sieval/tasks/browsecomp_0shot_gen.py
+++ b/sieval/tasks/browsecomp_0shot_gen.py
@@ -144,24 +144,12 @@ class BrowseCompZeroShotGenTask(
     ):
         super().__init__(dataset=dataset, model=model, name=name)
         self._n = n
-        self._grader = self._resolve_grader(grader, models_by_role)
-
-    @classmethod
-    def _resolve_grader(
-        cls,
-        grader: Mapping | Model | None,
-        models_by_role: Mapping[str, Model] | None,
-    ) -> Model:
-        if models_by_role is not None:
-            if grader is not None:
-                raise ValueError("grader and models_by_role cannot both be supplied")
-            try:
-                return models_by_role["grader"]
-            except KeyError as exc:
-                raise ValueError(
-                    "models_by_role is missing the 'grader' model"
-                ) from exc
-        return cls._build_grader(grader)
+        self._grader = self._resolve_role_model(
+            "grader",
+            grader,
+            models_by_role,
+            build=lambda: self._build_grader(grader),
+        )
 
     @staticmethod
     def _build_grader(grader: Mapping | Model | None) -> Model:

--- a/sieval/tasks/browsecomp_0shot_gen.py
+++ b/sieval/tasks/browsecomp_0shot_gen.py
@@ -148,7 +148,7 @@ class BrowseCompZeroShotGenTask(
             "grader",
             grader,
             models_by_role,
-            build=lambda: self._build_grader(grader),
+            build=self._build_grader,
         )
 
     @staticmethod

--- a/sieval/tasks/complex_constraints_0shot_gen.py
+++ b/sieval/tasks/complex_constraints_0shot_gen.py
@@ -248,24 +248,12 @@ class ComplexConstraintsZeroShotGenTask(
     ):
         super().__init__(dataset=dataset, model=model, name=name)
         self._n = n
-        self._grader = self._resolve_grader(grader, models_by_role)
-
-    @classmethod
-    def _resolve_grader(
-        cls,
-        grader: Mapping | Model | None,
-        models_by_role: Mapping[str, Model] | None,
-    ) -> Model:
-        if models_by_role is not None:
-            if grader is not None:
-                raise ValueError("grader and models_by_role cannot both be supplied")
-            try:
-                return models_by_role["grader"]
-            except KeyError as exc:
-                raise ValueError(
-                    "models_by_role is missing the 'grader' model"
-                ) from exc
-        return cls._build_grader(grader)
+        self._grader = self._resolve_role_model(
+            "grader",
+            grader,
+            models_by_role,
+            build=lambda: self._build_grader(grader),
+        )
 
     @staticmethod
     def _build_grader(grader: Mapping | Model | None) -> Model:

--- a/sieval/tasks/complex_constraints_0shot_gen.py
+++ b/sieval/tasks/complex_constraints_0shot_gen.py
@@ -252,7 +252,7 @@ class ComplexConstraintsZeroShotGenTask(
             "grader",
             grader,
             models_by_role,
-            build=lambda: self._build_grader(grader),
+            build=self._build_grader,
         )
 
     @staticmethod

--- a/sieval/tasks/hle_0shot_gen.py
+++ b/sieval/tasks/hle_0shot_gen.py
@@ -193,24 +193,12 @@ class HLEZeroShotGenTask(
         # Which subset was loaded is the dataset's decision; read it back so
         # `report()` can record it.
         self._text_only = dataset.text_only
-        self._grader = self._resolve_grader(grader, models_by_role)
-
-    @classmethod
-    def _resolve_grader(
-        cls,
-        grader: Mapping | Model | None,
-        models_by_role: Mapping[str, Model] | None,
-    ) -> Model:
-        if models_by_role is not None:
-            if grader is not None:
-                raise ValueError("grader and models_by_role cannot both be supplied")
-            try:
-                return models_by_role["grader"]
-            except KeyError as exc:
-                raise ValueError(
-                    "models_by_role is missing the 'grader' model"
-                ) from exc
-        return cls._build_grader(grader)
+        self._grader = self._resolve_role_model(
+            "grader",
+            grader,
+            models_by_role,
+            build=lambda: self._build_grader(grader),
+        )
 
     @staticmethod
     def _build_grader(grader: Mapping | Model | None) -> Model:

--- a/sieval/tasks/hle_0shot_gen.py
+++ b/sieval/tasks/hle_0shot_gen.py
@@ -197,7 +197,7 @@ class HLEZeroShotGenTask(
             "grader",
             grader,
             models_by_role,
-            build=lambda: self._build_grader(grader),
+            build=self._build_grader,
         )
 
     @staticmethod

--- a/sieval/tasks/inverse_ifeval_0shot_gen.py
+++ b/sieval/tasks/inverse_ifeval_0shot_gen.py
@@ -173,24 +173,12 @@ class InverseIFEvalZeroShotGenTask(
             raise ValueError(f"k must be <= n, got k={k}, n={n}")
         self._n = n
         self._k = k
-        self._grader = self._resolve_grader(grader, models_by_role)
-
-    @classmethod
-    def _resolve_grader(
-        cls,
-        grader: Mapping | Model | None,
-        models_by_role: Mapping[str, Model] | None,
-    ) -> Model:
-        if models_by_role is not None:
-            if grader is not None:
-                raise ValueError("grader and models_by_role cannot both be supplied")
-            try:
-                return models_by_role["grader"]
-            except KeyError as exc:
-                raise ValueError(
-                    "models_by_role is missing the 'grader' model"
-                ) from exc
-        return cls._build_grader(grader)
+        self._grader = self._resolve_role_model(
+            "grader",
+            grader,
+            models_by_role,
+            build=lambda: self._build_grader(grader),
+        )
 
     @staticmethod
     def _build_grader(grader: Mapping | Model | None) -> Model:

--- a/sieval/tasks/inverse_ifeval_0shot_gen.py
+++ b/sieval/tasks/inverse_ifeval_0shot_gen.py
@@ -177,7 +177,7 @@ class InverseIFEvalZeroShotGenTask(
             "grader",
             grader,
             models_by_role,
-            build=lambda: self._build_grader(grader),
+            build=self._build_grader,
         )
 
     @staticmethod

--- a/sieval/tasks/simpleqa_verified_0shot_gen.py
+++ b/sieval/tasks/simpleqa_verified_0shot_gen.py
@@ -135,24 +135,12 @@ class SimpleQAVerifiedZeroShotGenTask(
     ):
         super().__init__(dataset=dataset, model=model, name=name)
         self._n = n
-        self._grader = self._resolve_grader(grader, models_by_role)
-
-    @classmethod
-    def _resolve_grader(
-        cls,
-        grader: Mapping | Model | None,
-        models_by_role: Mapping[str, Model] | None,
-    ) -> Model:
-        if models_by_role is not None:
-            if grader is not None:
-                raise ValueError("grader and models_by_role cannot both be supplied")
-            try:
-                return models_by_role["grader"]
-            except KeyError as exc:
-                raise ValueError(
-                    "models_by_role is missing the 'grader' model"
-                ) from exc
-        return cls._build_grader(grader)
+        self._grader = self._resolve_role_model(
+            "grader",
+            grader,
+            models_by_role,
+            build=lambda: self._build_grader(grader),
+        )
 
     @staticmethod
     def _build_grader(grader: Mapping | Model | None) -> Model:

--- a/sieval/tasks/simpleqa_verified_0shot_gen.py
+++ b/sieval/tasks/simpleqa_verified_0shot_gen.py
@@ -139,7 +139,7 @@ class SimpleQAVerifiedZeroShotGenTask(
             "grader",
             grader,
             models_by_role,
-            build=lambda: self._build_grader(grader),
+            build=self._build_grader,
         )
 
     @staticmethod

--- a/tests/unit/core/tasks/test_task.py
+++ b/tests/unit/core/tasks/test_task.py
@@ -152,6 +152,25 @@ class _TopLogprobsTask(_ConcreteTask):
     )
 
 
+class _MetaNamedTask(_ConcreteTask):
+    """Stands in for a ``@sieval_task``-decorated class, which sets this attr."""
+
+    _sieval_task_meta = SimpleNamespace(name="meta_named_task")
+
+
+class _MetaNamedSubTask(_MetaNamedTask):
+    """Subclass with no meta of its own — must not borrow its parent's name."""
+
+
+def _named_binding(name: str) -> NamedModelBinding:
+    return NamedModelBinding(
+        binding_id=f"binding:{name}",
+        root_deployment_key=f"deployment:{name}",
+        requested_model_id=f"org/{name}",
+        config_name=name,
+    )
+
+
 # ===================================================================
 # name property
 # ===================================================================
@@ -249,21 +268,12 @@ class TestRequiresCapabilityGate:
 
 
 class TestModelRequirementsFor:
-    @staticmethod
-    def _binding(name: str) -> NamedModelBinding:
-        return NamedModelBinding(
-            binding_id=f"binding:{name}",
-            root_deployment_key=f"deployment:{name}",
-            requested_model_id=f"org/{name}",
-            config_name=name,
-        )
-
     def test_binds_candidate_and_preserves_task_source(self):
-        candidate = self._binding("candidate")
+        candidate = _named_binding("candidate")
         context = RequirementContext(
             model_bindings={
                 "candidate": candidate,
-                "judge": self._binding("judge"),
+                "judge": _named_binding("judge"),
             }
         )
 
@@ -275,7 +285,7 @@ class TestModelRequirementsFor:
         assert result.source_task == "_ScoringTask"
 
     def test_single_legacy_model_alias_is_accepted(self):
-        binding = self._binding("legacy")
+        binding = _named_binding("legacy")
         (result,) = _ConcreteTask.model_requirements_for(
             RequirementContext(model_bindings={"model": binding})
         )
@@ -286,13 +296,174 @@ class TestModelRequirementsFor:
     def test_candidate_and_model_alias_are_ambiguous(self):
         context = RequirementContext(
             model_bindings={
-                "candidate": self._binding("candidate"),
-                "model": self._binding("legacy"),
+                "candidate": _named_binding("candidate"),
+                "model": _named_binding("legacy"),
             }
         )
 
         with pytest.raises(ValueError, match="ambiguous"):
             _ConcreteTask.model_requirements_for(context)
+
+
+# ===================================================================
+# auxiliary model-role binding — the declaration half
+# ===================================================================
+class TestBindRoleRequirement:
+    """Reached directly by the eight grader/extractor tasks.
+
+    ``model_requirements_for`` picks ``role`` out of the bindings it was handed,
+    so it can never miss one; those tasks name a literal role instead, which is
+    the only way the missing-binding branch fires.
+    """
+
+    def test_binds_the_named_role(self):
+        grader = _named_binding("grader")
+        context = RequirementContext(
+            model_bindings={"candidate": _named_binding("candidate"), "grader": grader}
+        )
+
+        (result,) = _ConcreteTask._bind_role_requirement(
+            context, "grader", _ScoringTask.requires
+        )
+
+        assert result.role == "grader"
+        assert result.binding is grader
+        assert result.requires is _ScoringTask.requires
+        assert result.source_task == "_ConcreteTask"
+
+    def test_source_task_prefers_the_decorated_name(self):
+        context = RequirementContext(
+            model_bindings={"grader": _named_binding("grader")}
+        )
+
+        (result,) = _MetaNamedTask._bind_role_requirement(
+            context, "grader", _MetaNamedTask.requires
+        )
+
+        assert result.source_task == "meta_named_task"
+
+    def test_source_task_is_not_inherited_from_the_parent(self):
+        """Looked up in ``cls.__dict__``, so a subclass reports its own name."""
+        context = RequirementContext(
+            model_bindings={"grader": _named_binding("grader")}
+        )
+
+        (result,) = _MetaNamedSubTask._bind_role_requirement(
+            context, "grader", _MetaNamedSubTask.requires
+        )
+
+        assert result.source_task == "_MetaNamedSubTask"
+
+    def test_missing_binding_names_the_task_and_role(self):
+        context = RequirementContext(
+            model_bindings={"candidate": _named_binding("candidate")}
+        )
+
+        with pytest.raises(
+            ValueError, match="_ConcreteTask requires a 'grader' model binding"
+        ) as excinfo:
+            _ConcreteTask._bind_role_requirement(
+                context, "grader", _ConcreteTask.requires
+            )
+
+        assert isinstance(excinfo.value.__cause__, KeyError)
+
+    def test_missing_binding_uses_an_before_a_vowel_role(self):
+        context = RequirementContext(
+            model_bindings={"candidate": _named_binding("candidate")}
+        )
+
+        with pytest.raises(ValueError, match="requires an 'extractor' model binding"):
+            _ConcreteTask._bind_role_requirement(
+                context, "extractor", _ConcreteTask.requires
+            )
+
+    def test_rejects_a_context_of_the_wrong_type(self):
+        with pytest.raises(TypeError, match="context must be a RequirementContext"):
+            _ConcreteTask._bind_role_requirement(
+                cast(Any, {"grader": _named_binding("grader")}),
+                "grader",
+                _ConcreteTask.requires,
+            )
+
+    @pytest.mark.parametrize("role", ["", cast(Any, None)])
+    def test_rejects_an_empty_or_non_string_role(self, role):
+        context = RequirementContext(
+            model_bindings={"grader": _named_binding("grader")}
+        )
+
+        with pytest.raises(TypeError, match="role must be a non-empty string"):
+            _ConcreteTask._bind_role_requirement(context, role, _ConcreteTask.requires)
+
+    def test_rejects_requires_of_the_wrong_type(self):
+        """Pins the contract, not the layer that enforces it.
+
+        ``TaskModelRequirement.__post_init__`` rejects a non-``TaskRequirements``
+        with the same message, so this still passes with the guard here removed
+        — deliberately kept as the entry-point contract rather than as cover for
+        that line.
+        """
+        context = RequirementContext(
+            model_bindings={"grader": _named_binding("grader")}
+        )
+
+        with pytest.raises(TypeError, match="requires must be TaskRequirements"):
+            _ConcreteTask._bind_role_requirement(
+                context, "grader", cast(Any, {"input": "chat"})
+            )
+
+
+# ===================================================================
+# auxiliary model-role resolution — the resolution half
+# ===================================================================
+def _unreachable_build(_configured):
+    raise AssertionError("build must not be called when models_by_role is supplied")
+
+
+class TestResolveRoleModel:
+    """The shared ``models_by_role`` contract, independent of any one task."""
+
+    def test_returns_the_pooled_role_model(self):
+        grader = _MockChatModel()
+
+        result = Task._resolve_role_model(
+            "grader", None, {"grader": grader}, build=_unreachable_build
+        )
+
+        assert result is grader
+
+    def test_rejects_both_supply_routes(self):
+        grader = _MockChatModel()
+
+        with pytest.raises(ValueError, match="cannot both be supplied"):
+            Task._resolve_role_model(
+                "grader", grader, {"grader": grader}, build=_unreachable_build
+            )
+
+    def test_missing_role_names_it_and_chains_the_keyerror(self):
+        with pytest.raises(ValueError, match="missing the 'grader' model") as excinfo:
+            Task._resolve_role_model("grader", None, {}, build=_unreachable_build)
+
+        assert isinstance(excinfo.value.__cause__, KeyError)
+
+    def test_build_receives_the_configured_value(self):
+        """``configured`` reaches ``build``, rather than being closed over.
+
+        The call site threading it twice is how a mistyped ``configured`` slips
+        past the both-supplied guard, so the pairing is pinned here.
+        """
+        built = _MockChatModel()
+        seen: list[object] = []
+        configured = {"model": "grader-1"}
+
+        def build(cfg) -> Model:
+            seen.append(cfg)
+            return built
+
+        result = Task._resolve_role_model("grader", configured, None, build=build)
+
+        assert seen == [configured]
+        assert result is built
 
 
 # ===================================================================

--- a/tests/unit/core/tasks/test_task.py
+++ b/tests/unit/core/tasks/test_task.py
@@ -396,13 +396,8 @@ class TestBindRoleRequirement:
             _ConcreteTask._bind_role_requirement(context, role, _ConcreteTask.requires)
 
     def test_rejects_requires_of_the_wrong_type(self):
-        """Pins the contract, not the layer that enforces it.
-
-        ``TaskModelRequirement.__post_init__`` rejects a non-``TaskRequirements``
-        with the same message, so this still passes with the guard here removed
-        — deliberately kept as the entry-point contract rather than as cover for
-        that line.
-        """
+        """Pins the contract at this entry point; ``TaskModelRequirement``
+        owns the check itself."""
         context = RequirementContext(
             model_bindings={"grader": _named_binding("grader")}
         )


### PR DESCRIPTION
## Type

- refactor — code restructuring, no behavior change (one unreachable error-ordering corner, called out below)

## Summary

- Eight tasks each carried their own `_resolve_grader` / `_resolve_extractor`. Normalising the role name away, seven are **byte-identical**; AGIEval's differs only because its builder also needs the candidate model.
- The declaration half of the role contract was already shared (`Task._bind_role_requirement`); only the resolution half was copied. So the `models_by_role` protocol — pooled role model, both-supplied rejection, missing-role message — had eight owners that must move together, and the next grader-bearing benchmark would have added a ninth.
- Adds `Task._resolve_role_model(role, configured, models_by_role, build=...)` and routes all eight through it. `build` takes `configured` and returns the Model, so each task keeps its own constructor and its own "you must supply one" message — the part that legitimately differs (AGIEval admits the `self` sentinel and explains its 26-point extractor spread; each grader task explains its own scoring dependency). The seven grader tasks pass `self._build_grader` **directly**; AGIEval wraps it only to add the candidate model.
- A type parameter ties the two arguments together — `configured: T` against `build: Callable[[T], Model]` — so `configured` is typed by whatever the builder accepts rather than `object`, and the value is not threaded through the call twice. Threading it twice was how a mistyped `configured` could slip past the both-supplied guard and let a pooled model win silently; `ty` now rejects a mismatched pairing.
- **Both halves of the contract get direct unit tests.** `_bind_role_requirement` had none, and its missing-binding branch is unreachable from `model_requirements_for` (which picks the role out of the bindings it was handed), so that message and its `a`/`an` agreement were entirely unasserted — even though all eight tasks name a literal role and can miss.
- Retires a third copy of `requires must be TaskRequirements`: `TaskModelRequirement.__post_init__` owns it, and the copies in `_bind_model_requirements` / `_bind_role_requirement` each sat in front of a construction that re-checks the same thing. The two **class-named** variants stay — they validate the `requires` ClassVar, a different contract.
- Net **−76 lines** of production code (+166 in tests).

### The one behaviour exception

Everything about the shared helper is byte-identical to the code it replaces. The exception is the retired type check: a call invalid in **two** ways at once now reports the binding problem instead of the type problem — `_bind_role_requirement(ctx, "grader", <not TaskRequirements>)` with no `grader` binding raises the missing-binding `ValueError`, and `model_requirements_for` with a bad `requires` ClassVar *and* no bindings raises the no-candidate `ValueError`.

Every singly-invalid call is unchanged, including a bad `requires` with a resolvable binding, which still raises the identical `TypeError` from `__post_init__`. Neither corner is reachable in production: `requires` always arrives as `cls.requires`, already rejected earlier by the two class-named guards (`sieval/core/tasks/meta.py` at decoration, `_validate_model_requirements` at construction).

## Related Issues

Refs #25 — follow-up from the PR #45 review.

## Test Plan

### Automated

- [x] Lint/format clean (`ruff check && ruff format --check`)
- [x] Type check clean (`ty check`)
- [x] Unit tests pass (`pdm run pytest`) — 5186 passed; preflight 25 PASS, no FAIL/WARN; `sync_package_stubs.py --check` and `sync_meta_index.py --check` both clean

### Manual

- [x] **Behaviour pinned against the pre-refactor code.** All eight tasks × six supply combinations (both supplied / missing role / pooled present / wrong role key / direct / neither) driven through both trees and diffed: **48/48 rows identical**, exception chaining included. Both resolution entry points are classmethods, so this needs no dataset or model fixtures.

- [x] **Mutation-tested the shared helper**, because a green suite after a move refactor proves only that nothing imports the dead code. Three mutations against `Task._resolve_role_model`, all caught:

  | mutation | result |
  |---|---|
  | remove the both-supplied guard | 9 failed — one per task, plus the core test |
  | make it ignore `models_by_role` | 27 failed — three per task, plus three core |
  | mis-key the role lookup | 9 failed — one per task, plus the core test |

  The per-task failure counts are the point: all eight tasks genuinely execute the shared path, rather than passing on leftovers of their own.

- [x] **Mutation-tested the declaration half**, now that it has tests. Dropping the vowel branch from the `a`/`an` article, letting `source_task` inherit a parent's meta, dropping the role guard, dropping the context guard, and collapsing `source_task` to the bare class name are **5/5 caught, each by the intended test**.

- [x] Verified no lingering references to the removed methods anywhere in the tree, including `.pyi` stubs.

## Checklist

### Required (all PRs)

- [x] PR title follows conventional format (`type(scope): description`)
- [x] No internal paths, credentials, or personal info in committed files
- [x] AI-generated code has `AI-Generated Code - <model> (<provider>)` in module docstring — no new modules; all touched files already carry theirs
- [x] No new upper-layer dependencies added to `core/` — the helper lives on `Task` in `core/tasks/` and imports nothing new beyond `collections.abc.Callable`
- [x] Deleted code verified — no remaining call sites depend on it
