### PR TITLE
feat(models): record the full token breakdown, not just the totals

### DIFF
--- a/sieval/core/models/_legacy_bridge.py
+++ b/sieval/core/models/_legacy_bridge.py
@@ -37,15 +37,26 @@ from .ir import (
     StructuredOutputParams,
     TokenLogprob,
     ToolParams,
+    UsageStats,
 )
 
 
 class ModelUsage(TypedDict):
-    """Token usage statistics from a single model API call."""
+    """Token usage statistics from a single model API call.
+
+    The optional keys are breakdowns of the first two counts, not addends, and
+    are written only where the server reported them -- so an absent key means
+    "not reported", never zero. Read them with ``.get()``.
+    """
 
     input_tokens: int
     output_tokens: int
     total_tokens: int
+    reasoning_tokens: NotRequired[int]
+    cached_tokens: NotRequired[int]
+    accepted_prediction_tokens: NotRequired[int]
+    rejected_prediction_tokens: NotRequired[int]
+    reported_total_tokens: NotRequired[int]
 
 
 class ModelMeta(TypedDict):
@@ -385,6 +396,32 @@ def kwargs_to_request(
     )
 
 
+def _model_usage(counts: UsageStats) -> ModelUsage:
+    """Project usage onto the record shape, omitting whatever went unreported.
+
+    The three totals are always written. Each breakdown key is written only
+    where the server actually reported it -- storing a zero instead would put a
+    measurement on disk that was never taken, and any later average over a
+    fleet of mixed servers would silently fold those in.
+    """
+    usage: ModelUsage = {
+        "input_tokens": counts.input_tokens,
+        "output_tokens": counts.output_tokens,
+        "total_tokens": counts.total_tokens,
+    }
+    if counts.reasoning_tokens is not None:
+        usage["reasoning_tokens"] = counts.reasoning_tokens
+    if counts.cached_tokens is not None:
+        usage["cached_tokens"] = counts.cached_tokens
+    if counts.accepted_prediction_tokens is not None:
+        usage["accepted_prediction_tokens"] = counts.accepted_prediction_tokens
+    if counts.rejected_prediction_tokens is not None:
+        usage["rejected_prediction_tokens"] = counts.rejected_prediction_tokens
+    if counts.reported_total_tokens is not None:
+        usage["reported_total_tokens"] = counts.reported_total_tokens
+    return usage
+
+
 def response_to_model_output(model_meta: ModelMeta, response: Response) -> ModelOutput:
     """Shape a canonical ``Response`` into the legacy ``ModelOutput``."""
 
@@ -414,13 +451,7 @@ def response_to_model_output(model_meta: ModelMeta, response: Response) -> Model
             top_logprobs.append(merged)
         top_logprobs = top_logprobs or None
 
-    usage: ModelUsage | None = None
-    if response.usage is not None:
-        usage = {
-            "input_tokens": response.usage.input_tokens,
-            "output_tokens": response.usage.output_tokens,
-            "total_tokens": response.usage.total_tokens,
-        }
+    usage = _model_usage(response.usage) if response.usage is not None else None
     reasoning_texts: list[str] | None = None
     if response.reasoning is not None:
         reasoning_texts = [

--- a/sieval/core/models/dialects/_usage.py
+++ b/sieval/core/models/dialects/_usage.py
@@ -1,0 +1,70 @@
+"""Usage lifting shared by the OpenAI-shaped dialects.
+
+Chat and completions receive the same ``CompletionUsage`` wire object, so what
+counts as a readable token breakdown has one owner here rather than two copies
+that drift the next time OpenAI adds a detail field.
+
+AI-Generated Code - Claude Opus 5 (1M context) (Anthropic)
+"""
+
+from typing import Any
+
+from sieval.core.models.ir import UsageStats
+
+_COMPLETION_DETAILS = "completion_tokens_details"
+_PROMPT_DETAILS = "prompt_tokens_details"
+
+
+def _detail(raw: Any, container: str, name: str) -> int | None:
+    """Read ``raw.<container>.<name>`` as a non-negative int, else ``None``.
+
+    Deliberately never raises. These counts are observational, the detail
+    objects are absent on most OpenAI-compatible servers, and the reply they
+    describe has already been billed -- so a malformed value reads as "not
+    reported" rather than costing the caller a completed response.
+    """
+    details = getattr(raw, container, None)
+    if details is None:
+        return None
+    value = getattr(details, name, None)
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        return None
+    return value
+
+
+def _reported_total(raw: Any, computed: int) -> int | None:
+    """The server's own total, kept only where it disagrees with *computed*.
+
+    Agreement is the overwhelmingly common case and carries no information, so
+    storing it on every record would bury the disagreements. Present means the
+    server's accounting differs from ours -- usually explained by the reasoning
+    count beside it.
+    """
+    value = getattr(raw, "total_tokens", None)
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        return None
+    return None if value == computed else value
+
+
+def usage_stats(raw: Any, input_tokens: int, output_tokens: int) -> UsageStats:
+    """Assemble usage from the two validated counts and the optional details.
+
+    ``total_tokens`` is computed, not read: a reported total that does not
+    decompose is recorded as ``reported_total_tokens`` rather than rejected,
+    because the tokens it describes were already generated and billed.
+    """
+    total = input_tokens + output_tokens
+    return UsageStats(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        total_tokens=total,
+        reasoning_tokens=_detail(raw, _COMPLETION_DETAILS, "reasoning_tokens"),
+        cached_tokens=_detail(raw, _PROMPT_DETAILS, "cached_tokens"),
+        accepted_prediction_tokens=_detail(
+            raw, _COMPLETION_DETAILS, "accepted_prediction_tokens"
+        ),
+        rejected_prediction_tokens=_detail(
+            raw, _COMPLETION_DETAILS, "rejected_prediction_tokens"
+        ),
+        reported_total_tokens=_reported_total(raw, total),
+    )

--- a/sieval/core/models/dialects/openai_chat.py
+++ b/sieval/core/models/dialects/openai_chat.py
@@ -59,6 +59,8 @@ from sieval.core.models.ir import (
     UsageStats,
 )
 
+from ._usage import usage_stats
+
 _OPENAI_REASONING_EFFORTS = frozenset(
     {"none", "minimal", "low", "medium", "high", "xhigh", "max"}
 )
@@ -258,9 +260,9 @@ class _LegacyPlan:
 def _chat_usage_stats(raw: Any) -> UsageStats | None:
     """Build usage from the reply's prompt and completion counts.
 
-    ``total_tokens`` is computed, not read: a reported total that does not
-    decompose is a bookkeeping quirk, and rejecting the reply would discard
-    tokens already generated and billed.
+    Only these two counts are contractual. ``total_tokens`` is computed from
+    them and the optional detail breakdown is best-effort -- see
+    :func:`._usage.usage_stats`.
     """
     if raw is None:
         return None
@@ -273,11 +275,7 @@ def _chat_usage_stats(raw: Any) -> UsageStats | None:
                 f"chat usage.{name} must be a non-negative integer"
             )
         values.append(value)
