### PR TITLE
fix(models): compute usage totals, and reject bad builder defaults at bind time

### DIFF
--- a/sieval/core/models/dialects/openai_chat.py
+++ b/sieval/core/models/dialects/openai_chat.py
@@ -256,9 +256,17 @@ class _LegacyPlan:
 
 
 def _chat_usage_stats(raw: Any) -> UsageStats | None:
+    """Build usage from a chat reply's reported prompt and completion counts.
+
+    ``total_tokens`` is computed rather than read. A server whose reported total
+    does not decompose into prompt + completion has a bookkeeping quirk, not a
+    corrupt reply, and rejecting it would discard tokens that were generated and
+    billed -- in the streaming path, only once the rollout had already finished.
+    The sglang transport has always summed rather than trusted; this agrees.
+    """
     if raw is None:
         return None
-    names = ("prompt_tokens", "completion_tokens", "total_tokens")
+    names = ("prompt_tokens", "completion_tokens")
     values: list[int] = []
     for name in names:
         value = getattr(raw, name, None)
@@ -267,14 +275,10 @@ def _chat_usage_stats(raw: Any) -> UsageStats | None:
                 f"chat usage.{name} must be a non-negative integer"
             )
         values.append(value)
-    if values[2] != values[0] + values[1]:
-        raise OutputContractError(
-            "chat usage.total_tokens must equal prompt_tokens + completion_tokens"
-        )
     return UsageStats(
         input_tokens=values[0],
         output_tokens=values[1],
-        total_tokens=values[2],
+        total_tokens=values[0] + values[1],
     )
 
 

--- a/sieval/core/models/dialects/openai_chat.py
+++ b/sieval/core/models/dialects/openai_chat.py
@@ -256,13 +256,11 @@ class _LegacyPlan:
 
 
 def _chat_usage_stats(raw: Any) -> UsageStats | None:
-    """Build usage from a chat reply's reported prompt and completion counts.
+    """Build usage from the reply's prompt and completion counts.
 
-    ``total_tokens`` is computed rather than read. A server whose reported total
-    does not decompose into prompt + completion has a bookkeeping quirk, not a
-    corrupt reply, and rejecting it would discard tokens that were generated and
-    billed -- in the streaming path, only once the rollout had already finished.
-    The sglang transport has always summed rather than trusted; this agrees.
+    ``total_tokens`` is computed, not read: a reported total that does not
+    decompose is a bookkeeping quirk, and rejecting the reply would discard
+    tokens already generated and billed.
     """
     if raw is None:
         return None

--- a/sieval/core/models/dialects/openai_completions.py
+++ b/sieval/core/models/dialects/openai_completions.py
@@ -280,13 +280,10 @@ def _optional_response_string(value: object, path: str) -> str | None:
 
 
 def _completions_usage_stats(raw: object) -> UsageStats | None:
-    """Build usage from a completion reply's prompt and completion counts.
+    """Build usage from the reply's prompt and completion counts.
 
-    ``total_tokens`` is computed rather than read, so a server that reports a
-    total which does not decompose cannot cost the caller a completed reply.
-    Stays separate from the chat copy despite reading the same two field names:
-    response parsing is a per-wire-format concern, and the two endpoints have
-    already diverged once over how much of the reported usage they trusted.
+    ``total_tokens`` is computed, not read: a reported total that does not
+    decompose must not cost the caller a completed reply.
     """
     if raw is None:
         return None
@@ -730,8 +727,7 @@ class _Accumulator:
             raise OutputContractError(
                 "usage completion-token count contradicts echoed logprob positions"
             )
