### PR TITLE
refactor(models): split model.py by lifetime, not by size

### DIFF
--- a/sieval/core/models/__init__.py
+++ b/sieval/core/models/__init__.py
@@ -3,6 +3,7 @@
 AI-Generated Code - Claude Fable 5 (Anthropic)
 """
 
+from ._legacy_bridge import ModelCallMeta, ModelMeta, ModelOutput, ModelUsage
 from .capabilities import (
     Capability,
     CapabilityKey,
@@ -78,7 +79,7 @@ from .ir import (
     UsageStats,
     normalize_chat_input,
 )
-from .model import Model, ModelCallMeta, ModelMeta, ModelOutput, ModelUsage
+from .model import Model
 from .reconcile import (
     BindingReconcileInput,
     ConnectionScope,

--- a/sieval/core/models/_legacy_binding.py
+++ b/sieval/core/models/_legacy_binding.py
@@ -1,0 +1,170 @@
+"""Binding construction for the legacy ``ChatModel``/``GenModel`` constructors.
+
+These wrappers accept a bare ``model=``/``api_base=`` pair and must still
+present a truthful :class:`RuntimeBindingPlan`, so this module fabricates one
+from an externally-owned connection rather than from a reconciled deployment.
+Kept apart from ``model`` by lifetime: nothing here is reachable from the
+canonical ``Model.bind`` path, so it goes when the wrappers do.
+
+AI-Generated Code - Claude Opus 5 (1M context) (Anthropic)
+"""
+
+from dataclasses import dataclass
+from typing import Any
+from uuid import uuid4
+
+import anyio
+from openai import AsyncOpenAI
+
+from sieval.core.types import JSONValue
+
+from ._fingerprint import fingerprint_mapping
+from .capabilities import RequestDefaults, Supported
+from .deployment import (
+    ConnectionIdentity,
+    ConnectionPool,
+    Deployment,
+    Engine,
+    ServingFacts,
+    resolve_route,
+)
+from .dialect_registry import capability_decisions_for, get_dialect_spec
+from .reconcile import RuntimeBindingPlan
+
+
+@dataclass(frozen=True)
+class _LegacyOpenAIBinding:
+    deployment: Deployment
+    pool: ConnectionPool[Any]
+    runtime_plan: RuntimeBindingPlan
+    local_limiter: anyio.CapacityLimiter | None
+    parent_limiter: anyio.CapacityLimiter | None
+
+
+def _legacy_runtime_plan(
+    *,
+    dialect_id: str,
+    requested_model_id: str,
+    deployment: Deployment,
+    identity: ConnectionIdentity,
+) -> RuntimeBindingPlan:
+    """Build honest external-Python binding evidence for legacy wrappers."""
+
+    spec = get_dialect_spec(dialect_id)
+    route = resolve_route(deployment, dialect_id, spec.connection_family)
+    decisions = capability_decisions_for(dialect_id)
+    available = frozenset(
+        key for key, decision in decisions.items() if isinstance(decision, Supported)
+    )
+    effective: dict[str, JSONValue] = {key: {} for key in sorted(available)}
+    identity_fingerprint = fingerprint_mapping(
+        {
+            "endpoint": identity.endpoint,
+            "connection_family": identity.connection_family,
+            "credential_scope": identity.credential_scope,
+            "retry_policy": identity.retry_policy,
+            "quota_scope": identity.quota_scope,
+        }
+    )
+    identity_suffix = identity_fingerprint.removeprefix("sha256:")[:16]
+    binding_id = f"legacy:{dialect_id}:{requested_model_id}:{identity_suffix}"
+    root_deployment_key = f"legacy:{deployment.fingerprint}:{identity_suffix}"
+    binding_plan_fingerprint = fingerprint_mapping(
+        {
+            "available_capabilities": sorted(available),
+            "binding_id": binding_id,
+            "capability_minimums": {},
+            "declared_capabilities": effective,
+            "dialect_id": dialect_id,
+            "effective_capabilities": effective,
+            "request_checks": [],
+            "request_defaults": {},
+            "requested_model_id": requested_model_id,
+            "required_output_channels": [],
+            "root_deployment_key": root_deployment_key,
+        }
+    )
+    return RuntimeBindingPlan(
+        binding_id=binding_id,
+        root_deployment_key=root_deployment_key,
+        requested_model_id=requested_model_id,
+        dialect_id=dialect_id,
+        declared_capabilities=effective,
+        effective_capabilities=effective,
+        available_capabilities=available,
+        capability_minimums={},
+        request_defaults=RequestDefaults(),
+        required_output_channels=frozenset(),
+        request_checks=(),
+        deployment_fingerprint=deployment.fingerprint,
+        resolved_route=route,
+        connection_identity=identity,
+        binding_plan_fingerprint=binding_plan_fingerprint,
+        deployment_plan_fingerprint="external:none",
+    )
+
+
+def build_legacy_openai_binding(
+    *,
+    dialect_id: str,
+    model: str,
+    api_base: str | None,
+    api_key: str | None,
+    max_retries: int,
+    concurrency_limit: int | None,
+    parent_limiter: anyio.CapacityLimiter | None,
+) -> _LegacyOpenAIBinding:
+    """Create the wrapper-owned client/pool boundary used for one cycle."""
+
+    client = AsyncOpenAI(
+        base_url=api_base,
+        api_key=api_key,
+        max_retries=max_retries,
+    )
+    endpoint = str(client.base_url).rstrip("/")
+    local_limiter = (
+        anyio.CapacityLimiter(concurrency_limit)
+        if concurrency_limit is not None
+        else None
+    )
+    shared_limiter = parent_limiter
+    if shared_limiter is None:
+        shared_limiter = local_limiter
+
+    private_scope = uuid4().hex
+    identity = ConnectionIdentity(
+        endpoint=endpoint,
+        connection_family="openai_sdk",
+        credential_scope=(
+            f"legacy-private:{private_scope}:explicit-credential"
+            if api_key is not None
+            else f"legacy-private:{private_scope}:environment-credential"
+        ),
+        retry_policy=f"openai-sdk:max-retries={max_retries}",
+        quota_scope=f"legacy-private:{private_scope}",
+    )
+    deployment = Deployment(
+        deployment_id=None,
+        plan=None,
+        engine=Engine("unknown"),
+        engine_source="unknown",
+        api_base=endpoint,
+        endpoints={},
+        topology=None,
+        metrics_url=None,
+        facts=ServingFacts(),
+    )
+    pool = ConnectionPool(client, identity, shared_limiter)
+    runtime_plan = _legacy_runtime_plan(
+        dialect_id=dialect_id,
+        requested_model_id=model,
+        deployment=deployment,
+        identity=identity,
+    )
+    return _LegacyOpenAIBinding(
+        deployment=deployment,
+        pool=pool,
+        runtime_plan=runtime_plan,
+        local_limiter=local_limiter,
+        parent_limiter=parent_limiter,
+    )

--- a/sieval/core/models/_legacy_bridge.py
+++ b/sieval/core/models/_legacy_bridge.py
@@ -3,8 +3,10 @@
 Tasks still call ``agenerate``/``alogprobs`` with loose keyword arguments and
 read a ``ModelOutput`` back; the canonical plane speaks ``Request``/``Response``
 only. Separated from ``model`` by lifetime, so the move to ``arun`` deletes this
-file as a unit with nothing in the canonical ``Model`` left to unpick — true only
-while it stays free-function shaped.
+file as a unit — true only while it stays free-function shaped and free of
+primitives the canonical plane also needs. ``Model.meta()`` is the one thread to
+cut by hand: it is public, has a caller outside the legacy path, and returns the
+``ModelMeta`` defined below.
 
 AI-Generated Code - Claude Opus 5 (1M context) (Anthropic)
 """
@@ -17,6 +19,7 @@ from typing import NotRequired, TypedDict, cast
 from sieval.core.types import JSONValue
 from sieval.core.utils.serialization import sieval_record
 