-    return UsageStats(
-        input_tokens=values[0],
-        output_tokens=values[1],
-        total_tokens=values[0] + values[1],
-    )
+    return usage_stats(raw, values[0], values[1])
 
 
 def _optional_response_string(value: object, path: str) -> str | None:

--- a/sieval/core/models/dialects/openai_completions.py
+++ b/sieval/core/models/dialects/openai_completions.py
@@ -55,6 +55,8 @@ from sieval.core.models.ir import (
 )
 from sieval.core.types import JSONValue
 
+from ._usage import usage_stats
+
 _PREFILL_UNSUPPORTED_REASON = (
     "assistant prefill is a chat input operation, not a completion operation"
 )
@@ -282,8 +284,9 @@ def _optional_response_string(value: object, path: str) -> str | None:
 def _completions_usage_stats(raw: object) -> UsageStats | None:
     """Build usage from the reply's prompt and completion counts.
 
-    ``total_tokens`` is computed, not read: a reported total that does not
-    decompose must not cost the caller a completed reply.
+    Only these two counts are contractual. ``total_tokens`` is computed from
+    them and the optional detail breakdown is best-effort -- see
+    :func:`._usage.usage_stats`.
     """
     if raw is None:
         return None
@@ -297,11 +300,7 @@ def _completions_usage_stats(raw: object) -> UsageStats | None:
                 f"completions usage.{name} must be a non-negative integer"
             )
         values.append(value)
-    return UsageStats(
-        input_tokens=values[0],
-        output_tokens=values[1],
-        total_tokens=values[0] + values[1],
-    )
+    return usage_stats(raw, values[0], values[1])
 
 
 def _logprob_sequence(raw: object, path: str) -> Sequence[object]:

--- a/sieval/core/models/ir.py
+++ b/sieval/core/models/ir.py
@@ -451,11 +451,30 @@ class GroundingMetadata:
 @sieval_record
 @dataclass(frozen=True)
 class UsageStats:
+    """Token counts for one call, plus whatever breakdown the server reported.
+
+    The trailing fields are **breakdowns of** ``input_tokens`` /
+    ``output_tokens``, not addends: summing them double-counts. Each is
+    ``None`` when the server did not report it, which ``0`` cannot express --
+    most OpenAI-compatible servers omit the detail objects entirely, so a zero
+    default would make "no cache hits" and "never said" the same number, and
+    any average over a mixed fleet silently wrong.
+
+    No subset relation is enforced. ``reasoning_tokens <= output_tokens`` is an
+    OpenAI convention rather than a wire guarantee, and a server that counts
+    reasoning outside its completion count is exactly the one whose reported
+    total exceeds the computed one -- which ``reported_total_tokens`` records
+    instead of rejecting.
+    """
+
     input_tokens: int = 0
     output_tokens: int = 0
-    reasoning_tokens: int = 0
-    cached_tokens: int = 0
     total_tokens: int = 0
+    reasoning_tokens: int | None = None
+    cached_tokens: int | None = None
+    accepted_prediction_tokens: int | None = None
+    rejected_prediction_tokens: int | None = None
+    reported_total_tokens: int | None = None
 
 
 @sieval_record

--- a/sieval/core/models/transports/sglang.py
+++ b/sieval/core/models/transports/sglang.py
@@ -280,16 +280,26 @@ class SglangTransport:
     def _parse_usage(metas: list[dict[str, Any]]) -> UsageStats | None:
         """Build usage from sglang ``meta_info`` token counts.
 
-        Prompt tokens are shared across n samples; completions sum.
+        Prompt tokens are shared across n samples; completions sum. So is
+        ``cached_tokens``, which describes the shared prefix -- it is read off
+        ``metas[0]`` for the same reason ``prompt_tokens`` is, and summing it
+        would multiply one cache hit by n.
+
+        sglang reports no reasoning or speculative-decoding breakdown, so those
+        stay ``None``: absent, not zero.
         """
         input_tokens = metas[0].get("prompt_tokens")
         if input_tokens is None:
             return None
         output_tokens = sum(m.get("completion_tokens") or 0 for m in metas)
+        cached = metas[0].get("cached_tokens")
+        if isinstance(cached, bool) or not isinstance(cached, int) or cached < 0:
+            cached = None
         return UsageStats(
             input_tokens=input_tokens,
             output_tokens=output_tokens,
             total_tokens=input_tokens + output_tokens,
+            cached_tokens=cached,
         )
 
     def _guard_radix_cache(self, meta: dict[str, Any]) -> None:

--- a/sieval/core/tasks/profiler.py
+++ b/sieval/core/tasks/profiler.py
@@ -4,9 +4,10 @@ import bisect
 import contextlib
 import time
 from collections import defaultdict
+from collections.abc import Mapping
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Self, TypedDict
+from typing import ClassVar, NotRequired, Self, TypedDict
 
 import anyio
 import orjson
@@ -61,6 +62,51 @@ class TaskTokenStats:
         return self.total / self.count if self.count > 0 else 0.0
 
 
+class UsageBreakdownStats:
+    """One optional usage field, summed against the count it breaks down.
+
+    ``parent_total`` accumulates only over the calls that actually reported the
+    field, so a share is taken against comparable tokens.  Dividing by every
+    call's output would understate reasoning on a fleet where only some servers
+    report it, and the error grows silently with the non-reporting share.
+    """
+
+    def __init__(self, parent_key: str):
+        self.parent_key = parent_key
+        self.total = 0
+        self.parent_total = 0
+        self.calls = 0
+
+    def update(self, value: int, parent: int) -> None:
+        self.total += value
+        self.parent_total += parent
+        self.calls += 1
+
+    @property
+    def share(self) -> float | None:
+        """The ratio, or ``None`` where there is no parent to take it against.
+
+        ``0.0`` would be the same lie the optional counts exist to avoid: a
+        server that reports 50 reasoning tokens against 0 completion tokens --
+        exactly the one counting reasoning outside its completion count -- has
+        not measured a 0% share, it has made the ratio undefined.  ``total``
+        still carries the number that was reported.
+        """
+        return self.total / self.parent_total if self.parent_total > 0 else None
+
+
+def _usage_count(usage: Mapping[str, object], key: str) -> int | None:
+    """Read one token count, tolerating the untyped shapes read back from disk.
+
+    ``None`` means the key was absent or unusable -- never zero, which is a
+    reported measurement.
+    """
+    value = usage.get(key)
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        return None
+    return value
+
+
 class ProfileConfigSnapshot(TypedDict):
     profile_io: bool
     profile_stages: bool
@@ -94,9 +140,28 @@ class ProfileTokenStats(TypedDict):
     buckets: dict[str, int]
 
 
+class ProfileTokenBreakdown(TypedDict):
+    """An optional usage field aggregated over the calls that reported it.
+
+    ``share`` is ``total / parent_total``, and both denominators cover only
+    ``calls_reporting``.  Compare that against ``calls_total`` before reading
+    the share as representative of the run.  It is **absent** when
+    ``parent_total`` is 0, since the ratio is undefined rather than zero.
+    """
+
+    total: int
+    parent: str
+    parent_total: int
+    share: NotRequired[float]
+    calls_reporting: int
+    calls_total: int
+
+
 class ProfileStageTokenUsage(TypedDict, total=False):
     input: ProfileTokenStats
     output: ProfileTokenStats
+    breakdown: dict[str, ProfileTokenBreakdown]
+    reported_total_mismatches: int
 
 
 class ProfileReport(TypedDict, total=False):
@@ -153,6 +218,9 @@ class TaskProfiler:
         # stage_name -> TaskTokenStats
         self._stage_input_tokens: dict[str, TaskTokenStats] = {}
         self._stage_output_tokens: dict[str, TaskTokenStats] = {}
+        self._stage_breakdown: dict[str, dict[str, UsageBreakdownStats]] = {}
+        self._stage_usage_calls: dict[str, int] = {}
+        self._stage_total_mismatches: dict[str, int] = {}
 
     def should_profile_io(self) -> bool:
         return self._profile_io
@@ -185,6 +253,45 @@ class TaskProfiler:
             stage_name
         ]
 
+    _BREAKDOWN_PARENTS: ClassVar[Mapping[str, str]] = {
+        "reasoning_tokens": "output_tokens",
+        "accepted_prediction_tokens": "output_tokens",
+        "rejected_prediction_tokens": "output_tokens",
+        "cached_tokens": "input_tokens",
+    }
+
+    def _accumulate_usage(self, stage_name: str, usage: Mapping[str, object]) -> None:
+        """Fold one call's usage into the per-stage statistics.
+
+        Shared by the live path and the resume rebuild.  Those two carried the
+        same input/output logic twice, so a field added to one of them would
+        have been dropped by the other on the next resume.
+        """
+        stage_input, stage_output = self._get_or_create_stage_token_stats(stage_name)
+        parents = {
+            "input_tokens": _usage_count(usage, "input_tokens") or 0,
+            "output_tokens": _usage_count(usage, "output_tokens") or 0,
+        }
+        if parents["input_tokens"] > 0:
+            stage_input.update(parents["input_tokens"])
+        if parents["output_tokens"] > 0:
+            stage_output.update(parents["output_tokens"])
+
+        self._stage_usage_calls[stage_name] = (
+            self._stage_usage_calls.get(stage_name, 0) + 1
+        )
+        breakdown = self._stage_breakdown.setdefault(stage_name, {})
+        for field, parent_key in self._BREAKDOWN_PARENTS.items():
+            value = _usage_count(usage, field)
+            if value is None:
+                continue
+            stats = breakdown.setdefault(field, UsageBreakdownStats(parent_key))
+            stats.update(value, parents[parent_key])
+        if _usage_count(usage, "reported_total_tokens") is not None:
+            self._stage_total_mismatches[stage_name] = (
+                self._stage_total_mismatches.get(stage_name, 0) + 1
+            )
+
     def record_model_usage(
         self,
         usage: dict[str, int] | ModelUsage | None,
@@ -192,14 +299,7 @@ class TaskProfiler:
     ) -> None:
         if not usage or not self._profile_usage or not stage_name:
             return