-        # No total-token check: _completions_usage_stats computes the total from
-        # the two counts above, so the identity holds by construction.
+        # No total-token check: the total is computed from these two counts.
         if self._top_logprobs and len(self._top_logprobs) != token_count:
             raise OutputContractError(
                 "input scoring top-logprob positions are inconsistent"

--- a/sieval/core/models/dialects/openai_completions.py
+++ b/sieval/core/models/dialects/openai_completions.py
@@ -280,10 +280,18 @@ def _optional_response_string(value: object, path: str) -> str | None:
 
 
 def _completions_usage_stats(raw: object) -> UsageStats | None:
+    """Build usage from a completion reply's prompt and completion counts.
+
+    ``total_tokens`` is computed rather than read, so a server that reports a
+    total which does not decompose cannot cost the caller a completed reply.
+    Stays separate from the chat copy despite reading the same two field names:
+    response parsing is a per-wire-format concern, and the two endpoints have
+    already diverged once over how much of the reported usage they trusted.
+    """
     if raw is None:
         return None
 
-    names = ("prompt_tokens", "completion_tokens", "total_tokens")
+    names = ("prompt_tokens", "completion_tokens")
     values: list[int] = []
     for name in names:
         value = getattr(raw, name, None)
@@ -295,7 +303,7 @@ def _completions_usage_stats(raw: object) -> UsageStats | None:
     return UsageStats(
         input_tokens=values[0],
         output_tokens=values[1],
-        total_tokens=values[2],
+        total_tokens=values[0] + values[1],
     )
 
 
@@ -722,10 +730,8 @@ class _Accumulator:
             raise OutputContractError(
                 "usage completion-token count contradicts echoed logprob positions"
             )
-        if usage.total_tokens != usage.input_tokens + usage.output_tokens:
-            raise OutputContractError(
-                "usage total-token count contradicts prompt and completion counts"
-            )
+        # No total-token check: _completions_usage_stats computes the total from
+        # the two counts above, so the identity holds by construction.
         if self._top_logprobs and len(self._top_logprobs) != token_count:
             raise OutputContractError(
                 "input scoring top-logprob positions are inconsistent"

--- a/sieval/core/models/model.py
+++ b/sieval/core/models/model.py
@@ -183,6 +183,15 @@ _REMOVED_SUBCLASS_HOOKS = frozenset({"_agenerate_impl", "_alogprobs_impl"})
 
 
 def _named_json_value(value: object, name: str) -> JSONValue:
+    """Validate and detach a JSON value, naming the offending leaf on failure.
+
+    Sequences are restricted to ``list``/``tuple`` rather than any ``Iterable``.
+    The result is persisted in ``ModelMeta.default_params``, and the two other
+    shapes an ``Iterable`` admits both corrupt that record silently: a ``set``
+    serializes in hash order, and a generator -- consumed by the first call --
+    serializes as ``[]`` on every later one. The same-package
+    ``_shared.copy_json_value`` has always rejected both; this agrees.
+    """
     if isinstance(value, float):
         if not math.isfinite(value):
             raise ValueError(f"{name} must not contain a non-finite float")
@@ -196,7 +205,7 @@ def _named_json_value(value: object, name: str) -> JSONValue:
                 raise TypeError(f"{name} keys must be strings")
             result[key] = _named_json_value(item, f"{name}.{key}")
         return result
-    if isinstance(value, Iterable) and not isinstance(value, str | bytes):
+    if isinstance(value, list | tuple):
         return [_named_json_value(item, name) for item in value]
     raise TypeError(f"{name} must be JSON-compatible, got {type(value).__name__}")
 

--- a/sieval/core/models/model.py
+++ b/sieval/core/models/model.py
@@ -185,12 +185,9 @@ _REMOVED_SUBCLASS_HOOKS = frozenset({"_agenerate_impl", "_alogprobs_impl"})
 def _named_json_value(value: object, name: str) -> JSONValue:
     """Validate and detach a JSON value, naming the offending leaf on failure.
 
-    Sequences are restricted to ``list``/``tuple`` rather than any ``Iterable``.
-    The result is persisted in ``ModelMeta.default_params``, and the two other
-    shapes an ``Iterable`` admits both corrupt that record silently: a ``set``
-    serializes in hash order, and a generator -- consumed by the first call --
-    serializes as ``[]`` on every later one. The same-package
-    ``_shared.copy_json_value`` has always rejected both; this agrees.
+    Sequences are ``list``/``tuple`` only: the result is persisted, and a
+    ``set`` would serialize in hash order while a generator would serialize
+    as ``[]`` once consumed.
     """
     if isinstance(value, float):
         if not math.isfinite(value):
@@ -211,13 +208,11 @@ def _named_json_value(value: object, name: str) -> JSONValue:
 
 
 def _checked_builder_defaults(values: Mapping[str, object]) -> dict[str, object]:
-    """Reject builder defaults that ``meta()`` would not be able to persist.
+    """Reject builder defaults that ``meta()`` could not persist.
 
-    ``meta()`` runs once per response, so a default that cannot round-trip
-    through JSON would otherwise raise only after a model call had been made
-    and billed. Checking at bind time moves that to the point where the value
-    is supplied. The originals are stored unconverted -- the request builders
-    still need them as given, and ``meta()`` does its own copy.
+    ``meta()`` runs once per response, so an unpersistable default would
+    otherwise raise only after a call had been billed. Values are stored
+    unconverted -- the request builders need them as given.
     """
     for key, value in values.items():
         _named_json_value(value, f"default_params.{key}")

--- a/sieval/core/models/model.py
+++ b/sieval/core/models/model.py
@@ -954,13 +954,16 @@ class Model:
         if stop is not None:
             if isinstance(stop, str):
                 stop_value = (stop,)
-            elif isinstance(stop, Iterable):
+            elif isinstance(stop, list | tuple):
                 values = tuple(stop)
                 if not all(isinstance(item, str) for item in values):
                     raise TypeError("stop must contain only strings")
                 stop_value = cast(tuple[str, ...], values)
             else:
-                raise TypeError("stop must be a string or iterable of strings")
+                # ``list``/``tuple`` only, matching ``_named_json_value``: this
+                # value is echoed into the persisted ``request_params``, and a
+                # ``set`` would land there in hash order.
+                raise TypeError("stop must be a string, list, or tuple of strings")
         sampling = SamplingParams(
             temperature=_optional_float(temperature_value, "temperature"),
             top_p=_optional_float(top_p_value, "top_p"),

--- a/sieval/core/models/model.py
+++ b/sieval/core/models/model.py
@@ -210,6 +210,20 @@ def _named_json_value(value: object, name: str) -> JSONValue:
     raise TypeError(f"{name} must be JSON-compatible, got {type(value).__name__}")
 
 
+def _checked_builder_defaults(values: Mapping[str, object]) -> dict[str, object]:
+    """Reject builder defaults that ``meta()`` would not be able to persist.
+
+    ``meta()`` runs once per response, so a default that cannot round-trip
+    through JSON would otherwise raise only after a model call had been made
+    and billed. Checking at bind time moves that to the point where the value
+    is supplied. The originals are stored unconverted -- the request builders
+    still need them as given, and ``meta()`` does its own copy.
+    """
+    for key, value in values.items():
+        _named_json_value(value, f"default_params.{key}")
+    return dict(values)
+
+
 def _optional_float(value: object, name: str) -> float | None:
     if value is None:
         return None
@@ -551,7 +565,7 @@ class Model:
         self._transport = dialect  # one-cycle private compatibility alias
         self._model = runtime_plan.requested_model_id
         self._api_base = api_base
-        self._kwargs = dict(builder_defaults)
+        self._kwargs = _checked_builder_defaults(builder_defaults)
         self._extra = dict(extra) if extra is not None else None
         self._limiter = local_limiter
         self._parent_limiter = parent_limiter
@@ -601,7 +615,7 @@ class Model:
             raise ValueError("concurrency_limit must be a positive integer")
 
         new_model = copy.copy(self)
-        new_model._kwargs = {**self._kwargs, **kwargs}
+        new_model._kwargs = _checked_builder_defaults({**self._kwargs, **kwargs})
         if extra is not None:
             new_model._extra = dict(extra)
         if concurrency_limit is not None:

--- a/tests/unit/core/models/dialects/test_openai_chat.py
+++ b/tests/unit/core/models/dialects/test_openai_chat.py
@@ -812,7 +812,7 @@ class TestResponseLifting:
         [
             _usage(-1, 1, 0),
             _usage(1, True, 2),
-            _usage(1, 1, 2.0),
+            _usage(1, 2.0, 3),
         ],
     )
     async def test_usage_fields_must_be_non_negative_integers(
@@ -824,11 +824,17 @@ class TestResponseLifting:
             await dialect.arun(Request(input=_chat()))
 
     @pytest.mark.anyio
-    async def test_usage_total_must_equal_input_plus_output(self) -> None:
+    async def test_reported_total_is_ignored_in_favour_of_the_computed_one(
+        self,
+    ) -> None:
+        """A total that does not decompose must not cost the caller the reply."""
         dialect, _ = _dialect(_response(_choice(0, "ok"), usage=_usage(2, 3, 99)))
 
-        with pytest.raises(OutputContractError, match="must equal"):
-            await dialect.arun(Request(input=_chat()))
+        response = await dialect.arun(Request(input=_chat()))
+
+        assert response.usage == UsageStats(
+            input_tokens=2, output_tokens=3, total_tokens=5
+        )
 
     @pytest.mark.anyio
     @pytest.mark.parametrize(

--- a/tests/unit/core/models/dialects/test_openai_completions.py
+++ b/tests/unit/core/models/dialects/test_openai_completions.py
@@ -430,7 +430,6 @@ class TestInputScoringBoundary:
             (_usage(0, 2), "positive"),
             (_usage(3, 0), "exceeds"),
             (_usage(1, 0), "completion-token"),
-            (_usage(1, 1, 9), "total-token"),
         ],
     )
     async def test_inconsistent_usage_is_an_error(
@@ -450,6 +449,29 @@ class TestInputScoringBoundary:
 
         with pytest.raises(OutputContractError, match=message):
             await dialect.execute(prepared)
+
+    @pytest.mark.anyio
+    async def test_reported_total_is_ignored_in_favour_of_the_computed_one(
+        self,
+    ) -> None:
+        """A total that does not decompose must not cost the caller the reply."""
+        dialect, _ = _dialect(
+            _response(
+                _choice(tokens=["p", " out"], token_logprobs=[None, -0.2]),
+                usage=_usage(1, 1, 9),
+            )
+        )
+        req = Request(
+            input=CompletionInput("p"),
+            scoring=ScoringParams(input_scoring=True),
+        )
+        _, prepared = _prepare(dialect, req)
+
+        result = await dialect.execute(prepared)
+
+        assert result.usage == UsageStats(
+            input_tokens=1, output_tokens=1, total_tokens=2
+        )
 
 
 class TestOutputLifting:

--- a/tests/unit/core/models/test_model.py
+++ b/tests/unit/core/models/test_model.py
@@ -564,6 +564,11 @@ class TestBuildGenerateRequest:
         req = self._model()._build_generate_request("p", stop=["\n\n", "Q:"])
         assert req.sampling.stop == ("\n\n", "Q:")
 
+    def test_stop_tuple_becomes_tuple(self):
+        """Bind time stores a tuple default unconverted, so this path sees one."""
+        req = self._model()._build_generate_request("p", stop=("\n\n", "Q:"))
+        assert req.sampling.stop == ("\n\n", "Q:")
+
     def test_top_k_kwarg_is_sampling_top_k(self):
         """`top_k` is the vLLM/sglang sampling knob, not the logprobs count."""
         req = self._model()._build_generate_request("p", top_k=40)
@@ -669,6 +674,20 @@ class TestBuilderValidation:
 
         assert model.meta()["default_params"]["stop"] == ["a", "b"]
 
+    @pytest.mark.parametrize(
+        "stop",
+        [{"a", "b"}, (item for item in ["a", "b"])],
+        ids=["set", "generator"],
+    )
+    def test_call_time_stop_is_refused_on_the_same_terms_as_a_default(self, stop):
+        """``stop`` lands in the persisted ``request_params``, so it needs an order.
+
+        The builder pops ``stop`` before the JSON check runs, so narrowing that
+        check alone left this path taking any iterable.
+        """
+        with pytest.raises(TypeError, match="stop must be a string, list, or tuple"):
+            self._model()._build_generate_request("p", stop=stop)
+
     def test_n_must_be_int(self):
         with pytest.raises(TypeError, match="n must be an int"):
             self._model()._build_generate_request("p", n="3")
@@ -716,7 +735,7 @@ class TestBuilderValidation:
             ({"temperature": True}, TypeError, "temperature must be a number"),
             ({"top_k": True}, TypeError, "top_k must be an integer"),
             ({"stop": ["ok", 1]}, TypeError, "only strings"),
-            ({"stop": 3}, TypeError, "string or iterable"),
+            ({"stop": 3}, TypeError, "string, list, or tuple"),
             ({"return_logprobs": "yes"}, TypeError, "must be a bool"),
             ({"logprobs": "five"}, TypeError, "bool or integer"),
             ({"top_logprobs": True}, TypeError, "must be an integer"),

--- a/tests/unit/core/models/test_model.py
+++ b/tests/unit/core/models/test_model.py
@@ -650,13 +650,7 @@ class TestBuilderValidation:
         ids=["set", "generator"],
     )
     def test_binding_rejects_default_params_that_cannot_round_trip(self, default):
-        """``default_params`` is persisted, so only stable sequences may enter.
-
-        A ``set`` serializes in hash order; a generator, consumed by the first
-        call, serializes as ``[]`` on every later one. Both corrupt the record
-        without raising, which is why the coercion rejects them outright -- at
-        bind time, before a model call can be spent on a doomed record.
-        """
+        """``default_params`` is persisted: a ``set`` reorders, a generator empties."""
         with pytest.raises(
             TypeError, match="default_params.stop must be JSON-compatible"
         ):

--- a/tests/unit/core/models/test_model.py
+++ b/tests/unit/core/models/test_model.py
@@ -649,19 +649,26 @@ class TestBuilderValidation:
         [{"a", "b"}, (item for item in ["a", "b"])],
         ids=["set", "generator"],
     )
-    def test_meta_rejects_default_params_that_cannot_round_trip(self, default):
+    def test_binding_rejects_default_params_that_cannot_round_trip(self, default):
         """``default_params`` is persisted, so only stable sequences may enter.
 
         A ``set`` serializes in hash order; a generator, consumed by the first
         call, serializes as ``[]`` on every later one. Both corrupt the record
-        without raising, which is why the coercion rejects them outright.
+        without raising, which is why the coercion rejects them outright -- at
+        bind time, before a model call can be spent on a doomed record.
         """
-        model = GenModel(model="m", api_key="k", stop=default)
+        with pytest.raises(
+            TypeError, match="default_params.stop must be JSON-compatible"
+        ):
+            GenModel(model="m", api_key="k", stop=default)
+
+    def test_with_args_rejects_default_params_that_cannot_round_trip(self):
+        model = GenModel(model="m", api_key="k")
 
         with pytest.raises(
             TypeError, match="default_params.stop must be JSON-compatible"
         ):
-            model.meta()
+            model.with_args(stop={"a", "b"})
 
     def test_meta_keeps_tuple_default_params(self):
         model = GenModel(model="m", api_key="k", stop=("a", "b"))

--- a/tests/unit/core/models/test_model.py
+++ b/tests/unit/core/models/test_model.py
@@ -644,6 +644,30 @@ class TestBuilderValidation:
     def _model(self):
         return GenModel(model="m", api_key="k")
 
+    @pytest.mark.parametrize(
+        "default",
+        [{"a", "b"}, (item for item in ["a", "b"])],
+        ids=["set", "generator"],
+    )
+    def test_meta_rejects_default_params_that_cannot_round_trip(self, default):
+        """``default_params`` is persisted, so only stable sequences may enter.
+
+        A ``set`` serializes in hash order; a generator, consumed by the first
+        call, serializes as ``[]`` on every later one. Both corrupt the record
+        without raising, which is why the coercion rejects them outright.
+        """
+        model = GenModel(model="m", api_key="k", stop=default)
+
+        with pytest.raises(
+            TypeError, match="default_params.stop must be JSON-compatible"
+        ):
+            model.meta()
+
+    def test_meta_keeps_tuple_default_params(self):
+        model = GenModel(model="m", api_key="k", stop=("a", "b"))
+
+        assert model.meta()["default_params"]["stop"] == ["a", "b"]
+
     def test_n_must_be_int(self):
         with pytest.raises(TypeError, match="n must be an int"):
             self._model()._build_generate_request("p", n="3")
@@ -733,6 +757,8 @@ class TestBuilderValidation:
         [
             ({1: "bad-key"}, "keys must be strings"),
             (object(), "JSON-compatible"),
+            ({"a", "b"}, "JSON-compatible"),
+            ((item for item in ["a"]), "JSON-compatible"),
         ],
     )
     def test_tool_choice_must_be_json_compatible(self, tool_choice, match):

--- a/tests/unit/core/models/test_model_derivation.py
+++ b/tests/unit/core/models/test_model_derivation.py
@@ -230,11 +230,10 @@ class TestModelDerivation:
         assert m["default_params"]["top_p"] == 0.9
 
     @pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
-    def test_model_meta_rejects_non_finite_default_params(self, value):
-        model = StubGenModel(model="bad-param", api_key="fake", custom=value)
-
+    def test_binding_rejects_non_finite_default_params(self, value):
+        """Rejected at bind time, so no model call can be spent on it first."""
         with pytest.raises(ValueError, match="non-finite"):
-            model.meta()
+            StubGenModel(model="bad-param", api_key="fake", custom=value)
 
     @pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
     def test_request_builder_rejects_non_finite_sampling_values(self, base_gen, value):


### PR DESCRIPTION
## Type

- fix — bug fix or alignment correction

## Summary

Four fixes to what a per-call record may contain, and to *when* a call is worth failing over.

- **Usage totals are computed, not read.** One concept had three stances: `openai_chat` raised when the reported total did not decompose, `openai_completions` accepted whatever the server sent, and the sglang transport never read a reported total at all — it summed. Both dialects now agree with sglang.
- **`default_params` rejects values that cannot round-trip.** `_named_json_value` took any non-`str`/`bytes` `Iterable`, where the same-package `copy_json_value` has always taken only `list`/`tuple`. Narrowed to match.
- **The same rule now holds at call time.** `_kwargs_to_request` pops `stop` *before* the JSON check runs and handles it with its own `isinstance(stop, Iterable)` branch, so narrowing `_named_json_value` closed the bind-time door and left the call-time one open.
- **Builder defaults are checked at bind time.** `meta()` runs per response, so it was the first thing to notice a bad default — raising only after a call had been billed.

**Why the usage check was the risky one.** `OutputContractError` is documented as "a successful wire reply violated its declared output contract" — the tokens were billed. It is never caught anywhere in `sieval`, so it reaches the runner's generic `except Exception`, consumes a retry, and lands the sample in `fails` scoring 0. A server one token off discarded a good reply, and in the streaming path only after the rollout had finished. Computing the total also makes the identity structural, so `_validate_input_scoring_boundary`'s total-token comparison can no longer fire and is removed; the remaining boundary checks compare usage against echoed logprob positions and still have teeth.

**Why the `Iterable` gap mattered.** Two admitted shapes corrupt `ModelMeta.default_params` — which its own docstring calls "persisted" — without raising: a `set` serializes in hash order, against the resume strict-match contract; a generator is consumed by the first call, so every later `meta()` persists `[]`. Verified before changing anything: `{"c","a","b"}` → `['a','c','b']`, and a generator gives `['a','b']` then `[]`.

**Why the call-time half had to follow.** `stop` is echoed into `request_params`, which is persisted, so the bind-time fix on its own produced a rule that held at one entry point and not the other — `ChatModel(stop={"a","b"})` raised while `agenerate(stop={"a","b"})` was accepted and sent the set in hash order. Measured across four processes, the same five-element set produced a different order each time. `tools` / `tool_choice` are deliberately left taking any iterable: a set of tool definitions is impossible (mappings are unhashable) and the elements already go through `_named_json_value`.

## Related Issues

Refs #25. Follow-ups from the review of #98, which flagged both as belonging in their own PR.

## Test Plan

### Automated

- [x] Lint/format clean (`ruff check && ruff format --check`)
- [x] Type check clean (`ty check`)
- [x] Unit tests pass (`pdm run pytest`) — 5332 passed. Three `tests/performance` gates (efficiency/memory ratios) fail only when the whole suite runs; all three pass in isolation on this branch. Load sensitivity, not a regression — the diff adds one `isinstance` check.
- [x] `sieval/core/models/model.py` line+branch coverage 99% (`coverage run --source=sieval`, per `sieval/core/CLAUDE.md`) — no uncovered line falls in the changed region.

### Manual

- [x] **Mutation-tested every new test** — each reverted change fails only the tests that should catch it:

  | mutation | result |
  |---|---|
  | usage reads the server-reported total again | 2 failed |
  | `_named_json_value` widened back to `Iterable` | 5 failed |
  | call-time `stop` widened back to `Iterable` | 2 failed |
  | bind-time validation turned into a no-op | 6 failed (both write sites) |

- [x] **Reachability scan** — both narrowings close a trap, not a live defect. `_kwargs` has two writes (`_initialize`, `with_args`); `builder_defaults` comes only from the `ChatModel`/`GenModel` constructors. All eight construction sites are `ChatModel(**config)` from task YAML, which cannot express a set or generator. On the call-time side, every in-tree `stop=` passes a `list(...)` or a module-level tuple (`human_eval`, `gsm8k`, `gsm1k`, `mbpp`, `livecodebench`, `openbookqa`, `hendrycks_math`, `theoremqa`), and every other `agenerate(...)` argument is a scalar. The exposure is to out-of-tree task authors, whose symptom would have been a resume abort reporting a diff it cannot describe.

## Checklist

### Required (all PRs)

- [x] PR title follows conventional format (`type(scope): description`)
- [x] No internal paths, credentials, or personal info in committed files
- [x] AI-generated code has `AI-Generated Code - <model> (<provider>)` in module docstring — no new modules
- [x] No new upper-layer dependencies added to `core/`
- [x] Deleted code verified — the removed total-token check is unreachable once the total is computed; its test case goes with it

### If: Breaking Change

- [x] Described what breaks and migration path in Summary
- [x] Existing tests updated to reflect new behavior

Programmatic callers only, and **all of it is unreleased — there is no migration path to write, and no CHANGELOG entry.** `sieval/core/models/dialects/` and `_named_json_value` do not exist at `v0.7.0`, where `Model.meta()` was a bare `dict(self._kwargs)` with no JSON validation of `default_params` and `self._kwargs = kwargs` with no copy. Every behaviour below arrived in #45 after that tag, so no released version can have depended on it.

- `ChatModel(model=..., stop={"a","b"})` raises at construction instead of persisting hash-ordered output, and a non-finite default raises there rather than on the first `meta()`.
- `agenerate(stop={"a","b"})` raises instead of sending the set in hash order.
- The narrowing also reaches `_named_json_value`'s other callers — `tools[i]`, `tool_choice`, the structured-output schema, and dialect options — so a `set` or generator nested in any of those now raises where it used to be silently flattened into a list.

No in-repo caller is affected and YAML config cannot produce any of these. Two existing tests asserted the old *timing*, not the old *outcome*, and were updated accordingly.