+from ._shared import named_json_value
 from .deployment import BINDING_RESOURCE_KEYS
 from .ir import (
     CompletionInput,
@@ -82,31 +85,6 @@ class ModelOutput:
     request_params: dict[str, JSONValue] | None = None
     response_model: str | None = None
     system_fingerprint: str | None = None
-
-
-def named_json_value(value: object, name: str) -> JSONValue:
-    """Validate and detach a JSON value, naming the offending leaf on failure.
-
-    Sequences are ``list``/``tuple`` only: the result is persisted, and a
-    ``set`` would serialize in hash order while a generator would serialize
-    as ``[]`` once consumed.
-    """
-    if isinstance(value, float):
-        if not math.isfinite(value):
-            raise ValueError(f"{name} must not contain a non-finite float")
-        return value
-    if value is None or isinstance(value, str | int | bool):
-        return value
-    if isinstance(value, Mapping):
-        result: dict[str, JSONValue] = {}
-        for key, item in value.items():
-            if not isinstance(key, str):
-                raise TypeError(f"{name} keys must be strings")
-            result[key] = named_json_value(item, f"{name}.{key}")
-        return result
-    if isinstance(value, list | tuple):
-        return [named_json_value(item, name) for item in value]
-    raise TypeError(f"{name} must be JSON-compatible, got {type(value).__name__}")
 
 
 def _optional_float(value: object, name: str) -> float | None:
@@ -408,10 +386,10 @@ def kwargs_to_request(
 
 
 def response_to_model_output(model_meta: ModelMeta, response: Response) -> ModelOutput:
-    """Shape a canonical ``Response`` into the legacy ``ModelOutput``.
+    """Shape a canonical ``Response`` into the legacy ``ModelOutput``."""
 
-    ``model_meta`` is mutated to carry provenance; callers pass a fresh mapping.
-    """
+    # The caller may keep this mapping, and provenance is persisted.
+    model_meta = model_meta.copy()
 
     segments: list[TokenLogprob] = []
     if response.input_scoring is not None:

--- a/sieval/core/models/_legacy_bridge.py
+++ b/sieval/core/models/_legacy_bridge.py
@@ -1,0 +1,476 @@
+"""One-cycle compatibility bridge between task kwargs and the canonical IR.
+
+Tasks still call ``agenerate``/``alogprobs`` with loose keyword arguments and
+read a ``ModelOutput`` back; the canonical plane speaks ``Request``/``Response``
+only. Separated from ``model`` by lifetime, so the move to ``arun`` deletes this
+file as a unit with nothing in the canonical ``Model`` left to unpick — true only
+while it stays free-function shaped.
+
+AI-Generated Code - Claude Opus 5 (1M context) (Anthropic)
+"""
+
+import math
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, replace
+from typing import NotRequired, TypedDict, cast
+
+from sieval.core.types import JSONValue
+from sieval.core.utils.serialization import sieval_record
+
+from .deployment import BINDING_RESOURCE_KEYS
+from .ir import (
+    CompletionInput,
+    DialectOptions,
+    ModelInput,
+    ModelProvenance,
+    OpaqueContinuation,
+    ReasoningParams,
+    Request,
+    Response,
+    SamplingParams,
+    SchedulingParams,
+    ScoringParams,
+    SessionParams,
+    StructuredOutputParams,
+    TokenLogprob,
+    ToolParams,
+)
+
+
+class ModelUsage(TypedDict):
+    """Token usage statistics from a single model API call."""
+
+    input_tokens: int
+    output_tokens: int
+    total_tokens: int
+
+
+class ModelMeta(TypedDict):
+    """Persisted identity and defaults for one model call."""
+
+    model: str
+    api_base: str | None
+    default_params: dict[str, JSONValue]
+    extra: NotRequired[dict[str, JSONValue]]
+    provenance: NotRequired[ModelProvenance]
+
+
+class ModelCallMeta(TypedDict):
+    """Per-API-call metadata: model info, usage, params, finish reasons."""
+
+    model: ModelMeta
+    usage: NotRequired[ModelUsage]
+    request_params: NotRequired[dict[str, JSONValue]]
+    finish_reasons: NotRequired[list[str]]
+    response_model: NotRequired[str]
+    system_fingerprint: NotRequired[str | None]
+
+
+@sieval_record
+@dataclass
+class ModelOutput:
+    """Legacy return type preserved while tasks migrate to ``Response``."""
+
+    model: ModelMeta
+    texts: list[str]
+    finish_reasons: list[str] | None = None
+    reasoning_texts: list[str] | None = None
+    logprobs_tokens: list[str] | None = None
+    logprobs: list[float | None] | None = None
+    top_logprobs: list[dict[str, float]] | None = None
+    usage: ModelUsage | None = None
+    request_params: dict[str, JSONValue] | None = None
+    response_model: str | None = None
+    system_fingerprint: str | None = None
+
+
+def named_json_value(value: object, name: str) -> JSONValue:
+    """Validate and detach a JSON value, naming the offending leaf on failure.
+
+    Sequences are ``list``/``tuple`` only: the result is persisted, and a
+    ``set`` would serialize in hash order while a generator would serialize
+    as ``[]`` once consumed.
+    """
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError(f"{name} must not contain a non-finite float")
+        return value
+    if value is None or isinstance(value, str | int | bool):
+        return value
+    if isinstance(value, Mapping):
+        result: dict[str, JSONValue] = {}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise TypeError(f"{name} keys must be strings")
+            result[key] = named_json_value(item, f"{name}.{key}")
+        return result
+    if isinstance(value, list | tuple):
+        return [named_json_value(item, name) for item in value]
+    raise TypeError(f"{name} must be JSON-compatible, got {type(value).__name__}")
+
+
+def _optional_float(value: object, name: str) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        raise TypeError(f"{name} must be a number")
+    result = float(value)
+    if not math.isfinite(result):
+        raise ValueError(f"{name} must be finite")
+    return result
+
+
+def _optional_int(value: object, name: str) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"{name} must be an integer")
+    return value
+
+
+def _pop_compatible_alias(
+    values: dict[str, object],
+    canonical: str,
+    legacy: str,
+    *,
+    default: object,
+) -> object:
+    """Pop one semantic value without silently resolving two conflicting owners."""
+
+    missing = object()
+    canonical_value = values.pop(canonical, missing)
+    legacy_value = values.pop(legacy, missing)
+    if (
+        canonical_value is not missing
+        and legacy_value is not missing
+        and canonical_value is not None
+        and legacy_value is not None
+        and canonical_value != legacy_value
+    ):
+        raise ValueError(
+            f"{canonical} conflicts with its legacy alias {legacy}: "
+            f"{canonical_value!r} != {legacy_value!r}"
+        )
+    if canonical_value is not missing and canonical_value is not None:
+        return canonical_value
+    if legacy_value is not missing:
+        return legacy_value
+    if canonical_value is not missing:
+        return canonical_value
+    return default
+
+
+def _coerce_structured_output(value: object) -> StructuredOutputParams:
+    if value is None:
+        return StructuredOutputParams()
+    if isinstance(value, StructuredOutputParams):
+        return value
+    if not isinstance(value, Mapping):
+        raise TypeError("response_format must be a mapping")
+    value_mapping = cast(Mapping[str, object], value)
+    format_ = value_mapping.get("type")
+    if format_ == "json_object":
+        return StructuredOutputParams(format="json_object")
+    if format_ != "json_schema":
+        raise ValueError(f"unsupported response_format type: {format_!r}")
+    raw_schema = value_mapping.get("json_schema")
+    if not isinstance(raw_schema, Mapping):
+        raise TypeError("json_schema response_format requires a mapping")
+    raw_schema_mapping = cast(Mapping[str, object], raw_schema)
+    schema = raw_schema_mapping.get("schema")
+    if not isinstance(schema, Mapping):
+        raise TypeError("json_schema response_format requires `schema`")
+    name = raw_schema_mapping.get("name")
+    strict = raw_schema_mapping.get("strict")
+    if name is not None and not isinstance(name, str):
+        raise TypeError("json_schema name must be a string")
+    if strict is not None and not isinstance(strict, bool):
+        raise TypeError("json_schema strict must be a bool")
+    return StructuredOutputParams(
+        format="json_schema",
+        schema=cast(Mapping[str, JSONValue], named_json_value(schema, "schema")),
+        name=name,
+        strict=strict,
+    )
+
+
+def validate_n(kwargs: Mapping[str, object]) -> int:
+    n = kwargs.get("n", 1)
+    if isinstance(n, bool) or not isinstance(n, int):
+        raise TypeError(f"n must be an int, got {type(n).__name__}: {n!r}")
+    if n < 1:
+        raise ValueError(f"n must be >= 1, got {n}")
+    return n
+
+
+def kwargs_to_request(
+    dialect_id: str,
+    input_: ModelInput,
+    final_kwargs: Mapping[str, object],
+) -> Request:
+    kw = dict(final_kwargs)
+    reserved = sorted(BINDING_RESOURCE_KEYS & set(kw))
+    if reserved:
+        raise ValueError(
+            "request arguments cannot change binding resources: " + ", ".join(reserved)
+        )
+    n = validate_n(kw)
+    kw.pop("n", None)
+
+    stream = kw.pop("stream", True)
+    if not isinstance(stream, bool):
+        raise TypeError("stream must be a bool")
+
+    max_tokens = _pop_compatible_alias(
+        kw,
+        "max_tokens",
+        "max_completion_tokens",
+        default=None,
+    )
+    temperature_value = kw.pop("temperature", None)
+    top_p_value = kw.pop("top_p", None)
+    top_k_value = kw.pop("top_k", None)
+    seed_value = kw.pop("seed", None)
+    frequency_penalty_value = kw.pop("frequency_penalty", None)
+    presence_penalty_value = kw.pop("presence_penalty", None)
+    stop = kw.pop("stop", None)
+    stop_value: tuple[str, ...] | None = None
+    if stop is not None:
+        if isinstance(stop, str):
+            stop_value = (stop,)
+        elif isinstance(stop, list | tuple):
+            values = tuple(stop)
+            if not all(isinstance(item, str) for item in values):
+                raise TypeError("stop must contain only strings")
+            stop_value = cast(tuple[str, ...], values)
+        else:
+            # ``list``/``tuple`` only, matching ``named_json_value``: this
+            # value is echoed into the persisted ``request_params``, and a
+            # ``set`` would land there in hash order.
+            raise TypeError("stop must be a string, list, or tuple of strings")
+    sampling = SamplingParams(
+        temperature=_optional_float(temperature_value, "temperature"),
+        top_p=_optional_float(top_p_value, "top_p"),
+        top_k=_optional_int(top_k_value, "top_k"),
+        max_tokens=_optional_int(max_tokens, "max_tokens"),
+        stop=stop_value,
+        seed=_optional_int(seed_value, "seed"),
+        frequency_penalty=_optional_float(frequency_penalty_value, "frequency_penalty"),
+        presence_penalty=_optional_float(presence_penalty_value, "presence_penalty"),
+        n=n,
+    )
+
+    return_logprobs = kw.pop("return_logprobs", False)
+    if not isinstance(return_logprobs, bool):
+        raise TypeError("return_logprobs must be a bool")
+    top_logprobs = kw.pop("top_logprobs", None)
+    legacy_logprobs = kw.pop("logprobs", None)
+    sampled = return_logprobs
+    breadth = 0
+    if isinstance(legacy_logprobs, bool):
+        sampled = sampled or legacy_logprobs
+    elif legacy_logprobs is not None:
+        if isinstance(legacy_logprobs, bool) or not isinstance(legacy_logprobs, int):
+            raise TypeError("logprobs must be a bool or integer")
+        sampled = True
+        breadth = legacy_logprobs
+    if top_logprobs is not None:
+        if isinstance(top_logprobs, bool) or not isinstance(top_logprobs, int):
+            raise TypeError("top_logprobs must be an integer")
+        breadth = top_logprobs
+        sampled = sampled or top_logprobs > 0
+    score_input = _pop_compatible_alias(
+        kw,
+        "score_input",
+        "echo",
+        default=False,
+    )
+    if not isinstance(score_input, bool):
+        raise TypeError("echo/score_input must be a bool")
+    scoring = ScoringParams(
+        input_scoring=score_input,
+        sampled_logprobs=sampled,
+        top_logprobs=breadth,
+    )
+
+    reasoning = kw.pop("reasoning", None)
+    effort = kw.pop("reasoning_effort", None)
+    if effort is not None and not isinstance(effort, str):
+        raise TypeError("reasoning_effort must be a string")
+    if reasoning is None:
+        reasoning_params = ReasoningParams(effort=effort)
+    elif isinstance(reasoning, ReasoningParams):
+        if effort is not None:
+            raise ValueError("reasoning and reasoning_effort cannot both be set")
+        reasoning_params = reasoning
+    else:
+        raise TypeError("reasoning must be ReasoningParams")
+
+    raw_tools = kw.pop("tools", ())
+    if raw_tools is None:
+        raw_tools = ()
+    if not isinstance(raw_tools, Iterable) or isinstance(
+        raw_tools, Mapping | str | bytes
+    ):
+        raise TypeError("tools must be an iterable of mappings")
+    functions: list[Mapping[str, JSONValue]] = []
+    for index, tool in enumerate(raw_tools):
+        if not isinstance(tool, Mapping):
+            raise TypeError("tools must contain mappings")
+        functions.append(
+            cast(
+                Mapping[str, JSONValue],
+                named_json_value(tool, f"tools[{index}]"),
+            )
+        )
+    choice = named_json_value(kw.pop("tool_choice", None), "tool_choice")
+    parallel = kw.pop("parallel_tool_calls", None)
+    if parallel is not None and not isinstance(parallel, bool):
+        raise TypeError("parallel_tool_calls must be a bool")
+    tools = ToolParams(
+        functions=tuple(functions),
+        choice=choice,
+        parallel=parallel,
+    )
+
+    structured_output = _coerce_structured_output(kw.pop("response_format", None))
+    previous_response_id = _pop_compatible_alias(
+        kw,
+        "previous_response_id",
+        "session_id",
+        default=None,
+    )
+    if previous_response_id is not None and not isinstance(previous_response_id, str):
+        raise TypeError("previous_response_id must be a string")
+    continuation = kw.pop("opaque_continuation", None)
+    if continuation is not None and not isinstance(continuation, OpaqueContinuation):
+        raise TypeError("opaque_continuation must be OpaqueContinuation")
+
+    suffix = kw.pop("suffix", None)
+    if suffix is not None:
+        if not isinstance(suffix, str):
+            raise TypeError("suffix must be a string")
+        if not isinstance(input_, CompletionInput):
+            raise TypeError("suffix requires CompletionInput")
+        if input_.suffix is not None and input_.suffix != suffix:
+            raise ValueError("suffix conflicts with CompletionInput.suffix")
+        input_ = replace(input_, suffix=suffix)
+
+    options: dict[str, JSONValue] = {}
+    explicit_options = kw.pop("dialect_options", None)
+    if explicit_options is not None:
+        if not isinstance(explicit_options, DialectOptions):
+            raise TypeError("dialect_options must be DialectOptions")
+        if explicit_options.dialect_id != dialect_id:
+            raise ValueError("dialect_options target another dialect")
+        reserved = sorted(BINDING_RESOURCE_KEYS & set(explicit_options.values))
+        if reserved:
+            raise ValueError(
+                "dialect_options cannot contain binding resources: "
+                + ", ".join(reserved)
+            )
+        options.update(explicit_options.values)
+    for container_name in ("extra_body", "extra_wire_params"):
+        raw = kw.pop(container_name, None)
+        if raw is None:
+            continue
+        if not isinstance(raw, Mapping):
+            raise TypeError(f"{container_name} must be a mapping")
+        for key, value in raw.items():
+            if not isinstance(key, str):
+                raise TypeError(f"{container_name} keys must be strings")
+            if key in BINDING_RESOURCE_KEYS:
+                raise ValueError(
+                    f"{container_name} cannot contain binding resource {key!r}"
+                )
+            if key in options:
+                raise ValueError(f"duplicate dialect option {key!r}")
+            options[key] = named_json_value(value, f"{container_name}.{key}")
+    for key, value in kw.items():
+        if key in options:
+            raise ValueError(f"duplicate dialect option {key!r}")
+        options[key] = named_json_value(value, key)
+
+    return Request(
+        input=input_,
+        sampling=sampling,
+        scoring=scoring,
+        reasoning=reasoning_params,
+        tools=tools,
+        structured_output=structured_output,
+        session=SessionParams(
+            previous_response_id=previous_response_id,
+            opaque_continuation=continuation,
+        ),
+        scheduling=SchedulingParams(stream=stream),
+        dialect_options=(DialectOptions(dialect_id, options) if options else None),
+    )
+
+
+def response_to_model_output(model_meta: ModelMeta, response: Response) -> ModelOutput:
+    """Shape a canonical ``Response`` into the legacy ``ModelOutput``.
+
+    ``model_meta`` is mutated to carry provenance; callers pass a fresh mapping.
+    """
+
+    segments: list[TokenLogprob] = []
+    if response.input_scoring is not None:
+        segments.extend(response.input_scoring.token_logprobs)
+    if response.logprobs is not None:
+        segments.extend(response.logprobs)
+    logprobs_present = (
+        response.input_scoring is not None or response.logprobs is not None
+    )
+    logprobs_tokens = [item.token for item in segments] if logprobs_present else None
+    logprobs = [item.logprob for item in segments] if logprobs_present else None
+
+    top_logprobs: list[dict[str, float]] | None = None
+    if response.top_logprobs is not None:
+        top_logprobs = []
+        for position in response.top_logprobs:
+            merged: dict[str, float] = {}
+            for item in position:
+                previous = merged.get(item.token)
+                if previous is None or item.logprob > previous:
+                    merged[item.token] = item.logprob
+            top_logprobs.append(merged)
+        top_logprobs = top_logprobs or None
+
+    usage: ModelUsage | None = None
+    if response.usage is not None:
+        usage = {
+            "input_tokens": response.usage.input_tokens,
+            "output_tokens": response.usage.output_tokens,
+            "total_tokens": response.usage.total_tokens,
+        }
+    reasoning_texts: list[str] | None = None
+    if response.reasoning is not None:
+        reasoning_texts = [
+            item.text or "" if item is not None else "" for item in response.reasoning
+        ]
+        if not any(reasoning_texts):
+            reasoning_texts = None
+
+    if response.provenance is not None:
+        model_meta["provenance"] = response.provenance
+    return ModelOutput(
+        model=model_meta,
+        texts=list(response.texts),
+        finish_reasons=(
+            list(response.finish_reasons)
+            if response.finish_reasons is not None
+            else None
+        ),
+        reasoning_texts=reasoning_texts,
+        logprobs_tokens=logprobs_tokens,
+        logprobs=logprobs,
+        top_logprobs=top_logprobs,
+        usage=usage,
+        request_params=(
+            dict(response.request_params)
+            if response.request_params is not None
+            else None
+        ),
+        response_model=response.response_model,
+        system_fingerprint=response.system_fingerprint,
+    )

--- a/sieval/core/models/_shared.py
+++ b/sieval/core/models/_shared.py
@@ -1,7 +1,11 @@
-"""JSON-shape primitives for the modules that build reconciliation records.
+"""JSON-shape primitives for the modules that build persisted records.
 
 `capabilities`, `requirements` and `reconcile` must agree on what counts as
 representable JSON, or a record depends on which of them normalised it first.
+`model` and `_legacy_bridge` need the same agreement, so the primitives live
+here rather than in either caller — notably not in `_legacy_bridge`, which is
+scheduled to be deleted whole. The two coercers differ only in how an error
+names a rejected leaf; merging them would change existing messages.
 
 AI-Generated Code - Claude Opus 5 (1M context) (Anthropic)
 """
@@ -38,6 +42,32 @@ def copy_json_value(value: object, path: str) -> JSONValue:
             for index, item in enumerate(value)
         ]
     raise TypeError(f"{path} contains non-JSON value {type(value).__name__}")
+
+
+def named_json_value(value: object, name: str) -> JSONValue:
+    """Validate and detach a JSON value, naming the offending leaf on failure.
+
+    Sequences are ``list``/``tuple`` only: the result is persisted, and a
+    ``set`` would serialize in hash order while a generator would serialize
+    as ``[]`` once consumed.
+    """
+
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError(f"{name} must not contain a non-finite float")
+        return value
+    if value is None or isinstance(value, str | int | bool):
+        return value
+    if isinstance(value, Mapping):
+        result: dict[str, JSONValue] = {}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise TypeError(f"{name} keys must be strings")
+            result[key] = named_json_value(item, f"{name}.{key}")
+        return result
+    if isinstance(value, list | tuple):
+        return [named_json_value(item, name) for item in value]
+    raise TypeError(f"{name} must be JSON-compatible, got {type(value).__name__}")
 
 
 def validate_nonempty_string(value: object, name: str) -> None:

--- a/sieval/core/models/chat_model.py
+++ b/sieval/core/models/chat_model.py
@@ -15,11 +15,12 @@ import anyio
 
 from sieval.core.types import JSONValue
 
+from ._legacy_binding import build_legacy_openai_binding
 from .dialect import Dialect
 from .dialect_registry import _register_compat_model_type
 from .dialects.openai_chat import OpenAIChatDialect
 from .ir import ChatInput, ChatMessage, ModelInput, normalize_chat_input
-from .model import Model, build_legacy_openai_binding
+from .model import Model
 
 
 class ChatModel(Model):

--- a/sieval/core/models/gen_model.py
+++ b/sieval/core/models/gen_model.py
@@ -12,11 +12,12 @@ import anyio
 
 from sieval.core.types import JSONValue
 
+from ._legacy_binding import build_legacy_openai_binding
 from .dialect import Dialect
 from .dialect_registry import _register_compat_model_type
 from .dialects.openai_completions import OpenAICompletionsDialect
 from .ir import CompletionInput, ModelInput
-from .model import Model, build_legacy_openai_binding
+from .model import Model
 
 
 class GenModel(Model):

--- a/sieval/core/models/model.py
+++ b/sieval/core/models/model.py
@@ -15,33 +15,31 @@ AI-Generated Code - GPT-5.6 (OpenAI)
 """
 
 import copy
-import math
-from collections.abc import Iterable, Mapping
-from dataclasses import dataclass, fields, replace
+from collections.abc import Mapping
+from dataclasses import fields, replace
 from types import TracebackType
-from typing import Any, NotRequired, Self, TypedDict, cast
-from uuid import uuid4
+from typing import Any, Self, TypedDict, cast
 
 import anyio
-from openai import AsyncOpenAI
 
 from sieval.core.types import JSONValue
-from sieval.core.utils.serialization import sieval_record
 
-from ._fingerprint import fingerprint_mapping
+from ._legacy_bridge import (
+    ModelMeta,
+    ModelOutput,
+    kwargs_to_request,
+    named_json_value,
+    response_to_model_output,
+    validate_n,
+)
 from .capabilities import (
     Capability,
     RequestDefaults,
-    Supported,
 )
 from .deployment import (
     BINDING_RESOURCE_KEYS,
-    ConnectionIdentity,
     ConnectionPool,
     Deployment,
-    Engine,
-    ServingFacts,
-    resolve_route,
 )
 from .dialect import (
     Dialect,
@@ -55,7 +53,6 @@ from .dialect import (
 from .dialect_registry import (
     _compat_model_input_kind,
     bind_dialect,
-    capability_decisions_for,
     get_dialect_spec,
 )
 from .exceptions import CapabilityError
@@ -63,52 +60,13 @@ from .ir import (
     CapabilityEvidence,
     ChatInput,
     CompletionInput,
-    DialectOptions,
     ModelIdentity,
     ModelInput,
     ModelProvenance,
-    OpaqueContinuation,
-    ReasoningParams,
     Request,
     Response,
-    SamplingParams,
-    SchedulingParams,
-    ScoringParams,
-    SessionParams,
-    StructuredOutputParams,
-    TokenLogprob,
-    ToolParams,
 )
 from .reconcile import RuntimeBindingPlan
-
-
-class ModelUsage(TypedDict):
-    """Token usage statistics from a single model API call."""
-
-    input_tokens: int
-    output_tokens: int
-    total_tokens: int
-
-
-class ModelMeta(TypedDict):
-    """Persisted identity and defaults for one model call."""
-
-    model: str
-    api_base: str | None
-    default_params: dict[str, JSONValue]
-    extra: NotRequired[dict[str, JSONValue]]
-    provenance: NotRequired[ModelProvenance]
-
-
-class ModelCallMeta(TypedDict):
-    """Per-API-call metadata: model info, usage, params, finish reasons."""
-
-    model: ModelMeta
-    usage: NotRequired[ModelUsage]
-    request_params: NotRequired[dict[str, JSONValue]]
-    finish_reasons: NotRequired[list[str]]
-    response_model: NotRequired[str]
-    system_fingerprint: NotRequired[str | None]
 
 
 class ModelQuotaSnapshot(TypedDict):
@@ -125,33 +83,6 @@ class ModelQuotaInfo(TypedDict):
     total: int | float
     parent: ModelQuotaSnapshot | None
     child: ModelQuotaSnapshot | None
-
-
-@sieval_record
-@dataclass
-class ModelOutput:
-    """Legacy return type preserved while tasks migrate to ``Response``."""
-
-    model: ModelMeta
-    texts: list[str]
-    finish_reasons: list[str] | None = None
-    reasoning_texts: list[str] | None = None
-    logprobs_tokens: list[str] | None = None
-    logprobs: list[float | None] | None = None
-    top_logprobs: list[dict[str, float]] | None = None
-    usage: ModelUsage | None = None
-    request_params: dict[str, JSONValue] | None = None
-    response_model: str | None = None
-    system_fingerprint: str | None = None
-
-
-@dataclass(frozen=True)
-class _LegacyOpenAIBinding:
-    deployment: Deployment
-    pool: ConnectionPool[Any]
-    runtime_plan: RuntimeBindingPlan
-    local_limiter: anyio.CapacityLimiter | None
-    parent_limiter: anyio.CapacityLimiter | None
 
 
 _LEGACY_CAPABILITY_MAP: Mapping[str, tuple[Capability, ...]] = {
@@ -182,31 +113,6 @@ _REQUEST_CHECK_VERIFIERS = frozenset({"validate_response_channel"})
 _REMOVED_SUBCLASS_HOOKS = frozenset({"_agenerate_impl", "_alogprobs_impl"})
 
 
-def _named_json_value(value: object, name: str) -> JSONValue:
-    """Validate and detach a JSON value, naming the offending leaf on failure.
-
-    Sequences are ``list``/``tuple`` only: the result is persisted, and a
-    ``set`` would serialize in hash order while a generator would serialize
-    as ``[]`` once consumed.
-    """
-    if isinstance(value, float):
-        if not math.isfinite(value):
-            raise ValueError(f"{name} must not contain a non-finite float")
-        return value
-    if value is None or isinstance(value, str | int | bool):
-        return value
-    if isinstance(value, Mapping):
-        result: dict[str, JSONValue] = {}
-        for key, item in value.items():
-            if not isinstance(key, str):
-                raise TypeError(f"{name} keys must be strings")
-            result[key] = _named_json_value(item, f"{name}.{key}")
-        return result
-    if isinstance(value, list | tuple):
-        return [_named_json_value(item, name) for item in value]
-    raise TypeError(f"{name} must be JSON-compatible, got {type(value).__name__}")
-
-
 def _checked_builder_defaults(values: Mapping[str, object]) -> dict[str, object]:
     """Reject builder defaults that ``meta()`` could not persist.
 
@@ -215,222 +121,8 @@ def _checked_builder_defaults(values: Mapping[str, object]) -> dict[str, object]
     unconverted -- the request builders need them as given.
     """
     for key, value in values.items():
-        _named_json_value(value, f"default_params.{key}")
+        named_json_value(value, f"default_params.{key}")
     return dict(values)
-
-
-def _optional_float(value: object, name: str) -> float | None:
-    if value is None:
-        return None
-    if isinstance(value, bool) or not isinstance(value, int | float):
-        raise TypeError(f"{name} must be a number")
-    result = float(value)
-    if not math.isfinite(result):
-        raise ValueError(f"{name} must be finite")
-    return result
-
-
-def _optional_int(value: object, name: str) -> int | None:
-    if value is None:
-        return None
-    if isinstance(value, bool) or not isinstance(value, int):
-        raise TypeError(f"{name} must be an integer")
-    return value
-
-
-def _pop_compatible_alias(
-    values: dict[str, object],
-    canonical: str,
-    legacy: str,
-    *,
-    default: object,
-) -> object:
-    """Pop one semantic value without silently resolving two conflicting owners."""
-
-    missing = object()
-    canonical_value = values.pop(canonical, missing)
-    legacy_value = values.pop(legacy, missing)
-    if (
-        canonical_value is not missing
-        and legacy_value is not missing
-        and canonical_value is not None
-        and legacy_value is not None
-        and canonical_value != legacy_value
-    ):
-        raise ValueError(
-            f"{canonical} conflicts with its legacy alias {legacy}: "
-            f"{canonical_value!r} != {legacy_value!r}"
-        )
-    if canonical_value is not missing and canonical_value is not None:
-        return canonical_value
-    if legacy_value is not missing:
-        return legacy_value
-    if canonical_value is not missing:
-        return canonical_value
-    return default
-
-
-def _legacy_runtime_plan(
-    *,
-    dialect_id: str,
-    requested_model_id: str,
-    deployment: Deployment,
-    identity: ConnectionIdentity,
-) -> RuntimeBindingPlan:
-    """Build honest external-Python binding evidence for legacy wrappers."""
-
-    spec = get_dialect_spec(dialect_id)
-    route = resolve_route(deployment, dialect_id, spec.connection_family)
-    decisions = capability_decisions_for(dialect_id)
-    available = frozenset(
-        key for key, decision in decisions.items() if isinstance(decision, Supported)
-    )
-    effective: dict[str, JSONValue] = {key: {} for key in sorted(available)}
-    identity_fingerprint = fingerprint_mapping(
-        {
-            "endpoint": identity.endpoint,
-            "connection_family": identity.connection_family,
-            "credential_scope": identity.credential_scope,
-            "retry_policy": identity.retry_policy,
-            "quota_scope": identity.quota_scope,
-        }
-    )
-    identity_suffix = identity_fingerprint.removeprefix("sha256:")[:16]
-    binding_id = f"legacy:{dialect_id}:{requested_model_id}:{identity_suffix}"
-    root_deployment_key = f"legacy:{deployment.fingerprint}:{identity_suffix}"
-    binding_plan_fingerprint = fingerprint_mapping(
-        {
-            "available_capabilities": sorted(available),
-            "binding_id": binding_id,
-            "capability_minimums": {},
-            "declared_capabilities": effective,
-            "dialect_id": dialect_id,
-            "effective_capabilities": effective,
-            "request_checks": [],
-            "request_defaults": {},
-            "requested_model_id": requested_model_id,
-            "required_output_channels": [],
-            "root_deployment_key": root_deployment_key,
-        }
-    )
-    return RuntimeBindingPlan(
-        binding_id=binding_id,
-        root_deployment_key=root_deployment_key,
-        requested_model_id=requested_model_id,
-        dialect_id=dialect_id,
-        declared_capabilities=effective,
-        effective_capabilities=effective,
-        available_capabilities=available,
-        capability_minimums={},
-        request_defaults=RequestDefaults(),
-        required_output_channels=frozenset(),
-        request_checks=(),
-        deployment_fingerprint=deployment.fingerprint,
-        resolved_route=route,
-        connection_identity=identity,
-        binding_plan_fingerprint=binding_plan_fingerprint,
-        deployment_plan_fingerprint="external:none",
-    )
-
-
-def build_legacy_openai_binding(
-    *,
-    dialect_id: str,
-    model: str,
-    api_base: str | None,
-    api_key: str | None,
-    max_retries: int,
-    concurrency_limit: int | None,
-    parent_limiter: anyio.CapacityLimiter | None,
-) -> _LegacyOpenAIBinding:
-    """Create the wrapper-owned client/pool boundary used for one cycle."""
-
-    client = AsyncOpenAI(
-        base_url=api_base,
-        api_key=api_key,
-        max_retries=max_retries,
-    )
-    endpoint = str(client.base_url).rstrip("/")
-    local_limiter = (
-        anyio.CapacityLimiter(concurrency_limit)
-        if concurrency_limit is not None
-        else None
-    )
-    shared_limiter = parent_limiter
-    if shared_limiter is None:
-        shared_limiter = local_limiter
-
-    private_scope = uuid4().hex
-    identity = ConnectionIdentity(
-        endpoint=endpoint,
-        connection_family="openai_sdk",
-        credential_scope=(
-            f"legacy-private:{private_scope}:explicit-credential"
-            if api_key is not None
-            else f"legacy-private:{private_scope}:environment-credential"
-        ),
-        retry_policy=f"openai-sdk:max-retries={max_retries}",
-        quota_scope=f"legacy-private:{private_scope}",
-    )
-    deployment = Deployment(
-        deployment_id=None,
-        plan=None,
-        engine=Engine("unknown"),
-        engine_source="unknown",
-        api_base=endpoint,
-        endpoints={},
-        topology=None,
-        metrics_url=None,
-        facts=ServingFacts(),
-    )
-    pool = ConnectionPool(client, identity, shared_limiter)
-    runtime_plan = _legacy_runtime_plan(
-        dialect_id=dialect_id,
-        requested_model_id=model,
-        deployment=deployment,
-        identity=identity,
-    )
-    return _LegacyOpenAIBinding(
-        deployment=deployment,
-        pool=pool,
-        runtime_plan=runtime_plan,
-        local_limiter=local_limiter,
-        parent_limiter=parent_limiter,
-    )
-
-
-def _coerce_structured_output(value: object) -> StructuredOutputParams:
-    if value is None:
-        return StructuredOutputParams()
-    if isinstance(value, StructuredOutputParams):
-        return value
-    if not isinstance(value, Mapping):
-        raise TypeError("response_format must be a mapping")
-    value_mapping = cast(Mapping[str, object], value)
-    format_ = value_mapping.get("type")
-    if format_ == "json_object":
-        return StructuredOutputParams(format="json_object")
-    if format_ != "json_schema":
-        raise ValueError(f"unsupported response_format type: {format_!r}")
-    raw_schema = value_mapping.get("json_schema")
-    if not isinstance(raw_schema, Mapping):
-        raise TypeError("json_schema response_format requires a mapping")
-    raw_schema_mapping = cast(Mapping[str, object], raw_schema)
-    schema = raw_schema_mapping.get("schema")
-    if not isinstance(schema, Mapping):
-        raise TypeError("json_schema response_format requires `schema`")
-    name = raw_schema_mapping.get("name")
-    strict = raw_schema_mapping.get("strict")
-    if name is not None and not isinstance(name, str):
-        raise TypeError("json_schema name must be a string")
-    if strict is not None and not isinstance(strict, bool):
-        raise TypeError("json_schema strict must be a bool")
-    return StructuredOutputParams(
-        format="json_schema",
-        schema=cast(Mapping[str, JSONValue], _named_json_value(schema, "schema")),
-        name=name,
-        strict=strict,
-    )
 
 
 def _apply_request_defaults(req: Request, defaults: RequestDefaults) -> Request:
@@ -769,7 +461,7 @@ class Model:
             "model": self._model,
             "api_base": self._api_base,
             "default_params": {
-                key: _named_json_value(value, f"default_params.{key}")
+                key: named_json_value(value, f"default_params.{key}")
                 for key, value in self._kwargs.items()
             },
         }
@@ -870,7 +562,7 @@ class Model:
 
     async def agenerate(self, prompt: object, **kwargs: object) -> ModelOutput:
         req = self._build_generate_request(prompt, **kwargs)
-        return self._response_to_model_output(await self.arun(req))
+        return response_to_model_output(self.meta(), await self.arun(req))
 
     async def alogprobs(
         self,
@@ -899,16 +591,7 @@ class Model:
             and response.top_logprobs is None
         ):
             raise RuntimeError("logprobs requested but the server returned none.")
-        return self._response_to_model_output(response)
-
-    @staticmethod
-    def _validate_n(kwargs: Mapping[str, object]) -> int:
-        n = kwargs.get("n", 1)
-        if isinstance(n, bool) or not isinstance(n, int):
-            raise TypeError(f"n must be an int, got {type(n).__name__}: {n!r}")
-        if n < 1:
-            raise ValueError(f"n must be >= 1, got {n}")
-        return n
+        return response_to_model_output(self.meta(), response)
 
     def _coerce_input(self, prompt: object) -> ModelInput:
         if isinstance(prompt, CompletionInput | ChatInput):
@@ -918,225 +601,11 @@ class Model:
             "or ChatInput"
         )
 
-    def _kwargs_to_request(
-        self,
-        input_: ModelInput,
-        final_kwargs: Mapping[str, object],
-    ) -> Request:
-        kw = dict(final_kwargs)
-        reserved = sorted(BINDING_RESOURCE_KEYS & set(kw))
-        if reserved:
-            raise ValueError(
-                "request arguments cannot change binding resources: "
-                + ", ".join(reserved)
-            )
-        n = self._validate_n(kw)
-        kw.pop("n", None)
-
-        stream = kw.pop("stream", True)
-        if not isinstance(stream, bool):
-            raise TypeError("stream must be a bool")
-
-        max_tokens = _pop_compatible_alias(
-            kw,
-            "max_tokens",
-            "max_completion_tokens",
-            default=None,
-        )
-        temperature_value = kw.pop("temperature", None)
-        top_p_value = kw.pop("top_p", None)
-        top_k_value = kw.pop("top_k", None)
-        seed_value = kw.pop("seed", None)
-        frequency_penalty_value = kw.pop("frequency_penalty", None)
-        presence_penalty_value = kw.pop("presence_penalty", None)
-        stop = kw.pop("stop", None)
-        stop_value: tuple[str, ...] | None = None
-        if stop is not None:
-            if isinstance(stop, str):
-                stop_value = (stop,)
-            elif isinstance(stop, list | tuple):
-                values = tuple(stop)
-                if not all(isinstance(item, str) for item in values):
-                    raise TypeError("stop must contain only strings")
-                stop_value = cast(tuple[str, ...], values)
-            else:
-                # ``list``/``tuple`` only, matching ``_named_json_value``: this
-                # value is echoed into the persisted ``request_params``, and a
-                # ``set`` would land there in hash order.
-                raise TypeError("stop must be a string, list, or tuple of strings")
-        sampling = SamplingParams(
-            temperature=_optional_float(temperature_value, "temperature"),
-            top_p=_optional_float(top_p_value, "top_p"),
-            top_k=_optional_int(top_k_value, "top_k"),
-            max_tokens=_optional_int(max_tokens, "max_tokens"),
-            stop=stop_value,
-            seed=_optional_int(seed_value, "seed"),
-            frequency_penalty=_optional_float(
-                frequency_penalty_value, "frequency_penalty"
-            ),
-            presence_penalty=_optional_float(
-                presence_penalty_value, "presence_penalty"
-            ),
-            n=n,
-        )
-
-        return_logprobs = kw.pop("return_logprobs", False)
-        if not isinstance(return_logprobs, bool):
-            raise TypeError("return_logprobs must be a bool")
-        top_logprobs = kw.pop("top_logprobs", None)
-        legacy_logprobs = kw.pop("logprobs", None)
-        sampled = return_logprobs
-        breadth = 0
-        if isinstance(legacy_logprobs, bool):
-            sampled = sampled or legacy_logprobs
-        elif legacy_logprobs is not None:
-            if isinstance(legacy_logprobs, bool) or not isinstance(
-                legacy_logprobs, int
-            ):
-                raise TypeError("logprobs must be a bool or integer")
-            sampled = True
-            breadth = legacy_logprobs
-        if top_logprobs is not None:
-            if isinstance(top_logprobs, bool) or not isinstance(top_logprobs, int):
-                raise TypeError("top_logprobs must be an integer")
-            breadth = top_logprobs
-            sampled = sampled or top_logprobs > 0
-        score_input = _pop_compatible_alias(
-            kw,
-            "score_input",
-            "echo",
-            default=False,
-        )
-        if not isinstance(score_input, bool):
-            raise TypeError("echo/score_input must be a bool")
-        scoring = ScoringParams(
-            input_scoring=score_input,
-            sampled_logprobs=sampled,
-            top_logprobs=breadth,
-        )
-
-        reasoning = kw.pop("reasoning", None)
-        effort = kw.pop("reasoning_effort", None)
-        if effort is not None and not isinstance(effort, str):
-            raise TypeError("reasoning_effort must be a string")
-        if reasoning is None:
-            reasoning_params = ReasoningParams(effort=effort)
-        elif isinstance(reasoning, ReasoningParams):
-            if effort is not None:
-                raise ValueError("reasoning and reasoning_effort cannot both be set")
-            reasoning_params = reasoning
-        else:
-            raise TypeError("reasoning must be ReasoningParams")
-
-        raw_tools = kw.pop("tools", ())
-        if raw_tools is None:
-            raw_tools = ()
-        if not isinstance(raw_tools, Iterable) or isinstance(
-            raw_tools, Mapping | str | bytes
-        ):
-            raise TypeError("tools must be an iterable of mappings")
-        functions: list[Mapping[str, JSONValue]] = []
-        for index, tool in enumerate(raw_tools):
-            if not isinstance(tool, Mapping):
-                raise TypeError("tools must contain mappings")
-            functions.append(
-                cast(
-                    Mapping[str, JSONValue],
-                    _named_json_value(tool, f"tools[{index}]"),
-                )
-            )
-        choice = _named_json_value(kw.pop("tool_choice", None), "tool_choice")
-        parallel = kw.pop("parallel_tool_calls", None)
-        if parallel is not None and not isinstance(parallel, bool):
-            raise TypeError("parallel_tool_calls must be a bool")
-        tools = ToolParams(
-            functions=tuple(functions),
-            choice=choice,
-            parallel=parallel,
-        )
-
-        structured_output = _coerce_structured_output(kw.pop("response_format", None))
-        previous_response_id = _pop_compatible_alias(
-            kw,
-            "previous_response_id",
-            "session_id",
-            default=None,
-        )
-        if previous_response_id is not None and not isinstance(
-            previous_response_id, str
-        ):
-            raise TypeError("previous_response_id must be a string")
-        continuation = kw.pop("opaque_continuation", None)
-        if continuation is not None and not isinstance(
-            continuation, OpaqueContinuation
-        ):
-            raise TypeError("opaque_continuation must be OpaqueContinuation")
-
-        suffix = kw.pop("suffix", None)
-        if suffix is not None:
-            if not isinstance(suffix, str):
-                raise TypeError("suffix must be a string")
-            if not isinstance(input_, CompletionInput):
-                raise TypeError("suffix requires CompletionInput")
-            if input_.suffix is not None and input_.suffix != suffix:
-                raise ValueError("suffix conflicts with CompletionInput.suffix")
-            input_ = replace(input_, suffix=suffix)
-
-        options: dict[str, JSONValue] = {}
-        explicit_options = kw.pop("dialect_options", None)
-        if explicit_options is not None:
-            if not isinstance(explicit_options, DialectOptions):
-                raise TypeError("dialect_options must be DialectOptions")
-            if explicit_options.dialect_id != self.dialect_id:
-                raise ValueError("dialect_options target another dialect")
-            reserved = sorted(BINDING_RESOURCE_KEYS & set(explicit_options.values))
-            if reserved:
-                raise ValueError(
-                    "dialect_options cannot contain binding resources: "
-                    + ", ".join(reserved)
-                )
-            options.update(explicit_options.values)
-        for container_name in ("extra_body", "extra_wire_params"):
-            raw = kw.pop(container_name, None)
-            if raw is None:
-                continue
-            if not isinstance(raw, Mapping):
-                raise TypeError(f"{container_name} must be a mapping")
-            for key, value in raw.items():
-                if not isinstance(key, str):
-                    raise TypeError(f"{container_name} keys must be strings")
-                if key in BINDING_RESOURCE_KEYS:
-                    raise ValueError(
-                        f"{container_name} cannot contain binding resource {key!r}"
-                    )
-                if key in options:
-                    raise ValueError(f"duplicate dialect option {key!r}")
-                options[key] = _named_json_value(value, f"{container_name}.{key}")
-        for key, value in kw.items():
-            if key in options:
-                raise ValueError(f"duplicate dialect option {key!r}")
-            options[key] = _named_json_value(value, key)
-
-        return Request(
-            input=input_,
-            sampling=sampling,
-            scoring=scoring,
-            reasoning=reasoning_params,
-            tools=tools,
-            structured_output=structured_output,
-            session=SessionParams(
-                previous_response_id=previous_response_id,
-                opaque_continuation=continuation,
-            ),
-            scheduling=SchedulingParams(stream=stream),
-            dialect_options=(
-                DialectOptions(self.dialect_id, options) if options else None
-            ),
-        )
-
     def _build_generate_request(self, prompt: object, **kwargs: object) -> Request:
         final_kwargs = {**self._kwargs, **kwargs}
-        return self._kwargs_to_request(self._coerce_input(prompt), final_kwargs)
+        return kwargs_to_request(
+            self.dialect_id, self._coerce_input(prompt), final_kwargs
+        )
 
     def _build_logprobs_request(
         self,
@@ -1164,75 +633,10 @@ class Model:
                 "score_input": score_input,
             }
         )
-        if self._validate_n(final_kwargs) > 1:
+        if validate_n(final_kwargs) > 1:
             raise ValueError("alogprobs only supports n=1")
-        return self._kwargs_to_request(self._coerce_input(prompt), final_kwargs)
-
-    def _response_to_model_output(self, response: Response) -> ModelOutput:
-        segments: list[TokenLogprob] = []
-        if response.input_scoring is not None:
-            segments.extend(response.input_scoring.token_logprobs)
-        if response.logprobs is not None:
-            segments.extend(response.logprobs)
-        logprobs_present = (
-            response.input_scoring is not None or response.logprobs is not None
-        )
-        logprobs_tokens = (
-            [item.token for item in segments] if logprobs_present else None
-        )
-        logprobs = [item.logprob for item in segments] if logprobs_present else None
-
-        top_logprobs: list[dict[str, float]] | None = None
-        if response.top_logprobs is not None:
-            top_logprobs = []
-            for position in response.top_logprobs:
-                merged: dict[str, float] = {}
-                for item in position:
-                    previous = merged.get(item.token)
-                    if previous is None or item.logprob > previous:
-                        merged[item.token] = item.logprob
-                top_logprobs.append(merged)
-            top_logprobs = top_logprobs or None
-
-        usage: ModelUsage | None = None
-        if response.usage is not None:
-            usage = {
-                "input_tokens": response.usage.input_tokens,
-                "output_tokens": response.usage.output_tokens,
-                "total_tokens": response.usage.total_tokens,
-            }
-        reasoning_texts: list[str] | None = None
-        if response.reasoning is not None:
-            reasoning_texts = [
-                item.text or "" if item is not None else ""
-                for item in response.reasoning
-            ]
-            if not any(reasoning_texts):
-                reasoning_texts = None
-
-        model_meta = self.meta()
-        if response.provenance is not None:
-            model_meta["provenance"] = response.provenance
-        return ModelOutput(
-            model=model_meta,
-            texts=list(response.texts),
-            finish_reasons=(
-                list(response.finish_reasons)
-                if response.finish_reasons is not None
-                else None
-            ),
-            reasoning_texts=reasoning_texts,
-            logprobs_tokens=logprobs_tokens,
-            logprobs=logprobs,
-            top_logprobs=top_logprobs,
-            usage=usage,
-            request_params=(
-                dict(response.request_params)
-                if response.request_params is not None
-                else None
-            ),
-            response_model=response.response_model,
-            system_fingerprint=response.system_fingerprint,
+        return kwargs_to_request(
+            self.dialect_id, self._coerce_input(prompt), final_kwargs
         )
 
     async def aclose(self) -> None:

--- a/sieval/core/models/model.py
+++ b/sieval/core/models/model.py
@@ -28,10 +28,10 @@ from ._legacy_bridge import (
     ModelMeta,
     ModelOutput,
     kwargs_to_request,
-    named_json_value,
     response_to_model_output,
     validate_n,
 )
+from ._shared import named_json_value
 from .capabilities import (
     Capability,
     RequestDefaults,

--- a/tests/unit/cli/test_resolution.py
+++ b/tests/unit/cli/test_resolution.py
@@ -90,7 +90,7 @@ def _project_sieval_first():
 class TestLoadClassFromPath:
     def test_valid_path(self):
         cls = load_class_from_path("sieval.core.models.model.ModelOutput")
-        from sieval.core.models.model import ModelOutput
+        from sieval.core.models import ModelOutput
 
         assert cls is ModelOutput
 

--- a/tests/unit/cli/test_resolution.py
+++ b/tests/unit/cli/test_resolution.py
@@ -89,16 +89,18 @@ def _project_sieval_first():
 # ===================================================================
 class TestLoadClassFromPath:
     def test_valid_path(self):
-        cls = load_class_from_path("sieval.core.models.model.ModelOutput")
-        from sieval.core.models import ModelOutput
+        # `Model` is defined in `sieval.core.models.model`; resolving a class
+        # that the module merely re-exports would not prove the path is walked.
+        cls = load_class_from_path("sieval.core.models.model.Model")
+        from sieval.core.models import Model
 
-        assert cls is ModelOutput
+        assert cls is Model
 
     # (class_path, expected_exception, expected_error_pattern)
     @pytest.mark.parametrize(
         "class_path,error_type,error_match",
         [
-            ("ModelOutput", ValueError, "Invalid class path"),
+            ("Model", ValueError, "Invalid class path"),
             ("nonexistent.module.Foo", ImportError, "Could not import"),
             (
                 "sieval.core.models.model.NonExistentClass",
@@ -121,9 +123,9 @@ class TestLoadClassFromName:
         "class_name,search_modules,expected_path",
         [
             (
-                "ModelOutput",
+                "Model",
                 ["sieval.core.models.model"],
-                "sieval.core.models.model.ModelOutput",
+                "sieval.core.models.model.Model",
             ),
             (
                 "ChatModel",
@@ -131,9 +133,9 @@ class TestLoadClassFromName:
                 "sieval.core.models.chat_model.ChatModel",
             ),
             (
-                "ModelOutput",
+                "Model",
                 ["nonexistent.module", "sieval.core.models.model"],
-                "sieval.core.models.model.ModelOutput",
+                "sieval.core.models.model.Model",
             ),
         ],
     )
@@ -157,14 +159,14 @@ class TestResolveClass:
         "class_spec,search_modules,expected_path",
         [
             (
-                "sieval.core.models.model.ModelOutput",
+                "sieval.core.models.model.Model",
                 [],
-                "sieval.core.models.model.ModelOutput",
+                "sieval.core.models.model.Model",
             ),
             (
-                "ModelOutput",
+                "Model",
                 ["sieval.core.models.model"],
-                "sieval.core.models.model.ModelOutput",
+                "sieval.core.models.model.Model",
             ),
         ],
     )
@@ -175,7 +177,7 @@ class TestResolveClass:
     def test_leading_dot_raises_value_error(self):
         # Relative import syntax is explicitly rejected.
         with pytest.raises(ValueError, match="Relative import syntax"):
-            resolve_class(".ModelOutput", ["sieval.core.models.model"])
+            resolve_class(".Model", ["sieval.core.models.model"])
 
 
 # ===================================================================

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -8,7 +8,7 @@ import os
 
 import pytest
 
-from sieval.core.models.model import ModelMeta, ModelOutput, ModelUsage
+from sieval.core.models import ModelMeta, ModelOutput, ModelUsage
 from sieval.core.tasks.context import TaskContext, TaskStageMeta
 
 # scripts/ tests are repo-hygiene checks (preflight, layer imports) that run

--- a/tests/unit/core/models/test_model.py
+++ b/tests/unit/core/models/test_model.py
@@ -1057,3 +1057,26 @@ class TestResponseBridge:
             Response(texts=("t",), reasoning=(ReasoningOutput(text=""),))
         )
         assert out.reasoning_texts is None
+
+    def test_caller_mapping_is_not_mutated_and_not_shared(self):
+        """Provenance is attached to a copy.
+
+        The mapping is a free function's argument now, not something the method
+        built for itself, so a caller may legitimately keep a reference to it.
+        Attaching provenance in place would write into that caller's dict and
+        leak the first response's provenance into every later output built from
+        it -- and `ModelCallMeta` is persisted.
+        """
+        model = GenModel(model="m", api_key="k")
+        caller_meta = model.meta()
+        provenance = model._provenance(Response(texts=("t",)))
+
+        first = response_to_model_output(
+            caller_meta, Response(texts=("a",), provenance=provenance)
+        )
+        second = response_to_model_output(caller_meta, Response(texts=("b",)))
+
+        assert "provenance" not in caller_meta
+        assert first.model["provenance"] == provenance
+        assert "provenance" not in second.model
+        assert first.model is not second.model

--- a/tests/unit/core/models/test_model.py
+++ b/tests/unit/core/models/test_model.py
@@ -36,6 +36,7 @@ from sieval.core.models import (
     TopKEntry,
     UsageStats,
 )
+from sieval.core.models._legacy_bridge import response_to_model_output
 from sieval.core.models.dialect import DialectError
 from sieval.core.models.model import _apply_request_defaults
 from sieval.core.models.reconcile import CheckStage, DeferredCheck
@@ -968,7 +969,8 @@ class TestRequestDefaultsProjection:
 # ===================================================================
 class TestResponseBridge:
     def _bridge(self, resp: Response) -> ModelOutput:
-        return GenModel(model="m", api_key="k")._response_to_model_output(resp)
+        model = GenModel(model="m", api_key="k")
+        return response_to_model_output(model.meta(), resp)
 
     def test_basic_fields(self):
         out = self._bridge(

--- a/tests/unit/core/tasks/test_anomaly.py
+++ b/tests/unit/core/tasks/test_anomaly.py
@@ -12,7 +12,7 @@ from unittest.mock import AsyncMock
 import orjson
 import pytest
 
-from sieval.core.models.model import ModelOutput
+from sieval.core.models import ModelOutput
 from sieval.core.tasks.anomaly import (
     _DETECTION_RULES,
     AnomalyReport,

--- a/tests/unit/core/utils/test_meta.py
+++ b/tests/unit/core/utils/test_meta.py
@@ -6,7 +6,7 @@ AI-Generated Code - Claude Opus 4.6 (Anthropic)
 
 import time
 
-from sieval.core.models.model import ModelMeta, ModelOutput
+from sieval.core.models import ModelMeta, ModelOutput
 from sieval.core.utils.meta import (
     build_model_call_meta,
     build_model_call_meta_from_mapping,

--- a/tests/unit/core/utils/test_serialization.py
+++ b/tests/unit/core/utils/test_serialization.py
@@ -11,7 +11,7 @@ from types import ModuleType
 
 import pytest
 
-from sieval.core.models.model import ModelOutput
+from sieval.core.models import ModelOutput
 from sieval.core.tasks.context import TaskStageOutput
 from sieval.core.utils.serialization import (
     dict_to_obj,


### PR DESCRIPTION
## Type

- refactor — code restructuring, no behavior change

  **One scoped exception**, called out under Manual: `response_to_model_output` now copies the caller's `model_meta` before attaching provenance. Both current call sites pass a fresh `meta()`, so nothing on disk was ever wrong — the guarantee is restored before a caller can get it wrong.

> **Rebased onto `main` after #100 merged.** #98 has merged too, so this is no longer a stacked PR. #100 edited two of the definitions this PR relocates, so its work is carried into the new homes and *verified* rather than assumed — see Manual.

## Summary

- `model.py` held two things with **different lifetimes**: the canonical `Model` composition root, which the plane keeps evolving, and the one-cycle compatibility surface, which is scheduled to die. Kept in one file, removing the compat layer is surgery on a live module; split out, it is a file deletion.

  | file | lines | holds |
  |---|---|---|
  | `model.py` | 1260 → **664** | canonical `Model` |
  | `_legacy_bridge.py` | **454** | task kwargs ↔ `Request`/`Response`, the `ModelOutput` family |
  | `_legacy_binding.py` | **170** | `RuntimeBindingPlan` fabricated for the bare `ChatModel`/`GenModel` constructors |

- The split works because the bridge was already free-function shaped, as the review measured: `_kwargs_to_request` (212 lines) touched only `self.dialect_id` and the static `self._validate_n`; `_response_to_model_output` only `self.meta()`. Those three become parameters. Nothing else changed.
- **Direction is now one-way**, which is the property that makes the eventual delete cheap: `_legacy_bridge` imports `deployment` + `ir` and *nothing* from `model`. `_legacy_binding` is reachable only from `chat_model`/`gen_model`, so it leaves when the wrappers do.
- `uuid4()`'s non-deterministic binding fingerprint (prior review N1(a)) now sits alone in `_legacy_binding`, visible and removable, instead of buried mid-file. This PR does not change it.
- **Second commit applies this PR's own review findings.** The split had made `_legacy_bridge` the owner of `named_json_value`, which `Model.meta()` needs too — so deleting the bridge would have broken the canonical plane, the one thing the split exists to make cheap. The primitive moves to `_shared` beside `copy_json_value`, and `model`'s inbound edge on the bridge drops from six names to five. `ModelMeta` is the one thread still to be cut by hand at deletion time (`Model.meta()` is public and `tasks/ruler_0shot_gen.py` calls it outside the legacy path); the module docstring says so now instead of implying the delete is free.

## Related Issues

Refs #25 — follow-up from the PR #45 review (N6). Does **not** close the `core/binding/` split, which is still gated on step 5 moving SGLang and on settling whether `capabilities.py` is vocabulary or binder logic.

## Test Plan

### Automated

- [x] Lint/format clean (`ruff check && ruff format --check`) — 495 files formatted
- [x] Type check clean (`ty check`)
- [x] Unit tests pass (`pdm run pytest`) — **5336 collected, all green, 5 deselected** (unit + integration); `tests/unit/core/models/` alone is 815; preflight 25/25, no FAIL/WARN. One repeat run flaked on the two load-sensitive performance tests (`test_benchmark_scenarios` at 55.5% concurrency efficiency, `test_pipeline_memory_scaling` at 6.6×) while the box was busy; both re-ran green in isolation and neither imports `core/models`.

### Manual

- [x] **No behaviour change, checked rather than asserted.** Every moved definition was compared against its post-#100 `origin/main` source (`d0d2027f`), not against the pre-#100 tree. Identity is measured **on the first commit**, the one that does the moving; the second commit's single deliberate change is listed separately in the last row of this section.

  | group | result |
  |---|---|
  | `ModelUsage`, `ModelMeta`, `ModelCallMeta`, `ModelOutput`, `_optional_float`, `_optional_int`, `_pop_compatible_alias`, `_LegacyOpenAIBinding`, `_legacy_runtime_plan`, `build_legacy_openai_binding` | byte-identical |
  | `_named_json_value` → `named_json_value`, `_coerce_structured_output` | identical modulo the documented rename |
  | `validate_n`, `kwargs_to_request`, `response_to_model_output` | **AST-identical** after the documented `self` → parameter substitutions (73 top-level body statements: 4 + 55 + 14) |
  | `_checked_builder_defaults` (new in #100, stays in `model.py`) | identical modulo the rename — only its call site is repointed |

- [x] **#100's work is carried, not silently reverted.** #100 narrowed `_named_json_value`'s sequence branch and `_kwargs_to_request`'s `stop` branch to `list`/`tuple`. Because the rebase relocated both definitions, git had no conflict to mark at their *new* locations — so this was checked by reverse-mutation: widening each branch back where it now lives makes #100's own guards fail (**3 cases** on the coercer, **2** on `stop`). #100's five test names are all present and the models suite went 73 → 74 tests.
- [x] **Zero runtime import cycles** across all 27 modules in `core/models` (TYPE_CHECKING excluded), same as before. `_legacy_bridge` out-edges: `_shared`, `deployment`, `ir`.
- [x] **The relocated bridge is live code, not an unreferenced copy** — three mutations, all caught by the suite: `validate_n` accepting `n < 1`, `kwargs_to_request` dropping the binding-resource guard, and `response_to_model_output` dropping the provenance attachment (that last one is caught by `tests/unit/core/runners/test_runner.py`, outside the model tests).
- [x] **The one deliberate behaviour change is guarded.** As a method, `_response_to_model_output` built the `model_meta` mapping itself, so mutating in place was safe by construction; as a free function it *receives* one, and writing into it leaked the first response's provenance into every later output built from the same mapping — into `ModelCallMeta`, which is persisted. The new test asserts the caller's mapping is untouched and that two outputs do not share it, and was confirmed to fail without the `.copy()`.

## Checklist

### Required (all PRs)

- [x] PR title follows conventional format (`type(scope): description`)
- [x] No internal paths, credentials, or personal info in committed files — also scanned the two commit messages
- [x] AI-generated code has `AI-Generated Code - <model> (<provider>)` in module docstring — both new modules carry it
- [x] No new upper-layer dependencies added to `core/`
- [x] Deleted code verified — no remaining call sites depend on it. Six test files imported the record types from `sieval.core.models.model` and now use the public `sieval.core.models` path; one test reached for the private `_response_to_model_output` and now calls the free function. `tests/unit/cli/test_resolution.py` resolved `ModelOutput` through `sieval.core.models.model`, which only re-exports it — six paths that would have broken at bridge-deletion time for reasons unrelated to the resolver; they use `Model` now, which that module actually defines.

### Follow-up (not in this PR)

- `copy_json_value` and `named_json_value` are still two functions. After #100 they no longer disagree about containers — both take `list`/`tuple` — so the only difference left is how an error names a rejected leaf: one indexes into the list, the other stops at the enclosing key. Folding them together changes the messages callers see, so it belongs in its own change rather than in a move.