-
-        stage_input, stage_output = self._get_or_create_stage_token_stats(stage_name)
-        pt = usage.get("input_tokens", 0)
-        ct = usage.get("output_tokens", 0)
-        if pt > 0:
-            stage_input.update(pt)
-        if ct > 0:
-            stage_output.update(ct)
+        self._accumulate_usage(stage_name, usage)
 
     def aggregate_stage_timings(self, contexts: dict[str | int, TaskContext]) -> None:
         """Rebuild per-stage timing distributions from persisted task contexts."""
@@ -218,32 +318,79 @@ class TaskProfiler:
         """Rebuild per-stage token usage statistics from persisted task contexts."""
         if not self._profile_usage:
             return
-        # Clear per-stage stats
+        # Clear per-stage stats.  The breakdown accumulators have to go too:
+        # they are additive, so a rebuild that kept them would double-count
+        # every call it then re-reads.
         for stats in self._stage_input_tokens.values():
             stats.clear()
         for stats in self._stage_output_tokens.values():
             stats.clear()
+        self._stage_breakdown.clear()
+        self._stage_usage_calls.clear()
+        self._stage_total_mismatches.clear()
 
         for ctx in contexts.values():
             if ctx.stage_meta:
                 for stage_name, meta_list in ctx.stage_meta.items():
-                    # Get or create per-stage stats
-                    stage_input, stage_output = self._get_or_create_stage_token_stats(
-                        stage_name
-                    )
                     for meta in meta_list:
                         # Read usage from model_calls (new structure)
                         model_calls = meta.get("model_calls", [])
                         for call in model_calls:
                             usage = call.get("usage")
-                            if isinstance(usage, dict):
-                                # Record to per-stage stats
-                                pt = usage.get("input_tokens", 0)
-                                ct = usage.get("output_tokens", 0)
-                                if pt > 0:
-                                    stage_input.update(pt)
-                                if ct > 0:
-                                    stage_output.update(ct)
+                            # Same admission test as the live path, not a
+                            # looser one: a usage the live path never counted
+                            # must not appear in calls_total after a resume.
+                            if isinstance(usage, dict) and usage and stage_name:
+                                self._accumulate_usage(stage_name, usage)
+
+    def _breakdown_to_dict(self, stage_name: str) -> dict[str, ProfileTokenBreakdown]:
+        calls_total = self._stage_usage_calls.get(stage_name, 0)
+        result: dict[str, ProfileTokenBreakdown] = {}
+        for field, stats in sorted(self._stage_breakdown.get(stage_name, {}).items()):
+            entry = ProfileTokenBreakdown(
+                total=stats.total,
+                parent=stats.parent_key,
+                parent_total=stats.parent_total,
+                calls_reporting=stats.calls,
+                calls_total=calls_total,
+            )
+            # Omitted, not zeroed: an undefined ratio is not a measured 0%.
+            if stats.share is not None:
+                entry["share"] = stats.share
+            result[field] = entry
+        return result
+
+    def _log_usage_breakdown(self, stage_name: str) -> None:
+        """Log the optional counts as shares, with their reporting denominator.
+
+        The denominator is printed on every line rather than only when partial:
+        a share whose coverage is stated only sometimes reads as full coverage
+        the rest of the time, which is the failure this whole field set exists
+        to avoid.  Fields no server reported have no accumulator, so they emit
+        no line at all rather than a misleading zero.
+        """
+        calls_total = self._stage_usage_calls.get(stage_name, 0)
+        for field, stats in sorted(self._stage_breakdown.get(stage_name, {}).items()):
+            parent = stats.parent_key.removesuffix("_tokens")
+            share = stats.share
+            # A 0-token parent makes the ratio undefined, and printing "0.0%"
+            # there reads as a measurement of no usage rather than no basis.
+            ratio = f"{share:.1%} of {parent}" if share is not None else f"no {parent}"
+            logger.info(
+                "     {}: {:,} ({}; {} of {} calls reporting)",
+                field.removesuffix("_tokens"),
+                stats.total,
+                ratio,
+                stats.calls,
+                calls_total,
+            )
+        mismatches = self._stage_total_mismatches.get(stage_name, 0)
+        if mismatches:
+            logger.info(
+                "     reported total differed from prompt+completion on {} of {} calls",
+                mismatches,
+                calls_total,
+            )
 
     def log_summary(self) -> None:
         """Emit a formatted profiling report (token usage, I/O, stages) via loguru."""
@@ -286,10 +433,13 @@ class TaskProfiler:
                             self._log_token_stats("  Input", input_stats)
                         if output_stats and output_stats.count > 0:
                             self._log_token_stats("  Output", output_stats)
+                        # Breakdowns are shares of the two counts above, so they
+                        # are logged after the stage total and never folded in.
                         stage_total = (input_stats.total if input_stats else 0) + (
                             output_stats.total if output_stats else 0
                         )
                         logger.info("     Stage Total: {:,}", stage_total)
+                        self._log_usage_breakdown(stage_name)
 
         if self._profile_io and self._io_aggregates:
             logger.info("=== {} I/O Profile Summary ===", header)
@@ -385,6 +535,12 @@ class TaskProfiler:
                     entry["input"] = self._token_stats_to_dict(input_stats)
                 if output_stats and output_stats.count > 0:
                     entry["output"] = self._token_stats_to_dict(output_stats)
+                breakdown = self._breakdown_to_dict(stage_name)
+                if breakdown:
+                    entry["breakdown"] = breakdown
+                mismatches = self._stage_total_mismatches.get(stage_name, 0)
+                if mismatches:
+                    entry["reported_total_mismatches"] = mismatches
                 if entry:
                     token_usage[stage_name] = entry
             if token_usage:

