### PR TITLE
fix(tests): keep a gen2 pause out of two sub-second perf gates

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -201,7 +201,7 @@ Mock models stub at the **Transport seam** (RFC #25): each overrides `_build_def
 | `BenchmarkTask` / `MultiIterBenchmarkTask` | Standard 4-stage tasks for benchmarks |
 | `IOProfile` | I/O pattern configuration |
 | `PerfTimer` / `MemoryTracker` | Timing and memory measurement utilities |
-| `suite_heap_excluded()` | `gc.freeze()` around a timed window, so a gen2 pass over the rest of the suite's heap (~286 ms after `tests/unit`) cannot land inside it. Wrap any gate whose margin is smaller than one pause |
+| `suite_heap_excluded()` | `gc.freeze()` around a timed window: a pass may still fire, but no longer rescans the rest of the suite's heap (~286 ms worth after `tests/unit`). Wrap any gate whose margin is under one pause. Not reentrant |
 | `make_large_dataset(n, payload_size)` | Generate large in-memory dataset |
 | `make_perf_config(tmp_path, **overrides)` | `TaskRunnerConfig` for performance tests |
 | `write_completed_samples(root, n_completed)` | Write FINAL contexts to disk for resume tests |

--- a/tests/README.md
+++ b/tests/README.md
@@ -201,6 +201,7 @@ Mock models stub at the **Transport seam** (RFC #25): each overrides `_build_def
 | `BenchmarkTask` / `MultiIterBenchmarkTask` | Standard 4-stage tasks for benchmarks |
 | `IOProfile` | I/O pattern configuration |
 | `PerfTimer` / `MemoryTracker` | Timing and memory measurement utilities |
+| `suite_heap_excluded()` | `gc.freeze()` around a timed window, so a gen2 pass over the rest of the suite's heap (~286 ms after `tests/unit`) cannot land inside it. Wrap any gate whose margin is smaller than one pause |
 | `make_large_dataset(n, payload_size)` | Generate large in-memory dataset |
 | `make_perf_config(tmp_path, **overrides)` | `TaskRunnerConfig` for performance tests |
 | `write_completed_samples(root, n_completed)` | Write FINAL contexts to disk for resume tests |

--- a/tests/acceptance/performance/test_performance_acceptance.py
+++ b/tests/acceptance/performance/test_performance_acceptance.py
@@ -38,6 +38,7 @@ from tests.conftest import (
     make_large_dataset,
     make_perf_config,
     samples_per_second,
+    suite_heap_excluded,
     write_completed_samples,
 )
 
@@ -187,7 +188,7 @@ async def _run_scenario(
 
     runner = TaskRunner(task, config)
     timer = PerfTimer()
-    with timer:
+    with suite_heap_excluded(), timer:
         report = await runner.arun()
 
     assert report is not None, f"Scenario {scenario.name} returned no report"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,12 +15,13 @@ class-path references).
 AI-Generated Code - Claude Opus 4.6 (Anthropic)
 """
 
+import gc
 import random
 import sys
 import threading
 import time
 from collections.abc import Iterator
-from contextlib import suppress
+from contextlib import contextmanager, suppress
 from dataclasses import dataclass
 from pathlib import Path
 from types import ModuleType
@@ -837,6 +838,46 @@ class PerfTimer:
 
     def __exit__(self, *args: Any) -> None:
         self.elapsed = time.perf_counter() - self._start
+
+
+@contextmanager
+def suite_heap_excluded() -> Iterator[None]:
+    """Keep the rest of the suite's live heap out of a short timed window.
+
+    A gen2 collection costs in proportion to the whole live heap, and by the
+    time a full run reaches the perf gates that heap is thousands of other
+    tests' fixtures. Measured on this tree: after ``tests/unit`` alone the
+    process holds ~833k tracked objects and one gen2 pass takes **286 ms** --
+    longer than the 0.20 s window ``test_throughput_vs_concurrency`` measures at
+    concurrency 16. One collection landing inside such a window is the entire
+    difference between 61.7% and 18.9% efficiency for unchanged code, and it is
+    a coin flip which window it lands in: in the run that produced those
+    figures, concurrency 1 and 4 came in 0.043 s and 0.053 s slower while
+    concurrency 16 took 0.457 s longer.
+
+    ``gc.freeze()``, not ``gc.disable()``: objects the code under test allocates
+    are still collected and still charged to the window, so GC pressure the
+    pipeline itself introduces stays measurable. Only the heap it did not
+    allocate stops being rescanned. (``test_serialization``'s ``_gc_paused``
+    disables the collector outright -- correct there, where the subject is a
+    tight serialization loop and any collection is pure noise.)
+
+    Not every timed gate needs this, and the test is whether one 286 ms pause
+    fits inside a gate's own margin rather than whether its window is short.
+    Checked against the measured figures: the absolute bounds in seconds have
+    room to spare; ``iteration_overhead`` (2.98x against a 5.0x bar) and
+    ``record_each_stage`` (46% against 200%) each survive a pause landing in
+    their worst window; ``dep_loading`` times ~18 ms but takes the best of
+    five, so a pause has to hit every run. The two wrapped here survive
+    nothing -- at concurrency 16 the pause is longer than the window it would
+    land in.
+    """
+    gc.collect()
+    gc.freeze()
+    try:
+        yield
+    finally:
+        gc.unfreeze()
 
 
 def samples_per_second(n_samples: int, elapsed_s: float) -> float:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -844,34 +844,44 @@ class PerfTimer:
 def suite_heap_excluded() -> Iterator[None]:
     """Keep the rest of the suite's live heap out of a short timed window.
 
-    A gen2 collection costs in proportion to the whole live heap, and by the
-    time a full run reaches the perf gates that heap is thousands of other
-    tests' fixtures. Measured on this tree: after ``tests/unit`` alone the
-    process holds ~833k tracked objects and one gen2 pass takes **286 ms** --
-    longer than the 0.20 s window ``test_throughput_vs_concurrency`` measures at
-    concurrency 16. One collection landing inside such a window is the entire
-    difference between 61.7% and 18.9% efficiency for unchanged code, and it is
-    a coin flip which window it lands in: in the run that produced those
-    figures, concurrency 1 and 4 came in 0.043 s and 0.053 s slower while
-    concurrency 16 took 0.457 s longer.
+    A gen2 collection costs in proportion to the whole live heap, which by the
+    time a full run reaches the perf gates is thousands of other tests'
+    fixtures. After ``tests/unit`` alone this process holds ~833k tracked
+    objects and one gen2 pass takes 286 ms -- longer than the 0.20 s window
+    ``test_throughput_vs_concurrency`` measures at concurrency 16, and the whole
+    difference between 61.7% and 18.9% efficiency for unchanged code.
 
     ``gc.freeze()``, not ``gc.disable()``: objects the code under test allocates
     are still collected and still charged to the window, so GC pressure the
-    pipeline itself introduces stays measurable. Only the heap it did not
-    allocate stops being rescanned. (``test_serialization``'s ``_gc_paused``
-    disables the collector outright -- correct there, where the subject is a
-    tight serialization loop and any collection is pure noise.)
+    pipeline itself creates stays measurable. Only the heap it did not allocate
+    stops being rescanned. (``test_serialization``'s ``_gc_paused`` disables
+    outright -- right for a tight loop where any collection is pure noise.)
 
-    Not every timed gate needs this, and the test is whether one 286 ms pause
-    fits inside a gate's own margin rather than whether its window is short.
-    Checked against the measured figures: the absolute bounds in seconds have
-    room to spare; ``iteration_overhead`` (2.98x against a 5.0x bar) and
-    ``record_each_stage`` (46% against 200%) each survive a pause landing in
-    their worst window; ``dep_loading`` times ~18 ms but takes the best of
-    five, so a pause has to hit every run. The two wrapped here survive
-    nothing -- at concurrency 16 the pause is longer than the window it would
-    land in.
+    Whether a gate needs this is whether one 286 ms pause fits inside its own
+    margin, not whether its window is short. All were checked. The absolute
+    bounds have room to spare, and ``iteration_overhead`` (2.98x/5.0x),
+    ``record_each_stage`` (46%/200%), ``multi_task_runner`` (~0.4 s/~1.9 s) and
+    ``composite_limiter`` (0.03 ms/1.0 ms) survive a worst-case landing;
+    ``dep_loading`` takes the best of five, so a pause must hit every run.
+    ``dataset_iteration_overhead`` only looks tighter -- 443.7x against 600x
+    leaves 37 ms fresh -- but its plain-list denominator slows 4x on locality
+    under 1.03M live objects, dropping the ratio to 104x and raising headroom to
+    ~460 ms against a 206 ms pass. Headroom outgrows the pause.
+
+    Wrapped: ``test_throughput_vs_concurrency``, and ``test_benchmark_scenarios``
+    via ``_run_scenario`` -- same exposure at no cost, though this does *not*
+    close that one's residual gap, whose cause is still open.
+    ``test_pipeline_memory_scaling`` is fixed by measurement instead.
+
+    Not reentrant: ``gc.unfreeze()`` is all-or-nothing, so a nested exit would
+    drop the outer guard. A nested enter is a no-op -- the outer freeze already
+    covers what this window inherited, and anything since belongs to the code
+    under test, which must stay charged.
     """
+    if gc.get_freeze_count():
+        yield
+        return
+
     gc.collect()
     gc.freeze()
     try:
@@ -915,10 +925,8 @@ class MemoryTracker:
             self._update_peak(self._read_rss_mb())
 
     def start(self) -> None:
-        import gc as _gc
-
-        _gc.collect()
-        _gc.collect()
+        gc.collect()
+        gc.collect()
         baseline = self._read_rss_mb()
         with self._lock:
             self.baseline_mb = baseline

--- a/tests/performance/test_concurrency_scaling.py
+++ b/tests/performance/test_concurrency_scaling.py
@@ -22,6 +22,7 @@ from tests.conftest import (
     make_large_dataset,
     make_perf_config,
     samples_per_second,
+    suite_heap_excluded,
 )
 
 
@@ -48,7 +49,7 @@ class TestThroughputVsConcurrency:
 
         runner = TaskRunner(task, config)
         timer = PerfTimer()
-        with timer:
+        with suite_heap_excluded(), timer:
             report = await runner.arun()
 
         assert report is not None

--- a/tests/performance/test_memory_usage.py
+++ b/tests/performance/test_memory_usage.py
@@ -7,7 +7,7 @@ workloads. To produce measurable RSS deltas, tests use large payloads
 force OS-level page allocation.
 
 Verifies that:
-- Pipeline memory scales sub-linearly with sample count
+- Pipeline peak memory per additional sample stays within budget
 - record_each_stage overhead is bounded
 - No memory leaks across runs
 - Context and saver buffer footprints are bounded
@@ -39,6 +39,13 @@ from tests.conftest import (
 # Python's existing heap and produce 0.0MB delta with psutil).
 _MEM_PAYLOAD_SIZE = 10 * 1024
 
+# Peak RSS the pipeline may add per additional sample, as a multiple of the
+# payload -- a sample in flight is its payload plus the context, stage results
+# and saver buffering around it.  Today reads 45-66 KB per 10KB sample, so 10x
+# leaves ~1.5x over the worst; also what `TestContextMemoryFootprint` allows one
+# context.
+_MARGINAL_PEAK_BUDGET = 10
+
 
 class TestPipelineMemoryScaling:
     """Bound the pipeline's peak memory per additional sample.
@@ -47,11 +54,10 @@ class TestPipelineMemoryScaling:
     memory.  The output_size is kept small (100B) so that stage results
     don't dominate RSS — the test focuses on raw_sample lifecycle.
 
-    Peak memory here is *linear* in sample count at roughly 80KB per 10KB
-    sample; the earlier "sub-linear" claim came from a denominator inflated by
-    one-time process growth (see the comment on the assertion).  What the gate
-    catches is that figure rising — the pipeline retaining more per sample than
-    it does today.
+    Peak memory here is *linear* in sample count; the earlier "sub-linear"
+    claim came from a denominator inflated by one-time process growth (see the
+    comment on the assertion).  What the gate catches is the marginal figure
+    rising — the pipeline retaining more per sample than it does today.
     """
 
     @pytest.mark.anyio
@@ -59,6 +65,7 @@ class TestPipelineMemoryScaling:
         """Memory at n=2000, 5000, 10000 with 10KB payloads."""
         results: dict[int, float] = {}
         peaks: dict[int, float] = {}
+        bases: dict[int, float] = {}
 
         for n_samples in [2000, 5000, 10000]:
             gc.collect()
@@ -88,32 +95,49 @@ class TestPipelineMemoryScaling:
 
             results[n_samples] = tracker.delta_mb
             peaks[n_samples] = tracker.peak_mb
+            bases[n_samples] = tracker.baseline_mb
             print(
                 f"PERF: memory n={n_samples} => "
                 f"delta={tracker.delta_mb:.1f}MB, "
-                f"peak={tracker.peak_mb:.1f}MB"
+                f"peak={tracker.peak_mb:.1f}MB, "
+                f"baseline={tracker.baseline_mb:.1f}MB"
             )
 
         # Marginal cost, not a ratio of deltas.  `delta` is the difference of
-        # two ~1 GB RSS readings and carries a large one-time process-growth
-        # term: measured at 122.7MB for n=2000 in a fresh process against 20MB
-        # of actual payload, and at 62.3MB for the identical run once the rest
-        # of the suite had already grown the process.  Dividing by that term
-        # published ratios from 1.2x to 6.7x for unchanged code, against a 4x
-        # bar.  Subtracting two measurements cancels the term instead: the
-        # marginal figure below held at 80.7 / 82.7 / 82.8 / 106.6 KB per
-        # sample across those same four process states.
+        # two ~1 GB RSS readings and is mostly one-time process growth: 122.7MB
+        # at n=2000 in a fresh process against 20MB of real payload, 62.3MB for
+        # the identical run once the suite had grown the process.  Dividing by
+        # that published 1.2x to 6.7x for unchanged code against a 4x bar.
+        #
+        # Differencing two *absolute* peaks does not cancel it either --
+        # `peak_mb` is a high-water mark, so the difference keeps
+        # `baseline[10000] - baseline[2000]`, the RSS retained across the earlier
+        # iterations.  That residue measured 257.1MB, 32.9 of the 84.6 KB/sample
+        # it reported, and kept the reading ordered by process weight
+        # (80.7 -> 106.6).  Taking each run's peak over its own baseline does
+        # cancel it: across four process states -- isolated, after
+        # `tests/unit/core`, after `tests/unit`, and a full-suite run -- it reads
+        # 45-66 KB per sample and is no longer ordered by how much ran first;
+        # the heaviest state reads lowest.  That ordering going away, not the
+        # spread, is what makes it usable as a gate.
         span = 10000 - 2000
-        marginal_kb = (peaks[10000] - peaks[2000]) * 1024 / span
+        marginal_kb = (
+            ((peaks[10000] - bases[10000]) - (peaks[2000] - bases[2000])) * 1024 / span
+        )
         payload_kb = _MEM_PAYLOAD_SIZE / 1024
         print(
             f"PERF: memory delta n=2000/10000 => {results[2000]:.1f}MB / "
             f"{results[10000]:.1f}MB (diagnostic only); marginal peak = "
             f"{marginal_kb:.1f}KB/sample over a {payload_kb:.0f}KB payload"
         )
-        assert marginal_kb < 200, (
-            f"Peak memory per additional sample too high: {marginal_kb:.1f}KB "
-            f"for a {payload_kb:.0f}KB payload"
+        # Two-sided: the upper bound catches the pipeline retaining more per
+        # sample, the lower one is the guard `results[2000] > 0` used to provide
+        # -- a run that measured nothing (sampler stalled, RSS fully reused)
+        # reads at or below zero, and a one-sided bound would pass it.
+        assert payload_kb < marginal_kb < payload_kb * _MARGINAL_PEAK_BUDGET, (
+            f"Peak memory per additional sample out of range: {marginal_kb:.1f}KB "
+            f"for a {payload_kb:.0f}KB payload (expected "
+            f"{payload_kb:.0f}-{payload_kb * _MARGINAL_PEAK_BUDGET:.0f}KB)"
         )
 
 

--- a/tests/performance/test_memory_usage.py
+++ b/tests/performance/test_memory_usage.py
@@ -41,11 +41,17 @@ _MEM_PAYLOAD_SIZE = 10 * 1024
 
 
 class TestPipelineMemoryScaling:
-    """Verify pipeline memory scales sub-linearly with sample count.
+    """Bound the pipeline's peak memory per additional sample.
 
     Uses 10KB payloads with concurrency=64 to measure end-to-end pipeline
     memory.  The output_size is kept small (100B) so that stage results
     don't dominate RSS — the test focuses on raw_sample lifecycle.
+
+    Peak memory here is *linear* in sample count at roughly 80KB per 10KB
+    sample; the earlier "sub-linear" claim came from a denominator inflated by
+    one-time process growth (see the comment on the assertion).  What the gate
+    catches is that figure rising — the pipeline retaining more per sample than
+    it does today.
     """
 
     @pytest.mark.anyio
@@ -88,17 +94,27 @@ class TestPipelineMemoryScaling:
                 f"peak={tracker.peak_mb:.1f}MB"
             )
 
-        # 10000/2000 = 5x samples, memory should grow sub-linearly (<4x)
-        assert results[2000] > 0, (
-            f"Baseline delta too small to measure: {results[2000]:.2f}MB"
-        )
-        ratio = results[10000] / results[2000]
-        peak_ratio = peaks[10000] / peaks[2000] if peaks[2000] > 0 else 0
+        # Marginal cost, not a ratio of deltas.  `delta` is the difference of
+        # two ~1 GB RSS readings and carries a large one-time process-growth
+        # term: measured at 122.7MB for n=2000 in a fresh process against 20MB
+        # of actual payload, and at 62.3MB for the identical run once the rest
+        # of the suite had already grown the process.  Dividing by that term
+        # published ratios from 1.2x to 6.7x for unchanged code, against a 4x
+        # bar.  Subtracting two measurements cancels the term instead: the
+        # marginal figure below held at 80.7 / 82.7 / 82.8 / 106.6 KB per
+        # sample across those same four process states.
+        span = 10000 - 2000
+        marginal_kb = (peaks[10000] - peaks[2000]) * 1024 / span
+        payload_kb = _MEM_PAYLOAD_SIZE / 1024
         print(
-            f"PERF: memory scaling ratio (10000/2000) "
-            f"delta={ratio:.1f}x, peak={peak_ratio:.1f}x"
+            f"PERF: memory delta n=2000/10000 => {results[2000]:.1f}MB / "
+            f"{results[10000]:.1f}MB (diagnostic only); marginal peak = "
+            f"{marginal_kb:.1f}KB/sample over a {payload_kb:.0f}KB payload"
         )
-        assert ratio < 4, f"Memory scales linearly or worse: {ratio:.1f}x"
+        assert marginal_kb < 200, (
+            f"Peak memory per additional sample too high: {marginal_kb:.1f}KB "
+            f"for a {payload_kb:.0f}KB payload"
+        )
 
 
 class TestInitPhaseMemory:


### PR DESCRIPTION
## Type

- fix — bug fix or alignment correction

## Summary

Two perf tests fail intermittently in full-suite runs and pass in isolation, with no change to the code they measure. Both were dismissed as "flaky under load"; neither is — the machine was at load average **3.54 on 128 cores** while they reproduced.

Neither is a CI gate, which is worth stating precisely: CI runs `tests/unit tests/integration tests/acceptance`, and both of these live under `tests/performance/`, which is not in that path list. What they gate is a bare local `pytest` — where a developer actually meets them, and where a red line on unrelated work costs an investigation.

- **`test_throughput_vs_concurrency` loses a single gen2 collection into a sub-second window.** After `tests/unit` alone the process holds **833,021** tracked objects and one gen2 pass costs **286 ms** — longer than the **0.20 s** window the test measures at concurrency 16. Its timed section now runs under `gc.freeze()`.
- **`test_pipeline_memory_scaling` divided by a number that was mostly one-time process growth.** `delta` for n=2000 measured **122.7 MB** in a fresh process against **20 MB** of actual payload, and **62.3 MB** for the identical run once the suite had already grown the process. The published ratio ranged **1.2x → 6.7x** for unchanged code against a 4x bar. Replaced by a marginal figure, which cancels that term.

**The shape is what rules out contention.** In the failing run, concurrency 1 and 4 came in **0.043 s** and **0.053 s** slower than isolated while concurrency 16 took **0.457 s** longer — one discrete pause landing in the shortest window, not everything degrading together. That 0.457 s sits on the measured pause-vs-heap curve (305k objects → 14.6 ms, 1M → 94 ms, 2M → 258 ms, 4M → 535 ms synthetic; the real heap is dearer per object, 286 ms at 833k).

**`gc.freeze()`, not `gc.disable()`.** These gates measure framework scheduling efficiency, and GC pressure the pipeline itself creates is part of that. Freeze takes only the heap it did not allocate out of the scan; objects allocated inside the window are still collected and still charged to it. `test_serialization`'s `_gc_paused` disables outright, which is right there — a tight serialization loop where any collection is pure noise — and is left alone.

**Hypotheses tested and discarded, recorded so they are not re-tried.** Allocator reuse does not explain the memory gate: 1 MB blocks go through `mmap` and are returned on free, so the same 100 MB allocation measured 96.7 MB on a small heap and 99.8 MB after an 800 MB peak had been freed.

## Related Issues

Follow-up to #96, which diagnosed this mechanism and fixed `test_orjson_vs_serialize_breakdown`. Its docstring reasoned that "the absolute bounds elsewhere have the headroom to absorb a collection" — true for the absolute bounds, not for these two.

## Test Plan

### Automated

- [x] Lint/format clean (`ruff check && ruff format --check`)
- [x] Type check clean (`ty check`)
- [x] Unit tests pass (`pdm run pytest`) — **two consecutive full-suite runs**, and in both, `test_throughput_vs_concurrency` and `test_pipeline_memory_scaling` pass. They failed in the two full-suite runs before this change.
- [x] Both also still pass in isolation, so the change did not simply loosen them.

### Manual

- [x] **Which gates need this was computed, not assumed.** Each timed gate was checked against one 286 ms pause landing in its worst window: `iteration_overhead` goes 2.98x → 4.15x against a 5.0x bar, `record_each_stage` 46% → 151% against 200%, `dep_loading` times ~18 ms but takes the best of five so a pause must hit every run. Those keep their headroom and are untouched.
- [x] **The marginal memory figure is stable where the ratio was not.** Across four process states (isolated, after `tests/unit/core`, after `acceptance+performance`, after the full suite) the ratio-of-deltas read 1.2x / 1.3x / 1.6x / 2.8x while the marginal peak read **51.7 / 65.6 / 57.8 / 48.0 KB per sample** — and, more to the point, is no longer ordered by how much of the suite ran first; the heaviest state is now the *lowest* reading. The bound is 10x the payload (100 KB against 10 KB), matching what `TestContextMemoryFootprint` allows a single context. Both bounds are verified live by mutation: a 4x bar fails at 49.3, an 8x floor fails at 61.8.
- [x] **The first version of this metric was still contaminated.** It differenced two *absolute* RSS peaks, and `peak_mb` is a high-water mark, so the difference still carried `baseline[10000] - baseline[2000]` — 257.1 MB of residue, 32.9 of the 84.6 KB/sample it reported, 39% of the figure — which kept the reading climbing with process weight (80.7 → 106.6). Each run's peak is now taken over its own baseline, which cancels it.

### Not fixed here, and why

`TestBenchmarkSummary::test_benchmark_scenarios` still fails in a full-suite run (high_concurrency **63.5%** against its 65% bar, against **79.2%** in a fresh process — reproducible, `tests/unit` alone is enough to cause it). It is **`@pytest.mark.benchmark`, which CI deselects** (`-m "not stress and not benchmark"`), and `tests/README.md` already documents that marker as "calibrated on a dedicated box… treat a failure as 're-run idle' before calling it a regression".

That marker does **not** mean it gates nothing — saying so gets it backwards. `/sieval-release` runs `pytest -m benchmark` and stops the release if it fails, so it is the only one of the three sitting behind an automated gate. What makes it safe to defer is different: the release runs `-m benchmark` **alone**, in a fresh process whose heap is small, so the 286 ms mechanism does not reach it there — reproducing the failure takes a bare full-suite `pytest`. Moving its threshold is still a calibration decision rather than a bug fix.

Its window is wrapped anyway, since it is the same exposure and costs nothing — but that is **not** what makes the residual gap, and the cause there is still open. Ruled out by experiment: memory footprint (1.2 GB of GC-untracked bytes → 78.3%, still passing), tracked-object population (856k tracked dicts → 78.5%, still passing), leaked loguru sinks (1 handler after `tests/unit`), and leaked threads (4 alive). Only actually running the suite reproduces it.

## Checklist

### Required (all PRs)

- [x] PR title follows conventional format (`type(scope): description`)
- [x] No internal paths, credentials, or personal info in committed files
- [x] AI-generated code has `AI-Generated Code - <model> (<provider>)` in module docstring — tests only, no new modules
- [x] No new upper-layer dependencies added to `core/`
- [x] Deleted code verified — the delta ratio survives as a printed diagnostic; only its assertion is replaced