--- a/tests/unit/core/models/dialects/test__usage.py
+++ b/tests/unit/core/models/dialects/test__usage.py
@@ -1,0 +1,109 @@
+"""Tests for the usage lifting shared by the OpenAI-shaped dialects."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from sieval.core.models.dialects._usage import usage_stats
+
+
+class TestOptionalDetails:
+    def test_details_are_lifted_when_reported(self):
+        raw = SimpleNamespace(
+            total_tokens=30,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=4),
+            completion_tokens_details=SimpleNamespace(
+                reasoning_tokens=6,
+                accepted_prediction_tokens=3,
+                rejected_prediction_tokens=1,
+            ),
+        )
+
+        stats = usage_stats(raw, 10, 20)
+
+        assert stats.cached_tokens == 4
+        assert stats.reasoning_tokens == 6
+        assert stats.accepted_prediction_tokens == 3
+        assert stats.rejected_prediction_tokens == 1
+
+    def test_absent_detail_objects_read_as_none_never_zero(self):
+        """The reason the fields are optional: silence is not a measurement."""
+        stats = usage_stats(SimpleNamespace(total_tokens=30), 10, 20)
+
+        assert stats.cached_tokens is None
+        assert stats.reasoning_tokens is None
+        assert stats.accepted_prediction_tokens is None
+        assert stats.rejected_prediction_tokens is None
+
+    def test_a_reported_zero_stays_zero(self):
+        """A server saying "nothing was cached" measured something."""
+        raw = SimpleNamespace(
+            total_tokens=30,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=0),
+        )
+
+        assert usage_stats(raw, 10, 20).cached_tokens == 0
+
+    def test_a_partial_detail_object_only_blanks_the_missing_field(self):
+        raw = SimpleNamespace(
+            total_tokens=30,
+            completion_tokens_details=SimpleNamespace(reasoning_tokens=6),
+        )
+
+        stats = usage_stats(raw, 10, 20)
+
+        assert stats.reasoning_tokens == 6
+        assert stats.accepted_prediction_tokens is None
+
+    @pytest.mark.parametrize(
+        "value",
+        [-1, True, "4", 1.5, None],
+        ids=["negative", "bool", "str", "float", "none"],
+    )
+    def test_a_malformed_detail_reads_as_unreported_and_never_raises(self, value):
+        """Observational counts must not cost a reply that was already billed."""
+        raw = SimpleNamespace(
+            total_tokens=30,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=value),
+        )
+
+        assert usage_stats(raw, 10, 20).cached_tokens is None
+
+    def test_no_subset_relation_is_enforced(self):
+        """``reasoning <= output`` is an OpenAI convention, not a wire guarantee.
+
+        A server counting reasoning outside its completion count is exactly the
+        one whose reported total exceeds the computed one, so rejecting the
+        pair would discard the case the field exists to describe.
+        """
+        raw = SimpleNamespace(
+            total_tokens=200,
+            completion_tokens_details=SimpleNamespace(reasoning_tokens=170),
+        )
+
+        stats = usage_stats(raw, 10, 20)
+
+        assert stats.reasoning_tokens == 170
+        assert stats.total_tokens == 30
+        assert stats.reported_total_tokens == 200
+
+
+class TestReportedTotal:
+    def test_a_divergent_total_is_recorded(self):
+        assert (
+            usage_stats(SimpleNamespace(total_tokens=99), 10, 20).reported_total_tokens
+            == 99
+        )
+
+    def test_an_agreeing_total_is_dropped(self):
+        """Agreement is the common case and carries nothing worth storing."""
+        assert (
+            usage_stats(SimpleNamespace(total_tokens=30), 10, 20).reported_total_tokens
+            is None
+        )
+
+    def test_an_absent_total_is_dropped(self):
+        assert usage_stats(SimpleNamespace(), 10, 20).reported_total_tokens is None
+
+    def test_the_computed_total_never_takes_the_reported_value(self):
+        assert usage_stats(SimpleNamespace(total_tokens=99), 10, 20).total_tokens == 30

--- a/tests/unit/core/models/dialects/test_openai_chat.py
+++ b/tests/unit/core/models/dialects/test_openai_chat.py
@@ -824,17 +824,32 @@ class TestResponseLifting:
             await dialect.arun(Request(input=_chat()))
 
     @pytest.mark.anyio
-    async def test_reported_total_is_ignored_in_favour_of_the_computed_one(
-        self,
-    ) -> None:
-        """A total that does not decompose must not cost the caller the reply."""
+    async def test_reported_total_is_recorded_not_trusted(self) -> None:
+        """A total that does not decompose is evidence, not grounds to reject.
+
+        The reply is kept and scored on the computed total; the server's own
+        figure survives beside it as the only trace that the two disagreed.
+        """
         dialect, _ = _dialect(_response(_choice(0, "ok"), usage=_usage(2, 3, 99)))
 
         response = await dialect.arun(Request(input=_chat()))
 
         assert response.usage == UsageStats(
-            input_tokens=2, output_tokens=3, total_tokens=5
+            input_tokens=2,
+            output_tokens=3,
+            total_tokens=5,
+            reported_total_tokens=99,
         )
+
+    @pytest.mark.anyio
+    async def test_agreeing_reported_total_is_not_recorded(self) -> None:
+        """Agreement carries no information, so storing it would bury the rest."""
+        dialect, _ = _dialect(_response(_choice(0, "ok"), usage=_usage(2, 3, 5)))
+
+        response = await dialect.arun(Request(input=_chat()))
+
+        assert response.usage is not None
+        assert response.usage.reported_total_tokens is None
 
     @pytest.mark.anyio
     @pytest.mark.parametrize(

--- a/tests/unit/core/models/dialects/test_openai_completions.py
+++ b/tests/unit/core/models/dialects/test_openai_completions.py
@@ -451,10 +451,8 @@ class TestInputScoringBoundary:
             await dialect.execute(prepared)
 
     @pytest.mark.anyio
-    async def test_reported_total_is_ignored_in_favour_of_the_computed_one(
-        self,
-    ) -> None:
-        """A total that does not decompose must not cost the caller the reply."""
+    async def test_reported_total_is_recorded_not_trusted(self) -> None:
+        """A total that does not decompose is evidence, not grounds to reject."""
         dialect, _ = _dialect(
             _response(
                 _choice(tokens=["p", " out"], token_logprobs=[None, -0.2]),
@@ -470,7 +468,10 @@ class TestInputScoringBoundary:
         result = await dialect.execute(prepared)
 
         assert result.usage == UsageStats(
-            input_tokens=1, output_tokens=1, total_tokens=2
+            input_tokens=1,
+            output_tokens=1,
+            total_tokens=2,
+            reported_total_tokens=9,
         )
 
 

--- a/tests/unit/core/models/test_model.py
+++ b/tests/unit/core/models/test_model.py
@@ -992,6 +992,49 @@ class TestResponseBridge:
         assert out.system_fingerprint == "fp"
         assert out.model["model"] == "m"
 
+    def test_unreported_breakdown_keys_are_omitted_from_the_record(self):
+        """Absent on disk is how "the server did not say" is spelled.
+
+        Writing zeros instead would put measurements in the record that were
+        never taken, and any later average over a mixed fleet folds them in.
+        """
+        out = self._bridge(
+            Response(
+                texts=("a",),
+                usage=UsageStats(input_tokens=3, output_tokens=4, total_tokens=7),
+            )
+        )
+
+        assert out.usage == {"input_tokens": 3, "output_tokens": 4, "total_tokens": 7}
+
+    def test_reported_breakdown_keys_reach_the_record(self):
+        out = self._bridge(
+            Response(
+                texts=("a",),
+                usage=UsageStats(
+                    input_tokens=3,
+                    output_tokens=4,
+                    total_tokens=7,
+                    reasoning_tokens=2,
+                    cached_tokens=0,
+                    accepted_prediction_tokens=1,
+                    rejected_prediction_tokens=1,
+                    reported_total_tokens=9,
+                ),
+            )
+        )
+
+        assert out.usage == {
+            "input_tokens": 3,
+            "output_tokens": 4,
+            "total_tokens": 7,
+            "reasoning_tokens": 2,
+            "cached_tokens": 0,
+            "accepted_prediction_tokens": 1,
+            "rejected_prediction_tokens": 1,
+            "reported_total_tokens": 9,
+        }
+
     def test_usage_absent_stays_none(self):
         """Absence != zeros: a zero-filled usage dict would silently corrupt
         the ARC echoed-logprob slice."""

--- a/tests/unit/core/models/transports/test_sglang.py
+++ b/tests/unit/core/models/transports/test_sglang.py
@@ -353,7 +353,7 @@ class TestNSamples:
         assert resp.finish_reasons == ("stop", "length", "stop")
         # prompt tokens counted once, completions summed.
         assert resp.usage == UsageStats(
-            input_tokens=4, output_tokens=6, total_tokens=10
+            input_tokens=4, output_tokens=6, total_tokens=10, cached_tokens=0
         )
         assert post.call_args[1]["body"]["sampling_params"]["n"] == 3
 
@@ -414,10 +414,37 @@ class TestLift:
         t, _ = _make_transport({"text": "out", "meta_info": meta})
         resp = await t.arun(_request("x"))
         assert resp.usage == UsageStats(
-            input_tokens=4, output_tokens=6, total_tokens=10
+            input_tokens=4, output_tokens=6, total_tokens=10, cached_tokens=0
         )
         assert resp.finish_reasons == ("length",)
         assert resp.texts == ("out",)
+
+    @pytest.mark.anyio
+    async def test_absent_cached_tokens_reads_as_unreported(self):
+        """An omitted key is silence; the 0 above is a measured cache miss."""
+        meta = _meta(prompt_tokens=4, completion_tokens=6)
+        del meta["cached_tokens"]
+        t, _ = _make_transport({"text": "out", "meta_info": meta})
+
+        resp = await t.arun(_request("x"))
+
+        assert resp.usage is not None
+        assert resp.usage.cached_tokens is None
+
+    @pytest.mark.anyio
+    async def test_cached_tokens_are_not_summed_across_samples(self):
+        """They describe the shared prefix, like prompt_tokens -- read once."""
+        t, _ = _make_transport(
+            [
+                {"text": "a", "meta_info": _meta(prompt_tokens=4, cached_tokens=3)},
+                {"text": "b", "meta_info": _meta(prompt_tokens=4, cached_tokens=3)},
+            ]
+        )
+
+        resp = await t.arun(_request("x", sampling=SamplingParams(n=2)))
+
+        assert resp.usage is not None
+        assert resp.usage.cached_tokens == 3
 
     @pytest.mark.anyio
     async def test_usage_none_when_prompt_tokens_absent(self):

--- a/tests/unit/core/tasks/test_profiler.py
+++ b/tests/unit/core/tasks/test_profiler.py
@@ -122,6 +122,202 @@ class TestTaskProfilerRecordUsage:
         assert _capture_logs(zero_usage.log_summary).strip() == ""
 
 
+class TestTaskProfilerUsageBreakdown:
+    def test_share_denominator_is_the_reporting_subset(self):
+        """A silent call must not dilute the share of the calls that spoke."""
+        profiler = TaskProfiler(profile_usage=True)
+        profiler.record_model_usage(
+            {
+                "input_tokens": 10,
+                "output_tokens": 100,
+                "total_tokens": 110,
+                "reasoning_tokens": 50,
+            },
+            stage_name="inferred",
+        )
+        profiler.record_model_usage(
+            {"input_tokens": 10, "output_tokens": 900, "total_tokens": 910},
+            stage_name="inferred",
+        )
+
+        reasoning = profiler.to_dict()["token_usage"]["inferred"]["breakdown"][
+            "reasoning_tokens"
+        ]
+        assert reasoning["total"] == 50
+        assert reasoning["parent"] == "output_tokens"
+        assert reasoning["parent_total"] == 100
+        assert reasoning["share"] == 0.5
+        assert reasoning["calls_reporting"] == 1
+        assert reasoning["calls_total"] == 2
+
+    def test_a_field_no_server_reported_produces_no_entry(self):
+        """Absent beats a zero that would read as a measurement."""
+        profiler = TaskProfiler(profile_usage=True)
+        profiler.record_model_usage(
+            {"input_tokens": 10, "output_tokens": 20, "total_tokens": 30},
+            stage_name="inferred",
+        )
+
+        assert "breakdown" not in profiler.to_dict()["token_usage"]["inferred"]
+
+    def test_a_reported_zero_counts_as_reported(self):
+        """A server saying "nothing was cached" is data, not silence."""
+        profiler = TaskProfiler(profile_usage=True)
+        profiler.record_model_usage(
+            {
+                "input_tokens": 100,
+                "output_tokens": 20,
+                "total_tokens": 120,
+                "cached_tokens": 0,
+            },
+            stage_name="inferred",
+        )
+
+        cached = profiler.to_dict()["token_usage"]["inferred"]["breakdown"][
+            "cached_tokens"
+        ]
+        assert cached["calls_reporting"] == 1
+        assert cached["total"] == 0
+        assert cached["share"] == 0.0
+
+    def test_breakdown_is_not_added_into_the_totals(self):
+        """Breakdowns are shares of input/output, never extra tokens."""
+        profiler = TaskProfiler(profile_usage=True)
+        profiler.record_model_usage(
+            {
+                "input_tokens": 100,
+                "output_tokens": 20,
+                "total_tokens": 120,
+                "reasoning_tokens": 15,
+                "cached_tokens": 90,
+            },
+            stage_name="inferred",
+        )
+
+        assert "Total Tokens Used: 120" in _capture_logs(profiler.log_summary)
+
+    def test_reported_total_mismatches_are_counted(self):
+        profiler = TaskProfiler(profile_usage=True)
+        profiler.record_model_usage(
+            {
+                "input_tokens": 10,
+                "output_tokens": 20,
+                "total_tokens": 30,
+                "reported_total_tokens": 99,
+            },
+            stage_name="inferred",
+        )
+        profiler.record_model_usage(
+            {"input_tokens": 10, "output_tokens": 20, "total_tokens": 30},
+            stage_name="inferred",
+        )
+
+        entry = profiler.to_dict()["token_usage"]["inferred"]
+        assert entry["reported_total_mismatches"] == 1
+
+    def test_summary_states_the_reporting_denominator_on_every_line(self):
+        """Stated only sometimes, a coverage note reads as full the rest."""
+        profiler = TaskProfiler(profile_usage=True)
+        profiler.record_model_usage(
+            {
+                "input_tokens": 10,
+                "output_tokens": 100,
+                "total_tokens": 110,
+                "reasoning_tokens": 50,
+            },
+            stage_name="inferred",
+        )
+        profiler.record_model_usage(
+            {"input_tokens": 10, "output_tokens": 900, "total_tokens": 910},
+            stage_name="inferred",
+        )
+
+        out = _capture_logs(profiler.log_summary)
+        assert "reasoning: 50 (50.0% of output; 1 of 2 calls reporting)" in out
+
+    def test_rebuilding_from_contexts_does_not_double_count(self):
+        """The accumulators are additive, so a rebuild has to clear them."""
+        profiler = TaskProfiler(profile_usage=True)
+        ctx = _make_ctx_with_meta(
+            {
+                "inferred": [
+                    {
+                        "model_calls": [
+                            {
+                                "usage": {
+                                    "input_tokens": 10,
+                                    "output_tokens": 100,
+                                    "total_tokens": 110,
+                                    "reasoning_tokens": 50,
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        )
+
+        profiler.aggregate_token_usage({0: ctx})
+        profiler.aggregate_token_usage({0: ctx})
+
+        reasoning = profiler.to_dict()["token_usage"]["inferred"]["breakdown"][
+            "reasoning_tokens"
+        ]
+        assert reasoning["total"] == 50
+        assert reasoning["calls_reporting"] == 1
+        assert reasoning["calls_total"] == 1
+
+    def test_share_is_absent_when_the_parent_count_is_zero(self):
+        """An undefined ratio is omitted, never reported as a measured 0%.
+
+        A server counting reasoning outside its completion count -- the case
+        ``reported_total_tokens`` exists for -- can report reasoning against 0
+        completion tokens.  ``0.0`` there would be the same lie the optional
+        counts are ``None`` to avoid, one layer up.
+        """
+        profiler = TaskProfiler(profile_usage=True)
+        profiler.record_model_usage(
+            {
+                "input_tokens": 10,
+                "output_tokens": 0,
+                "total_tokens": 10,
+                "reasoning_tokens": 50,
+            },
+            stage_name="inferred",
+        )
+
+        reasoning = profiler.to_dict()["token_usage"]["inferred"]["breakdown"][
+            "reasoning_tokens"
+        ]
+        assert "share" not in reasoning
+        assert reasoning["total"] == 50
+        assert reasoning["parent_total"] == 0
+
+        out = _capture_logs(profiler.log_summary)
+        assert "reasoning: 50 (no output; 1 of 1 calls reporting)" in out
+        assert "0.0%" not in out
+
+    def test_rebuild_admits_exactly_what_the_live_path_admits(self):
+        """The two paths share an accumulator; they must share its guard too.
+
+        ``record_model_usage`` skips a falsy usage, so a rebuild that counted
+        one would inflate ``calls_total`` -- and every share's stated coverage
+        with it -- on resume but not on the original run.
+        """
+        profiler = TaskProfiler(profile_usage=True)
+        # Not a ``ModelUsage``: the shape only arises off disk, where the
+        # record is read back untyped and nothing guarantees the three totals.
+        empty: dict[str, int] = {}
+        profiler.record_model_usage(empty, stage_name="inferred")
+        assert profiler.to_dict().get("token_usage") is None
+
+        ctx = _make_ctx_with_meta({"inferred": [{"model_calls": [{"usage": {}}]}]})
+        profiler.aggregate_token_usage({0: ctx})
+
+        assert profiler.to_dict().get("token_usage") is None
+        assert profiler._stage_usage_calls == {}
+
+
 class TestTaskProfilerAggregateStageTimings:
     def test_aggregate_stage_timings_enabled(self):
         profiler = TaskProfiler(profile_stages=True)


### PR DESCRIPTION
## Type

- feature — new benchmark, task, or capability

## Summary

`UsageStats` has declared `reasoning_tokens` and `cached_tokens` since the binding plane landed, and no dialect ever populated them. So a converted or requantized checkpoint that held its score while burning twice the reasoning budget was invisible — the delivery regression no accuracy metric catches. This collects the breakdown, persists it, and reports it.

- **Both OpenAI-shaped dialects lift `prompt_tokens_details` / `completion_tokens_details`** (reasoning, cached, accepted/rejected speculative-decoding tokens) through one shared `dialects/_usage.py`; chat and completions receive the same wire object, so the reader has one owner rather than two copies that drift the next time OpenAI adds a field. **sglang** surfaces the `cached_tokens` it was already reading twenty lines below for its radix-cache guard.
- **The optional counts are `int | None`, not `int = 0`.** Most OpenAI-compatible servers omit the detail objects entirely, so a zero default makes "no cache hits" and "never said" the same number, and any average over a mixed fleet silently wrong. Carried to disk: `ModelUsage` gains `NotRequired` keys written only where the server reported one, so an absent key means unreported and a present `0` is a real measurement.
- **No subset relation is enforced, and the reported total is now recorded rather than dropped.** `reasoning <= completion` is an OpenAI convention, not a wire guarantee — a server counting reasoning outside its completion count is exactly the one whose reported total exceeds the computed one. `reported_total_tokens` is kept only where it disagrees with prompt+completion, so it is absent on almost every call and, when present, is the only evidence that a provider's accounting differs from ours. #100 had nowhere to put that difference and dropped it silently; this closes that.
- **The profiler reports shares against the calls that reported them**, never against every call (which understates a share by exactly the non-reporting fraction), and prints that denominator on every line rather than only when partial — a coverage note given sometimes reads as full coverage the rest of the time. Breakdowns are never folded into `total_tokens`, which stays prompt+completion.

**One coupling fixed on the way.** `record_model_usage` and `aggregate_token_usage` carried the same accumulation logic twice — the live path and the resume rebuild. They now share one accumulator, because a field added to the live path alone would have vanished on the next resume. The rebuild also clears the new accumulators, which are additive and would otherwise double-count everything they re-read.

**Deliberately not collected:** `audio_tokens`. Nothing in sieval sends or receives audio, so it would ship as a permanently absent key.

## Related Issues

Refs #25. Follow-up from the review of #100, which established the computed total and flagged that a server/computed disagreement was being discarded with no trace.

## Test Plan

### Automated

- [x] Lint/format clean (`ruff check && ruff format --check`)
- [x] Type check clean (`ty check`)
- [x] Unit tests pass (`pdm run pytest`) — 5359 passed. Two `tests/performance` gates (efficiency/memory ratios) fail only when the whole suite runs and pass in isolation; pre-existing load sensitivity, unrelated to this diff.
- [x] Coverage over every changed module, all above the 95% `sieval/core` gate: `_usage.py` **100%**, `transports/sglang.py` **100%**, `model.py` 99%, `ir.py` 98%, `openai_completions.py` 97%, `openai_chat.py` 96%, `profiler.py` 96%.

### Manual

- [x] **Mutation-tested every new test** — each reverted decision fails only the tests that should catch it:

  | mutation | result |
  |---|---|
  | absent detail container reads as `0` instead of `None` | 6 failed |
  | `reported_total_tokens` recorded even when it agrees | 5 failed |
  | share denominator diluted with non-reporting calls | 2 failed |
  | resume rebuild stops clearing the breakdown accumulators | 1 failed |
  | sglang sums `cached_tokens` across the n samples | 2 failed |
  | `_model_usage` writes `0` instead of omitting an unreported key | 2 failed |

- [x] **The `None` vs `0` distinction is pinned from both directions**, since it is the whole reason the fields are optional: sglang's `_meta` fixture really does report `cached_tokens: 0`, and that 0 survives to the record; a meta with the key deleted yields `None`. Same pair at the dialect layer and across the `ModelUsage` record boundary.

## Checklist

### Required (all PRs)

- [x] PR title follows conventional format (`type(scope): description`)
- [x] No internal paths, credentials, or personal info in committed files
- [x] AI-generated code has `AI-Generated Code - <model> (<provider>)` in module docstring — new `dialects/_usage.py` carries it
- [x] No new upper-layer dependencies added to `core/`
- [x] Deleted code verified — nothing deleted; the duplicated accumulation in `aggregate_token_usage` moved into the shared `_accumulate_usage` and is covered by the rebuild test

### If: Breaking Change

- [x] Described what breaks and migration path in Summary
- [x] Existing tests updated to reflect new behavior

On-disk record shape only, and **all of it is unreleased — no migration path, no CHANGELOG entry.** `sieval/core/models/dialects/` does not exist at `v0.7.0`; the whole binding plane arrived in #45 after that tag. Two existing dialect tests asserted that a divergent reported total was discarded, and one sglang pair asserted `cached_tokens` was dropped; all four now assert the new, deliberate behaviour rather than the old absence.
