### PR TITLE
feat(dataset): filter by a composite or derived key, from either surface

### DIFF
--- a/sieval/cli/_filter_spec.py
+++ b/sieval/cli/_filter_spec.py
@@ -25,7 +25,6 @@ import hashlib
 import re
 from collections.abc import Mapping, MutableMapping
 from pathlib import Path
-from typing import Any, cast
 
 #: Config key holding the digest of the ``values_file`` a run selected on.
 DIGEST_KEY = "values_digest"
@@ -52,10 +51,11 @@ def check_by(by: object) -> str | None:
             )
         return None
     if isinstance(by, dict):
-        # cast: `isinstance(x, dict)` narrows an `object` to dict[Never, Never],
-        # which rejects every key lookup below.
-        mapping = cast(dict[object, object], by)
-        if set(mapping) != {"callable"} or not isinstance(mapping.get("callable"), str):
+        # The value is read positionally because `isinstance(x, dict)` narrows
+        # an `object` to dict[Never, Never], which rejects a `str` key lookup.
+        # The key check to its left is what guarantees there is one to read.
+        values = list(by.values())
+        if set(by) != {"callable"} or not isinstance(values[0], str):
             return (
                 f"'filter' 'by' as a mapping takes exactly one key, "
                 f"'callable', naming a dotted path; got {by!r}"
@@ -67,7 +67,7 @@ def check_by(by: object) -> str | None:
     )
 
 
-def check_values_source(op_args: Mapping[str, Any]) -> list[str]:
+def check_values_source(op_args: Mapping) -> list[str]:
     """Every problem with where a ``filter`` operation gets its values."""
     problems: list[str] = []
 
@@ -115,7 +115,7 @@ def compute_values_digest(data: bytes) -> str:
     return f"sha256:{hashlib.sha256(data).hexdigest()}"
 
 
-def pin_values_files(cfg: MutableMapping[str, Any], config_dir: Path) -> None:
+def pin_values_files(cfg: MutableMapping, config_dir: Path) -> None:
     """Record each ``filter`` operation's ``values_file`` digest into *cfg*.
 
     Called on the reified config before it is both persisted and handed to the

--- a/sieval/cli/_filter_spec.py
+++ b/sieval/cli/_filter_spec.py
@@ -1,22 +1,20 @@
 """Shape of a ``filter`` dataset operation, shared by its two surfaces.
 
 ``cli.validation`` shape-checks a config with no dataset in hand and collects
-every problem it finds; ``cli.leaderboard.session`` applies the operation and
-raises on the first. They ask the same questions of the same keys, so the
-questions live here and each caller keeps its own way of reporting the answer —
-returning a message rather than raising is what lets one accumulate and the
-other raise. ``cli.validation`` already imports ``cli.leaderboard.session``, so
-this cannot live in either without pointing that dependency backwards.
+every problem; ``cli.leaderboard.session`` applies the operation and raises on
+the first. Same questions, different reporting — which is why these return a
+message rather than raising. They live here because ``cli.validation`` already
+imports ``cli.leaderboard.session``, so neither file could hold them without
+pointing that dependency backwards.
 
 Callers prepend their own ``Dataset '<name>': `` to every message returned here.
 
-This module also pins ``values_file``. The accepted values live outside the
-config, so the config alone does not say which rows a run selected: two runs
-whose ``effective_config.yaml`` compares equal can score different sample sets
-if the file changed in between, and ``--resume`` would accept the second. So
-the file's digest is recorded *into* the config at load time, where the resume
-gate can see it. The path is still stored verbatim, which is what keeps
-``effective_config.yaml`` portable across machines.
+This module also pins ``values_file``. Its values live outside the config, so
+two runs whose ``effective_config.yaml`` compares equal can score different
+sample sets if the file changed in between — and ``--resume`` would accept the
+second. Recording the digest *into* the config puts that difference where the
+resume gate can see it, while the path stays verbatim so
+``effective_config.yaml`` remains portable across machines.
 
 AI-Generated Code - Claude Opus 5 (1M context) (Anthropic)
 """
@@ -51,9 +49,9 @@ def check_by(by: object) -> str | None:
             )
         return None
     if isinstance(by, dict):
-        # The value is read positionally because `isinstance(x, dict)` narrows
-        # an `object` to dict[Never, Never], which rejects a `str` key lookup.
-        # The key check to its left is what guarantees there is one to read.
+        # Read positionally: `isinstance(x, dict)` narrows an `object` to
+        # dict[Never, Never], which rejects a `str` key lookup. The key check
+        # to its left guarantees there is one value to read.
         values = list(by.values())
         if set(by) != {"callable"} or not isinstance(values[0], str):
             return (
@@ -120,15 +118,14 @@ def pin_values_files(cfg: MutableMapping, config_dir: Path) -> None:
 
     Called on the reified config before it is both persisted and handed to the
     runtime, so the digest reaches ``effective_config.yaml`` — and therefore
-    the ``--resume`` comparison — without the transform ever learning where a
-    config lives.
+    the ``--resume`` comparison.
 
-    A digest already present is *verified* rather than overwritten: that is the
-    case where a persisted ``effective_config.yaml`` is re-run after its values
-    file changed underneath it.
+    A digest already present is *verified* rather than overwritten: that is a
+    persisted ``effective_config.yaml`` re-run after its values file changed
+    underneath it.
 
-    Malformed operations are left alone. They are ``cli.validation``'s to
-    report, and a shape error raised from here would pre-empt a better message.
+    Malformed operations are left alone — they are ``cli.validation``'s to
+    report, and raising here would pre-empt a better message.
     """
     datasets = cfg.get("datasets")
     if not isinstance(datasets, dict):

--- a/sieval/cli/_filter_spec.py
+++ b/sieval/cli/_filter_spec.py
@@ -9,25 +9,50 @@ pointing that dependency backwards.
 
 Callers prepend their own ``Dataset '<name>': `` to every message returned here.
 
-This module also pins ``values_file``. Its values live outside the config, so
-two runs whose ``effective_config.yaml`` compares equal can score different
-sample sets if the file changed in between — and ``--resume`` would accept the
-second. Recording the digest *into* the config puts that difference where the
-resume gate can see it, while the path stays verbatim so
-``effective_config.yaml`` remains portable across machines.
+This module also pins the two things a ``filter`` names but does not contain:
+the ``values_file`` holding its accepted values, and the key function
+``by: {callable: ...}`` names. Either can change while the config does not, so
+two runs whose ``effective_config.yaml`` compares equal can select different
+rows — and ``--resume`` would accept the second. Recording a digest of each
+*into* the config puts that difference where the resume gate can see it, while
+the path and the dotted path stay verbatim so ``effective_config.yaml`` remains
+portable across machines.
 
 AI-Generated Code - Claude Opus 5 (1M context) (Anthropic)
 """
 
 import hashlib
+import inspect
 import re
-from collections.abc import Mapping, MutableMapping
+from collections.abc import Callable, Iterator, Mapping, MutableMapping
 from pathlib import Path
 
+from loguru import logger
+
+from .resolution import resolve_key_function
+
 #: Config key holding the digest of the ``values_file`` a run selected on.
-DIGEST_KEY = "values_digest"
+VALUES_DIGEST_KEY = "values_digest"
+
+#: Config key holding the digest of the key function a run selected with.
+BY_DIGEST_KEY = "by_digest"
 
 _DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+def key_function_spec(by: object) -> str | None:
+    """The dotted path *by* names, or ``None`` if it is not the callable form.
+
+    The one place that knows how ``by: {callable: 'pkg.module.fn'}`` is spelled,
+    so the checker, the pin and the session all read it the same way.
+    """
+    if not isinstance(by, dict) or set(by) != {"callable"}:
+        return None
+    # Read positionally: `isinstance(x, dict)` narrows an `object` to
+    # dict[Never, Never], which rejects a `str` key lookup. The key check above
+    # guarantees there is exactly one value to read.
+    spec = next(iter(by.values()))
+    return spec if isinstance(spec, str) else None
 
 
 def check_by(by: object) -> str | None:
@@ -49,11 +74,7 @@ def check_by(by: object) -> str | None:
             )
         return None
     if isinstance(by, dict):
-        # Read positionally: `isinstance(x, dict)` narrows an `object` to
-        # dict[Never, Never], which rejects a `str` key lookup. The key check
-        # to its left guarantees there is one value to read.
-        values = list(by.values())
-        if set(by) != {"callable"} or not isinstance(values[0], str):
+        if key_function_spec(by) is None:
             return (
                 f"'filter' 'by' as a mapping takes exactly one key, "
                 f"'callable', naming a dotted path; got {by!r}"
@@ -78,16 +99,17 @@ def check_values_source(op_args: Mapping) -> list[str]:
     if values_file is not None and not isinstance(values_file, str):
         problems.append(f"'filter' 'values_file' must be a path; got {values_file!r}")
 
-    digest = op_args.get(DIGEST_KEY)
+    digest = op_args.get(VALUES_DIGEST_KEY)
     if digest is not None:
         if not isinstance(digest, str) or not _DIGEST_RE.match(digest):
             problems.append(
-                f"'filter' {DIGEST_KEY!r} must look like 'sha256:<64 hex>'; "
+                f"'filter' {VALUES_DIGEST_KEY!r} must look like 'sha256:<64 hex>'; "
                 f"got {digest!r}"
             )
         elif values_file is None:
             problems.append(
-                f"'filter' {DIGEST_KEY!r} pins a 'values_file', but none is given"
+                f"'filter' {VALUES_DIGEST_KEY!r} pins a 'values_file', but none "
+                f"is given"
             )
 
     require_all = op_args.get("require_all")
@@ -96,6 +118,24 @@ def check_values_source(op_args: Mapping) -> list[str]:
             f"'filter' 'require_all' must be a boolean; got {require_all!r}"
         )
     return problems
+
+
+def check_by_digest(op_args: Mapping) -> list[str]:
+    """Every problem with a ``filter`` operation's pinned key-function digest."""
+    digest = op_args.get(BY_DIGEST_KEY)
+    if digest is None:
+        return []
+    if not isinstance(digest, str) or not _DIGEST_RE.match(digest):
+        return [
+            f"'filter' {BY_DIGEST_KEY!r} must look like 'sha256:<64 hex>'; "
+            f"got {digest!r}"
+        ]
+    if key_function_spec(op_args.get("by")) is None:
+        return [
+            f"'filter' {BY_DIGEST_KEY!r} pins a key function, but 'by' does not "
+            f"name one"
+        ]
+    return []
 
 
 def resolve_values_path(values_file: str, config_dir: Path) -> Path:
@@ -110,23 +150,54 @@ def resolve_values_path(values_file: str, config_dir: Path) -> Path:
 
 def compute_values_digest(data: bytes) -> str:
     """The recorded digest of a values file's contents."""
-    return f"sha256:{hashlib.sha256(data).hexdigest()}"
+    return _digest(data)
 
 
-def pin_values_files(cfg: MutableMapping, config_dir: Path) -> None:
-    """Record each ``filter`` operation's ``values_file`` digest into *cfg*.
+def compute_key_function_digest(fn: Callable) -> str | None:
+    """The recorded digest of a key function's source, or ``None``.
+
+    ``None`` means the source cannot be read — a builtin, a C extension, a
+    ``functools.partial``. Those stay unpinned rather than blocking the run.
+
+    The digest covers the ``def`` block and its decorators, not what the body
+    calls, so it is a tripwire for the function being edited rather than a proof
+    that the selection reproduces — the same reach ``values_digest`` has over a
+    file of ids but not over the dataset they index. Reformatting and comment
+    edits trip it too: on a resume a false positive is a question, a false
+    negative is a wrong number.
+    """
+    try:
+        source = inspect.getsource(fn)
+    except (OSError, TypeError):
+        return None
+    return _digest(source.encode("utf-8"))
+
+
+def pin_filter_digests(cfg: MutableMapping, config_dir: Path) -> None:
+    """Record each ``filter`` operation's provenance digests into *cfg*.
 
     Called on the reified config before it is both persisted and handed to the
-    runtime, so the digest reaches ``effective_config.yaml`` — and therefore
-    the ``--resume`` comparison.
+    runtime, so the digests reach ``effective_config.yaml`` — and therefore the
+    ``--resume`` comparison.
 
     A digest already present is *verified* rather than overwritten: that is a
-    persisted ``effective_config.yaml`` re-run after its values file changed
-    underneath it.
+    persisted ``effective_config.yaml`` re-run after its values file or its key
+    function changed underneath it.
 
     Malformed operations are left alone — they are ``cli.validation``'s to
     report, and raising here would pre-empt a better message.
     """
+    for name, op_args in _filter_operations(cfg):
+        _pin_values_file(name, op_args, config_dir)
+        _pin_key_function(name, op_args)
+
+
+def _digest(data: bytes) -> str:
+    return f"sha256:{hashlib.sha256(data).hexdigest()}"
+
+
+def _filter_operations(cfg: Mapping) -> Iterator[tuple[str, MutableMapping]]:
+    """Every well-formed ``filter`` operation in *cfg*, with its dataset name."""
     datasets = cfg.get("datasets")
     if not isinstance(datasets, dict):
         return
@@ -142,29 +213,74 @@ def pin_values_files(cfg: MutableMapping, config_dir: Path) -> None:
             if next(iter(op)) != "filter":
                 continue
             op_args = op["filter"]
-            if not isinstance(op_args, dict):
-                continue
-            values_file = op_args.get("values_file")
-            if not isinstance(values_file, str):
-                continue
+            if isinstance(op_args, dict):
+                yield name, op_args
 
-            path = resolve_values_path(values_file, config_dir)
-            if not path.is_file():
-                raise ValueError(
-                    f"Dataset '{name}': 'filter' 'values_file' not found: {path}"
-                )
-            digest = compute_values_digest(path.read_bytes())
-            recorded = op_args.get(DIGEST_KEY)
-            if recorded is None:
-                op_args[DIGEST_KEY] = digest
-            elif recorded != digest:
-                raise ValueError(
-                    f"Dataset '{name}': 'filter' 'values_file' {values_file} "
-                    f"has changed since this config recorded it "
-                    f"({DIGEST_KEY} says {recorded}, the file is {digest}). "
-                    f"The selection would not be the one this config names. "
-                    f"Either:\n"
-                    f"  1. Restore {path} to the contents the digest pins\n"
-                    f"  2. Drop '{DIGEST_KEY}' to pin the current contents — a "
-                    f"different selection, so use a fresh result_dir"
-                )
+
+def _pin_values_file(name: str, op_args: MutableMapping, config_dir: Path) -> None:
+    values_file = op_args.get("values_file")
+    if not isinstance(values_file, str):
+        return
+
+    path = resolve_values_path(values_file, config_dir)
+    if not path.is_file():
+        raise ValueError(f"Dataset '{name}': 'filter' 'values_file' not found: {path}")
+    digest = compute_values_digest(path.read_bytes())
+    recorded = op_args.get(VALUES_DIGEST_KEY)
+    if recorded is None:
+        op_args[VALUES_DIGEST_KEY] = digest
+    elif recorded != digest:
+        raise ValueError(
+            f"Dataset '{name}': 'filter' 'values_file' {values_file} "
+            f"has changed since this config recorded it "
+            f"({VALUES_DIGEST_KEY} says {recorded}, the file is {digest}). "
+            f"The selection would not be the one this config names. "
+            f"Either:\n"
+            f"  1. Restore {path} to the contents the digest pins\n"
+            f"  2. Drop '{VALUES_DIGEST_KEY}' to pin the current contents — a "
+            f"different selection, so use a fresh result_dir"
+        )
+
+
+def _pin_key_function(name: str, op_args: MutableMapping) -> None:
+    spec = key_function_spec(op_args.get("by"))
+    if spec is None:
+        return
+    try:
+        fn = resolve_key_function(spec)
+    except (ValueError, ImportError, AttributeError):
+        # Unresolvable: the session raises on it a moment later with a message
+        # that names the dataset and what could not be imported.
+        return
+
+    digest = compute_key_function_digest(fn)
+    recorded = op_args.get(BY_DIGEST_KEY)
+    if digest is None:
+        if recorded is not None:
+            raise ValueError(
+                f"Dataset '{name}': 'filter' 'by' callable {spec} is pinned by "
+                f"{BY_DIGEST_KEY}, but its source can no longer be read, so the "
+                f"pin cannot be checked. Drop '{BY_DIGEST_KEY}' to run it "
+                f"unpinned — a selection this config can no longer vouch for, "
+                f"so use a fresh result_dir"
+            )
+        logger.warning(
+            "Dataset '{}': 'filter' 'by' callable {} has no readable source, so "
+            "it is not pinned and --resume cannot tell if it changed. Give the "
+            "key a plain 'def' to make it pinnable.",
+            name,
+            spec,
+        )
+        return
+    if recorded is None:
+        op_args[BY_DIGEST_KEY] = digest
+    elif recorded != digest:
+        raise ValueError(
+            f"Dataset '{name}': 'filter' 'by' callable {spec} has changed since "
+            f"this config recorded it ({BY_DIGEST_KEY} says {recorded}, its "
+            f"source is now {digest}). The selection would not be the one this "
+            f"config names. Either:\n"
+            f"  1. Restore {spec} to the source the digest pins\n"
+            f"  2. Drop '{BY_DIGEST_KEY}' to pin the current source — a "
+            f"different selection, so use a fresh result_dir"
+        )

--- a/sieval/cli/_filter_spec.py
+++ b/sieval/cli/_filter_spec.py
@@ -1,0 +1,173 @@
+"""Shape of a ``filter`` dataset operation, shared by its two surfaces.
+
+``cli.validation`` shape-checks a config with no dataset in hand and collects
+every problem it finds; ``cli.leaderboard.session`` applies the operation and
+raises on the first. They ask the same questions of the same keys, so the
+questions live here and each caller keeps its own way of reporting the answer —
+returning a message rather than raising is what lets one accumulate and the
+other raise. ``cli.validation`` already imports ``cli.leaderboard.session``, so
+this cannot live in either without pointing that dependency backwards.
+
+Callers prepend their own ``Dataset '<name>': `` to every message returned here.
+
+This module also pins ``values_file``. The accepted values live outside the
+config, so the config alone does not say which rows a run selected: two runs
+whose ``effective_config.yaml`` compares equal can score different sample sets
+if the file changed in between, and ``--resume`` would accept the second. So
+the file's digest is recorded *into* the config at load time, where the resume
+gate can see it. The path is still stored verbatim, which is what keeps
+``effective_config.yaml`` portable across machines.
+
+AI-Generated Code - Claude Opus 5 (1M context) (Anthropic)
+"""
+
+import hashlib
+import re
+from collections.abc import Mapping, MutableMapping
+from pathlib import Path
+from typing import Any, cast
+
+#: Config key holding the digest of the ``values_file`` a run selected on.
+DIGEST_KEY = "values_digest"
+
+_DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+def check_by(by: object) -> str | None:
+    """The problem with a ``filter`` operation's ``by``, or ``None``.
+
+    Shape only — whether a named column exists and whether a dotted path
+    imports are questions for the session, which has the dataset and the
+    config's directory.
+    """
+    if by is None:
+        return "'filter' requires 'by'"
+    if isinstance(by, str):
+        return None
+    if isinstance(by, list):
+        if not by or not all(isinstance(col, str) for col in by):
+            return (
+                f"'filter' 'by' as a list must name one or more columns as "
+                f"strings; got {by!r}"
+            )
+        return None
+    if isinstance(by, dict):
+        # cast: `isinstance(x, dict)` narrows an `object` to dict[Never, Never],
+        # which rejects every key lookup below.
+        mapping = cast(dict[object, object], by)
+        if set(mapping) != {"callable"} or not isinstance(mapping.get("callable"), str):
+            return (
+                f"'filter' 'by' as a mapping takes exactly one key, "
+                f"'callable', naming a dotted path; got {by!r}"
+            )
+        return None
+    return (
+        f"'filter' 'by' must be a column name, a list of column names, or "
+        f"{{callable: 'pkg.module.fn'}}; got {by!r}"
+    )
+
+
+def check_values_source(op_args: Mapping[str, Any]) -> list[str]:
+    """Every problem with where a ``filter`` operation gets its values."""
+    problems: list[str] = []
+
+    # Presence, not truthiness: `value: 0` and `value: false` are legitimate
+    # column values and must not read as "omitted".
+    has_value = "value" in op_args
+    values_file = op_args.get("values_file")
+    if has_value == (values_file is not None):
+        problems.append("'filter' requires exactly one of 'value' or 'values_file'")
+    if values_file is not None and not isinstance(values_file, str):
+        problems.append(f"'filter' 'values_file' must be a path; got {values_file!r}")
+
+    digest = op_args.get(DIGEST_KEY)
+    if digest is not None:
+        if not isinstance(digest, str) or not _DIGEST_RE.match(digest):
+            problems.append(
+                f"'filter' {DIGEST_KEY!r} must look like 'sha256:<64 hex>'; "
+                f"got {digest!r}"
+            )
+        elif values_file is None:
+            problems.append(
+                f"'filter' {DIGEST_KEY!r} pins a 'values_file', but none is given"
+            )
+
+    require_all = op_args.get("require_all")
+    if require_all is not None and not isinstance(require_all, bool):
+        problems.append(
+            f"'filter' 'require_all' must be a boolean; got {require_all!r}"
+        )
+    return problems
+
+
+def resolve_values_path(values_file: str, config_dir: Path) -> Path:
+    """A ``values_file`` as an absolute path.
+
+    Relative paths resolve against the config that named them — the rule
+    ``alignment.card`` already follows.
+    """
+    path = Path(values_file)
+    return path if path.is_absolute() else (config_dir / path).resolve()
+
+
+def compute_values_digest(data: bytes) -> str:
+    """The recorded digest of a values file's contents."""
+    return f"sha256:{hashlib.sha256(data).hexdigest()}"
+
+
+def pin_values_files(cfg: MutableMapping[str, Any], config_dir: Path) -> None:
+    """Record each ``filter`` operation's ``values_file`` digest into *cfg*.
+
+    Called on the reified config before it is both persisted and handed to the
+    runtime, so the digest reaches ``effective_config.yaml`` — and therefore
+    the ``--resume`` comparison — without the transform ever learning where a
+    config lives.
+
+    A digest already present is *verified* rather than overwritten: that is the
+    case where a persisted ``effective_config.yaml`` is re-run after its values
+    file changed underneath it.
+
+    Malformed operations are left alone. They are ``cli.validation``'s to
+    report, and a shape error raised from here would pre-empt a better message.
+    """
+    datasets = cfg.get("datasets")
+    if not isinstance(datasets, dict):
+        return
+    for name, dataset_cfg in datasets.items():
+        if not isinstance(dataset_cfg, dict):
+            continue
+        operations = dataset_cfg.get("operations")
+        if not isinstance(operations, list):
+            continue
+        for op in operations:
+            if not isinstance(op, dict) or len(op) != 1:
+                continue
+            if next(iter(op)) != "filter":
+                continue
+            op_args = op["filter"]
+            if not isinstance(op_args, dict):
+                continue
+            values_file = op_args.get("values_file")
+            if not isinstance(values_file, str):
+                continue
+
+            path = resolve_values_path(values_file, config_dir)
+            if not path.is_file():
+                raise ValueError(
+                    f"Dataset '{name}': 'filter' 'values_file' not found: {path}"
+                )
+            digest = compute_values_digest(path.read_bytes())
+            recorded = op_args.get(DIGEST_KEY)
+            if recorded is None:
+                op_args[DIGEST_KEY] = digest
+            elif recorded != digest:
+                raise ValueError(
+                    f"Dataset '{name}': 'filter' 'values_file' {values_file} "
+                    f"has changed since this config recorded it "
+                    f"({DIGEST_KEY} says {recorded}, the file is {digest}). "
+                    f"The selection would not be the one this config names. "
+                    f"Either:\n"
+                    f"  1. Restore {path} to the contents the digest pins\n"
+                    f"  2. Drop '{DIGEST_KEY}' to pin the current contents — a "
+                    f"different selection, so use a fresh result_dir"
+                )

--- a/sieval/cli/_filter_spec.py
+++ b/sieval/cli/_filter_spec.py
@@ -39,6 +39,43 @@ BY_DIGEST_KEY = "by_digest"
 
 _DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 
+#: Every key a ``filter`` operation accepts. Enumerated so a typo in an
+#: *optional* one is caught: a misspelled ``by`` or ``value`` fails the checks
+#: below because what they name goes missing, but ``require_all_keys: true``
+#: reads as ``require_all`` simply left at its default, and a misspelled
+#: ``split`` reads as a split that is not there — both silently.
+_FILTER_KEYS = frozenset(
+    {
+        "by",
+        "value",
+        "values_file",
+        "require_all",
+        "split",
+        VALUES_DIGEST_KEY,
+        BY_DIGEST_KEY,
+    }
+)
+
+
+def check_arg_names(op_args: Mapping) -> list[str]:
+    """Every problem with a ``filter`` operation's key names, and with *split*.
+
+    *split* is checked here rather than against the dataset: whether the split
+    exists is the session's question, but whether it is a *string* is answerable
+    with no data in hand, and a non-string one silently matches no split.
+    """
+    problems: list[str] = []
+    unknown = sorted(set(op_args) - _FILTER_KEYS)
+    if unknown:
+        problems.append(
+            f"'filter' has unknown key(s) {unknown}; valid keys are "
+            f"{sorted(_FILTER_KEYS)}"
+        )
+    split = op_args.get("split")
+    if split is not None and not isinstance(split, str):
+        problems.append(f"'filter' 'split' must be a split name; got {split!r}")
+    return problems
+
 
 def key_function_spec(by: object) -> str | None:
     """The dotted path *by* names, or ``None`` if it is not the callable form.
@@ -146,6 +183,24 @@ def resolve_values_path(values_file: str, config_dir: Path) -> Path:
     """
     path = Path(values_file)
     return path if path.is_absolute() else (config_dir / path).resolve()
+
+
+def relative_values_files(cfg: Mapping) -> list[str]:
+    """Every ``values_file`` in *cfg* named by a relative path.
+
+    Such a path resolves against the config that named it, so the persisted
+    ``effective_config.yaml`` — which stores it verbatim, to stay portable —
+    only reproduces the selection when re-run from beside the original config.
+    Its header says so rather than the path being rewritten absolute: the
+    persisted copy would then no longer compare equal to the source config's
+    relative one, and ``--resume`` would reject its own artifact.
+    """
+    return [
+        values_file
+        for _, op_args in _filter_operations(cfg)
+        if isinstance(values_file := op_args.get("values_file"), str)
+        and not Path(values_file).is_absolute()
+    ]
 
 
 def compute_values_digest(data: bytes) -> str:

--- a/sieval/cli/_filter_spec.py
+++ b/sieval/cli/_filter_spec.py
@@ -188,12 +188,12 @@ def resolve_values_path(values_file: str, config_dir: Path) -> Path:
 def relative_values_files(cfg: Mapping) -> list[str]:
     """Every ``values_file`` in *cfg* named by a relative path.
 
-    Such a path resolves against the config that named it, so the persisted
-    ``effective_config.yaml`` — which stores it verbatim, to stay portable —
-    only reproduces the selection when re-run from beside the original config.
-    Its header says so rather than the path being rewritten absolute: the
-    persisted copy would then no longer compare equal to the source config's
-    relative one, and ``--resume`` would reject its own artifact.
+    Resolving against the config being run (above) means the persisted
+    ``effective_config.yaml`` reproduces the selection only when re-run from
+    beside the original config. Its header says so rather than the path being
+    rewritten absolute: the persisted copy would then stop comparing equal to
+    the source config's relative one, and ``--resume`` would reject its own
+    artifact.
     """
     return [
         values_file

--- a/sieval/cli/leaderboard/session.py
+++ b/sieval/cli/leaderboard/session.py
@@ -1130,12 +1130,10 @@ class EvalSession:
             model=model_override,
             result_dir=result_dir_override,
         )
-        # Pin every `filter` values_file into the config before it is copied,
-        # so the digest reaches BOTH the persisted view (and therefore the
-        # --resume comparison) and the runtime view below. It has to happen
-        # here rather than where the operation runs: `arun` persists before
-        # `_prepare_execution`, so by the time a dataset op is applied the
-        # comparison the digest exists for has already been made.
+        # Before the copy, so the digest reaches both the persisted view (and
+        # therefore --resume) and the runtime view below. Not where the
+        # operation runs: `arun` persists before `_prepare_execution`, so by
+        # then the comparison the digest exists for has already been made.
         pin_values_files(reified, self.config_path.parent)
         self._reified_config: dict[str, Any] = copy.deepcopy(reified)
 
@@ -3195,10 +3193,8 @@ class EvalSession:
                     )
 
                 case _:
-                    # Kept in step with `sieval.cli.validation._VALID_OPERATIONS`
-                    # by `test_the_unknown_operation_message_lists_every_valid
-                    # _operation`; this message silently omitted `filter` for as
-                    # long as `filter` had existed.
+                    # Kept in step with `validation._VALID_OPERATIONS` by
+                    # `test_the_unknown_operation_message_lists_every_valid_operation`.
                     raise ValueError(
                         f"Dataset '{dataset_name}': Unknown operation '{op_name}'. "
                         f"Valid operations: filter, repeat, shuffle, slice, "
@@ -3212,8 +3208,7 @@ class EvalSession:
 
         ``by: tag`` is a column, ``by: [tag, lang]`` a composite key, and
         ``by: {callable: 'pkg.module.fn'}`` a derived one — the config spelling
-        of the callable a Python caller would pass directly, so the two surfaces
-        can express the same selections.
+        of the callable a Python caller passes directly.
 
         The shape check is :func:`~sieval.cli._filter_spec.check_by`, shared with
         ``cli.validation``; only the resolution below is this surface's own.
@@ -3247,23 +3242,21 @@ class EvalSession:
 
         A ``.json`` file is a list of values, or an object whose *keys* are the
         values (so a map from id to whatever metadata produced the selection can
-        be used as-is). Anything else is read as one value per line, with blanks
-        and ``#`` comments skipped.
+        be used as-is). Anything else is one value per line, blanks and ``#``
+        comments skipped.
 
-        *expected_digest* is the ``values_digest`` pinned into the config at load
-        time. Re-checking it here closes the window between that read and this
-        one: the digest recorded next to a run's results then describes the bytes
-        the run actually selected on, not merely the bytes that were there when
-        the config was parsed.
+        *expected_digest* is the ``values_digest`` pinned at load time.
+        Re-checking it here closes the window between that read and this one, so
+        the digest stored beside the results describes the bytes the run
+        selected on, not the bytes that were there when the config was parsed.
         """
         if not isinstance(values_file, str):
             raise ValueError(
                 f"Dataset '{dataset_name}': 'filter' 'values_file' must be a "
                 f"path; got {values_file!r}"
             )
-        # Resolved against the config that named it, and stored verbatim, so
-        # ``effective_config.yaml`` stays portable across machines — the same
-        # rule ``alignment.card`` follows.
+        # Resolved against the config that named it, stored verbatim — the same
+        # rule `alignment.card` follows.
         path = resolve_values_path(values_file, self.config_path.parent)
         if not path.is_file():
             raise ValueError(

--- a/sieval/cli/leaderboard/session.py
+++ b/sieval/cli/leaderboard/session.py
@@ -3224,6 +3224,8 @@ class EvalSession:
         if isinstance(by_spec, str):
             return by_spec
         if isinstance(by_spec, list):
+            # cast, not a rebuild: `check_by` above has already established
+            # every element is a `str`, which the checker cannot see.
             return cast(list[str], by_spec)
         spec = cast(dict[str, str], by_spec)["callable"]
         try:

--- a/sieval/cli/leaderboard/session.py
+++ b/sieval/cli/leaderboard/session.py
@@ -25,6 +25,14 @@ from loguru import logger
 from packaging.version import InvalidVersion, Version
 
 from sieval import __version__
+from sieval.cli._filter_spec import (
+    DIGEST_KEY,
+    check_by,
+    check_values_source,
+    compute_values_digest,
+    pin_values_files,
+    resolve_values_path,
+)
 from sieval.cli.leaderboard.card import AlignmentCard, load_card
 from sieval.cli.resolution import (
     TASK_MODEL_ROLES,
@@ -1122,6 +1130,13 @@ class EvalSession:
             model=model_override,
             result_dir=result_dir_override,
         )
+        # Pin every `filter` values_file into the config before it is copied,
+        # so the digest reaches BOTH the persisted view (and therefore the
+        # --resume comparison) and the runtime view below. It has to happen
+        # here rather than where the operation runs: `arun` persists before
+        # `_prepare_execution`, so by the time a dataset op is applied the
+        # comparison the digest exists for has already been made.
+        pin_values_files(reified, self.config_path.parent)
         self._reified_config: dict[str, Any] = copy.deepcopy(reified)
 
         # Runtime view = reified + the legacy external adapter (mutates
@@ -3091,30 +3106,18 @@ class EvalSession:
                 case "filter":
                     by_spec = op_args.get("by")
                     split = op_args.get("split", "test")
-                    if by_spec is None:
-                        raise ValueError(
-                            f"Dataset '{dataset_name}': 'filter' requires 'by'"
-                        )
                     by = self._resolve_filter_by(by_spec, dataset_name)
-                    # Presence, not truthiness: `value: 0` and `value: false` are
-                    # legitimate column values and must not read as "omitted".
-                    has_value = "value" in op_args
+                    problems = check_values_source(op_args)
+                    if problems:
+                        raise ValueError(f"Dataset '{dataset_name}': {problems[0]}")
                     values_file = op_args.get("values_file")
-                    if has_value == (values_file is not None):
-                        raise ValueError(
-                            f"Dataset '{dataset_name}': 'filter' requires exactly "
-                            f"one of 'value' or 'values_file'"
-                        )
                     if values_file is not None:
-                        value = self._read_filter_values(values_file, dataset_name)
+                        value = self._read_filter_values(
+                            values_file, dataset_name, op_args.get(DIGEST_KEY)
+                        )
                     else:
                         value = op_args["value"]
                     require_all = op_args.get("require_all", False)
-                    if not isinstance(require_all, bool):
-                        raise ValueError(
-                            f"Dataset '{dataset_name}': 'filter' 'require_all' "
-                            f"must be a boolean; got {require_all!r}"
-                        )
                     dataset = dataset.filter(
                         by, value, require_all=require_all, split=split
                     )
@@ -3211,39 +3214,29 @@ class EvalSession:
         ``by: {callable: 'pkg.module.fn'}`` a derived one — the config spelling
         of the callable a Python caller would pass directly, so the two surfaces
         can express the same selections.
+
+        The shape check is :func:`~sieval.cli._filter_spec.check_by`, shared with
+        ``cli.validation``; only the resolution below is this surface's own.
         """
+        problem = check_by(by_spec)
+        if problem is not None:
+            raise ValueError(f"Dataset '{dataset_name}': {problem}")
         if isinstance(by_spec, str):
             return by_spec
         if isinstance(by_spec, list):
-            if not by_spec or not all(isinstance(col, str) for col in by_spec):
-                raise ValueError(
-                    f"Dataset '{dataset_name}': 'filter' 'by' as a list must "
-                    f"name one or more columns as strings; got {by_spec!r}"
-                )
             return cast(list[str], by_spec)
-        if isinstance(by_spec, dict):
-            mapping = cast(dict[object, object], by_spec)
-            spec = mapping.get("callable")
-            if set(mapping) != {"callable"} or not isinstance(spec, str):
-                raise ValueError(
-                    f"Dataset '{dataset_name}': 'filter' 'by' as a mapping takes "
-                    f"exactly one key, 'callable', naming a dotted path; "
-                    f"got {by_spec!r}"
-                )
-            try:
-                return resolve_key_function(spec)
-            except (ValueError, ImportError, AttributeError) as exc:
-                raise ValueError(
-                    f"Dataset '{dataset_name}': 'filter' 'by' callable "
-                    f"{spec!r} could not be resolved: {exc}"
-                ) from exc
-        raise ValueError(
-            f"Dataset '{dataset_name}': 'filter' 'by' must be a column name, a "
-            f"list of column names, or {{callable: 'pkg.module.fn'}}; "
-            f"got {by_spec!r}"
-        )
+        spec = cast(dict[str, str], by_spec)["callable"]
+        try:
+            return resolve_key_function(spec)
+        except (ValueError, ImportError, AttributeError) as exc:
+            raise ValueError(
+                f"Dataset '{dataset_name}': 'filter' 'by' callable "
+                f"{spec!r} could not be resolved: {exc}"
+            ) from exc
 
-    def _read_filter_values(self, values_file: object, dataset_name: str) -> list:
+    def _read_filter_values(
+        self, values_file: object, dataset_name: str, expected_digest: object = None
+    ) -> list:
         """The accepted values a ``filter`` operation's ``values_file`` names.
 
         Reading happens here rather than in :meth:`Dataset.filter` so the
@@ -3254,6 +3247,12 @@ class EvalSession:
         values (so a map from id to whatever metadata produced the selection can
         be used as-is). Anything else is read as one value per line, with blanks
         and ``#`` comments skipped.
+
+        *expected_digest* is the ``values_digest`` pinned into the config at load
+        time. Re-checking it here closes the window between that read and this
+        one: the digest recorded next to a run's results then describes the bytes
+        the run actually selected on, not merely the bytes that were there when
+        the config was parsed.
         """
         if not isinstance(values_file, str):
             raise ValueError(
@@ -3263,14 +3262,21 @@ class EvalSession:
         # Resolved against the config that named it, and stored verbatim, so
         # ``effective_config.yaml`` stays portable across machines — the same
         # rule ``alignment.card`` follows.
-        path = Path(values_file)
-        if not path.is_absolute():
-            path = (self.config_path.parent / path).resolve()
+        path = resolve_values_path(values_file, self.config_path.parent)
         if not path.is_file():
             raise ValueError(
                 f"Dataset '{dataset_name}': 'filter' 'values_file' not found: {path}"
             )
-        text = path.read_text(encoding="utf-8")
+        data = path.read_bytes()
+        if expected_digest is not None:
+            digest = compute_values_digest(data)
+            if digest != expected_digest:
+                raise ValueError(
+                    f"Dataset '{dataset_name}': 'filter' 'values_file' {path} "
+                    f"changed while the run was starting ({DIGEST_KEY} pinned "
+                    f"{expected_digest}, the file is now {digest})"
+                )
+        text = data.decode("utf-8")
         if path.suffix == ".json":
             try:
                 payload = json.loads(text)

--- a/sieval/cli/leaderboard/session.py
+++ b/sieval/cli/leaderboard/session.py
@@ -26,11 +26,13 @@ from packaging.version import InvalidVersion, Version
 
 from sieval import __version__
 from sieval.cli._filter_spec import (
-    DIGEST_KEY,
+    VALUES_DIGEST_KEY,
     check_by,
+    check_by_digest,
     check_values_source,
     compute_values_digest,
-    pin_values_files,
+    key_function_spec,
+    pin_filter_digests,
     resolve_values_path,
 )
 from sieval.cli.leaderboard.card import AlignmentCard, load_card
@@ -1130,11 +1132,11 @@ class EvalSession:
             model=model_override,
             result_dir=result_dir_override,
         )
-        # Before the copy, so the digest reaches both the persisted view (and
+        # Before the copy, so the digests reach both the persisted view (and
         # therefore --resume) and the runtime view below. Not where the
         # operation runs: `arun` persists before `_prepare_execution`, so by
-        # then the comparison the digest exists for has already been made.
-        pin_values_files(reified, self.config_path.parent)
+        # then the comparison the digests exist for has already been made.
+        pin_filter_digests(reified, self.config_path.parent)
         self._reified_config: dict[str, Any] = copy.deepcopy(reified)
 
         # Runtime view = reified + the legacy external adapter (mutates
@@ -3105,13 +3107,13 @@ class EvalSession:
                     by_spec = op_args.get("by")
                     split = op_args.get("split", "test")
                     by = self._resolve_filter_by(by_spec, dataset_name)
-                    problems = check_values_source(op_args)
+                    problems = check_values_source(op_args) + check_by_digest(op_args)
                     if problems:
                         raise ValueError(f"Dataset '{dataset_name}': {problems[0]}")
                     values_file = op_args.get("values_file")
                     if values_file is not None:
                         value = self._read_filter_values(
-                            values_file, dataset_name, op_args.get(DIGEST_KEY)
+                            values_file, dataset_name, op_args.get(VALUES_DIGEST_KEY)
                         )
                     else:
                         value = op_args["value"]
@@ -3222,7 +3224,10 @@ class EvalSession:
             # cast, not a rebuild: `check_by` above has already established
             # every element is a `str`, which the checker cannot see.
             return cast(list[str], by_spec)
-        spec = cast(dict[str, str], by_spec)["callable"]
+        # `check_by` passed and the two column forms are out, so this is the
+        # callable form; `key_function_spec` is what read it there too.
+        spec = key_function_spec(by_spec)
+        assert spec is not None
         try:
             return resolve_key_function(spec)
         except (ValueError, ImportError, AttributeError) as exc:
@@ -3268,7 +3273,7 @@ class EvalSession:
             if digest != expected_digest:
                 raise ValueError(
                     f"Dataset '{dataset_name}': 'filter' 'values_file' {path} "
-                    f"changed while the run was starting ({DIGEST_KEY} pinned "
+                    f"changed while the run was starting ({VALUES_DIGEST_KEY} pinned "
                     f"{expected_digest}, the file is now {digest})"
                 )
         text = data.decode("utf-8")

--- a/sieval/cli/leaderboard/session.py
+++ b/sieval/cli/leaderboard/session.py
@@ -27,12 +27,14 @@ from packaging.version import InvalidVersion, Version
 from sieval import __version__
 from sieval.cli._filter_spec import (
     VALUES_DIGEST_KEY,
+    check_arg_names,
     check_by,
     check_by_digest,
     check_values_source,
     compute_values_digest,
     key_function_spec,
     pin_filter_digests,
+    relative_values_files,
     resolve_values_path,
 )
 from sieval.cli.leaderboard.card import AlignmentCard, load_card
@@ -3107,7 +3109,11 @@ class EvalSession:
                     by_spec = op_args.get("by")
                     split = op_args.get("split", "test")
                     by = self._resolve_filter_by(by_spec, dataset_name)
-                    problems = check_values_source(op_args) + check_by_digest(op_args)
+                    problems = (
+                        check_arg_names(op_args)
+                        + check_values_source(op_args)
+                        + check_by_digest(op_args)
+                    )
                     if problems:
                         raise ValueError(f"Dataset '{dataset_name}': {problems[0]}")
                     values_file = op_args.get("values_file")
@@ -3249,6 +3255,12 @@ class EvalSession:
         values (so a map from id to whatever metadata produced the selection can
         be used as-is). Anything else is one value per line, blanks and ``#``
         comments skipped.
+
+        Only the JSON *list* form carries a type: lines are strings, and so are
+        an object's keys, so a numeric id column needs the list. A mismatch is
+        loud rather than silent — every key misses, which raises — but the
+        message reads ``id=['0', '1']`` against ``present values: [0, 1]``, and
+        the difference is one pair of quotes.
 
         *expected_digest* is the ``values_digest`` pinned at load time.
         Re-checking it here closes the window between that read and this one, so
@@ -3646,17 +3658,25 @@ class EvalSession:
             allow_unicode=True,
             sort_keys=False,
         )
+        extra_lines = [
+            "Reproduce:",
+            "  sieval run <this file>",
+            "    — universal; re-launches auto-served models",
+            "  sieval eval <this file>",
+            "    — only when every model already has api_base",
+        ]
+        if relative := relative_values_files(self._reified_config):
+            extra_lines += [
+                "",
+                "Relative filter values_file: " + ", ".join(relative),
+                "  resolves against the config being run, so reproduce from",
+                "  beside the source config above, or make the path absolute.",
+            ]
         header = _format_comment_header(
             title="Persisted by",
             source_config=str(self.config_path.resolve()),
             invocation=self.invocation,
-            extra_lines=[
-                "Reproduce:",
-                "  sieval run <this file>",
-                "    — universal; re-launches auto-served models",
-                "  sieval eval <this file>",
-                "    — only when every model already has api_base",
-            ],
+            extra_lines=extra_lines,
         )
         await self._persist_yaml_with_strict_resume(
             target_name="effective_config.yaml",

--- a/sieval/cli/leaderboard/session.py
+++ b/sieval/cli/leaderboard/session.py
@@ -33,12 +33,13 @@ from sieval.cli.resolution import (
     is_task_model_role_sentinel,
     normalize_inline_model_binding,
     resolve_dataset_class,
+    resolve_key_function,
     resolve_task_class,
     validate_named_config_map,
     validate_task_config_args,
     validate_task_model_requirements,
 )
-from sieval.core.datasets import Dataset
+from sieval.core.datasets import Dataset, TFilterKey
 from sieval.core.models import ChatModel, GenModel, Model, SglangGenModel
 from sieval.core.models.capabilities import (
     CAPABILITY_KEYS,
@@ -3088,22 +3089,42 @@ class EvalSession:
                     logger.debug("Dataset '{}': repeated {} times", dataset_name, times)
 
                 case "filter":
-                    by = op_args.get("by")
+                    by_spec = op_args.get("by")
                     split = op_args.get("split", "test")
-                    if by is None:
+                    if by_spec is None:
                         raise ValueError(
                             f"Dataset '{dataset_name}': 'filter' requires 'by'"
                         )
+                    by = self._resolve_filter_by(by_spec, dataset_name)
                     # Presence, not truthiness: `value: 0` and `value: false` are
                     # legitimate column values and must not read as "omitted".
-                    if "value" not in op_args:
+                    has_value = "value" in op_args
+                    values_file = op_args.get("values_file")
+                    if has_value == (values_file is not None):
                         raise ValueError(
-                            f"Dataset '{dataset_name}': 'filter' requires 'value'"
+                            f"Dataset '{dataset_name}': 'filter' requires exactly "
+                            f"one of 'value' or 'values_file'"
                         )
-                    value = op_args["value"]
-                    dataset = dataset.filter(by, value, split=split)
+                    if values_file is not None:
+                        value = self._read_filter_values(values_file, dataset_name)
+                    else:
+                        value = op_args["value"]
+                    require_all = op_args.get("require_all", False)
+                    if not isinstance(require_all, bool):
+                        raise ValueError(
+                            f"Dataset '{dataset_name}': 'filter' 'require_all' "
+                            f"must be a boolean; got {require_all!r}"
+                        )
+                    dataset = dataset.filter(
+                        by, value, require_all=require_all, split=split
+                    )
                     logger.debug(
-                        "Dataset '{}': filtered to {}={}", dataset_name, by, value
+                        "Dataset '{}': filtered to {}={}",
+                        dataset_name,
+                        by_spec,
+                        f"<{len(value)} keys from {values_file}>"
+                        if values_file is not None
+                        else value,
                     )
 
                 case "stratified_sample":
@@ -3171,13 +3192,107 @@ class EvalSession:
                     )
 
                 case _:
+                    # Kept in step with `sieval.cli.validation._VALID_OPERATIONS`
+                    # by `test_the_unknown_operation_message_lists_every_valid
+                    # _operation`; this message silently omitted `filter` for as
+                    # long as `filter` had existed.
                     raise ValueError(
                         f"Dataset '{dataset_name}': Unknown operation '{op_name}'. "
-                        f"Valid operations: slice, shuffle, repeat, "
+                        f"Valid operations: filter, repeat, shuffle, slice, "
                         f"stratified_sample"
                     )
 
         return dataset
+
+    def _resolve_filter_by(self, by_spec: object, dataset_name: str) -> TFilterKey:
+        """A ``filter`` operation's ``by``, in any of its three config forms.
+
+        ``by: tag`` is a column, ``by: [tag, lang]`` a composite key, and
+        ``by: {callable: 'pkg.module.fn'}`` a derived one — the config spelling
+        of the callable a Python caller would pass directly, so the two surfaces
+        can express the same selections.
+        """
+        if isinstance(by_spec, str):
+            return by_spec
+        if isinstance(by_spec, list):
+            if not by_spec or not all(isinstance(col, str) for col in by_spec):
+                raise ValueError(
+                    f"Dataset '{dataset_name}': 'filter' 'by' as a list must "
+                    f"name one or more columns as strings; got {by_spec!r}"
+                )
+            return cast(list[str], by_spec)
+        if isinstance(by_spec, dict):
+            mapping = cast(dict[object, object], by_spec)
+            spec = mapping.get("callable")
+            if set(mapping) != {"callable"} or not isinstance(spec, str):
+                raise ValueError(
+                    f"Dataset '{dataset_name}': 'filter' 'by' as a mapping takes "
+                    f"exactly one key, 'callable', naming a dotted path; "
+                    f"got {by_spec!r}"
+                )
+            try:
+                return resolve_key_function(spec)
+            except (ValueError, ImportError, AttributeError) as exc:
+                raise ValueError(
+                    f"Dataset '{dataset_name}': 'filter' 'by' callable "
+                    f"{spec!r} could not be resolved: {exc}"
+                ) from exc
+        raise ValueError(
+            f"Dataset '{dataset_name}': 'filter' 'by' must be a column name, a "
+            f"list of column names, or {{callable: 'pkg.module.fn'}}; "
+            f"got {by_spec!r}"
+        )
+
+    def _read_filter_values(self, values_file: object, dataset_name: str) -> list:
+        """The accepted values a ``filter`` operation's ``values_file`` names.
+
+        Reading happens here rather than in :meth:`Dataset.filter` so the
+        transform never learns where a config lives: the same selection stays
+        expressible from Python by passing the list directly.
+
+        A ``.json`` file is a list of values, or an object whose *keys* are the
+        values (so a map from id to whatever metadata produced the selection can
+        be used as-is). Anything else is read as one value per line, with blanks
+        and ``#`` comments skipped.
+        """
+        if not isinstance(values_file, str):
+            raise ValueError(
+                f"Dataset '{dataset_name}': 'filter' 'values_file' must be a "
+                f"path; got {values_file!r}"
+            )
+        # Resolved against the config that named it, and stored verbatim, so
+        # ``effective_config.yaml`` stays portable across machines — the same
+        # rule ``alignment.card`` follows.
+        path = Path(values_file)
+        if not path.is_absolute():
+            path = (self.config_path.parent / path).resolve()
+        if not path.is_file():
+            raise ValueError(
+                f"Dataset '{dataset_name}': 'filter' 'values_file' not found: {path}"
+            )
+        text = path.read_text(encoding="utf-8")
+        if path.suffix == ".json":
+            try:
+                payload = json.loads(text)
+            except json.JSONDecodeError as exc:
+                raise ValueError(
+                    f"Dataset '{dataset_name}': 'filter' 'values_file' {path} is "
+                    f"not valid JSON: {exc}"
+                ) from exc
+            if isinstance(payload, dict):
+                return list(payload)
+            if not isinstance(payload, list):
+                raise ValueError(
+                    f"Dataset '{dataset_name}': 'filter' 'values_file' {path} "
+                    f"must hold a JSON list of values or an object keyed by "
+                    f"them; got {type(payload).__name__}"
+                )
+            return payload
+        return [
+            stripped
+            for line in text.splitlines()
+            if (stripped := line.strip()) and not stripped.startswith("#")
+        ]
 
     def _setup_tasks(self) -> None:
         """Initialize all tasks from config."""

--- a/sieval/cli/leaderboard/session.py
+++ b/sieval/cli/leaderboard/session.py
@@ -3257,10 +3257,9 @@ class EvalSession:
         comments skipped.
 
         Only the JSON *list* form carries a type: lines are strings, and so are
-        an object's keys, so a numeric id column needs the list. A mismatch is
-        loud rather than silent — every key misses, which raises — but the
-        message reads ``id=['0', '1']`` against ``present values: [0, 1]``, and
-        the difference is one pair of quotes.
+        an object's keys, so a numeric id column needs the list. A mismatch
+        raises rather than passing silently, but reads ``id=['0', '1']`` against
+        ``present values: [0, 1]`` — the difference is one pair of quotes.
 
         *expected_digest* is the ``values_digest`` pinned at load time.
         Re-checking it here closes the window between that read and this one, so
@@ -3272,8 +3271,6 @@ class EvalSession:
                 f"Dataset '{dataset_name}': 'filter' 'values_file' must be a "
                 f"path; got {values_file!r}"
             )
-        # Resolved against the config that named it, stored verbatim — the same
-        # rule `alignment.card` follows.
         path = resolve_values_path(values_file, self.config_path.parent)
         if not path.is_file():
             raise ValueError(

--- a/sieval/cli/resolution.py
+++ b/sieval/cli/resolution.py
@@ -19,7 +19,7 @@ import hashlib
 import importlib
 import inspect
 import json
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from types import MappingProxyType
@@ -267,19 +267,23 @@ def validate_task_model_requirements(
     return tuple(records)
 
 
-def load_class_from_path(class_path: str) -> type:
+def load_object_from_path(object_path: str, kind: str = "class") -> object:
     """
-    Load a class from a full module path like 'sieval.core.datasets.AIME2024Dataset'.
+    Load a module attribute from a full path like 'pkg.module.Name'.
+
+    *kind* only names the attribute in the error messages ("class", "function"),
+    so the same import mechanism can be reported in the caller's vocabulary.
     """
-    if "." not in class_path:
+    if "." not in object_path:
         raise ValueError(
-            f"Invalid class path: {class_path}. Expected format: 'module.ClassName'"
+            f"Invalid {kind} path: {object_path}. Expected format: "
+            f"'module.{'ClassName' if kind == 'class' else 'name'}'"
         )
 
-    module_name, class_name = class_path.rsplit(".", 1)
+    module_name, attribute_name = object_path.rsplit(".", 1)
     try:
         module = importlib.import_module(module_name)
-        return getattr(module, class_name)
+        return getattr(module, attribute_name)
     except ImportError as exc:
         if _is_missing_module_error(exc, module_name):
             raise ImportError(f"Could not import module '{module_name}'") from exc
@@ -287,8 +291,50 @@ def load_class_from_path(class_path: str) -> type:
         raise
     except AttributeError as e:
         raise AttributeError(
-            f"Module '{module_name}' has no class '{class_name}'"
+            f"Module '{module_name}' has no {kind} '{attribute_name}'"
         ) from e
+
+
+def load_class_from_path(class_path: str) -> type:
+    """
+    Load a class from a full module path like 'sieval.core.datasets.AIME2024Dataset'.
+    """
+    return cast(type, load_object_from_path(class_path, "class"))
+
+
+def resolve_key_function(spec: str) -> Callable[..., object]:
+    """Resolve ``'pkg.module.function'`` to the callable it names.
+
+    The config counterpart of handing a Python caller a function directly —
+    ``dataset.filter(by=my_key, ...)`` in Python, ``by: {callable:
+    'pkg.module.my_key'}`` in YAML — so neither surface can express a selection
+    the other cannot. YAML cannot hold a function body, so it names one, exactly
+    as ``class:`` names a class rather than defining it.
+
+    A full dotted path is required: unlike a dataset or task class there is no
+    registry of key functions to search a bare name in, and silently importing
+    ``my_key`` from wherever it first appeared would make the resolved function
+    depend on import order.
+    """
+    if not isinstance(spec, str):
+        raise ValueError(f"Callable reference must be a string, got {spec!r}")
+    if spec.startswith("."):
+        raise ValueError(
+            f"Relative import syntax is not supported: '{spec}'. "
+            f"Use a full path ('pkg.module.my_key')"
+        )
+    if "." not in spec:
+        raise ValueError(
+            f"Invalid function path: {spec}. A callable must be given as a full "
+            f"path ('pkg.module.{spec}'), since there is no module to search a "
+            f"bare name in"
+        )
+    resolved = load_object_from_path(spec, "function")
+    if not callable(resolved):
+        raise ValueError(
+            f"'{spec}' resolved to {type(resolved).__name__}, not a callable"
+        )
+    return cast(Callable[..., object], resolved)
 
 
 def load_class_from_name(name: str, search_modules: list[str]) -> type:

--- a/sieval/cli/resolution.py
+++ b/sieval/cli/resolution.py
@@ -299,7 +299,12 @@ def load_class_from_path(class_path: str) -> type:
     """
     Load a class from a full module path like 'sieval.core.datasets.AIME2024Dataset'.
     """
-    return cast(type, load_object_from_path(class_path, "class"))
+    loaded = load_object_from_path(class_path, "class")
+    if not isinstance(loaded, type):
+        raise ValueError(
+            f"'{class_path}' resolved to {type(loaded).__name__}, not a class"
+        )
+    return loaded
 
 
 def resolve_key_function(spec: str) -> Callable[..., object]:
@@ -334,7 +339,7 @@ def resolve_key_function(spec: str) -> Callable[..., object]:
         raise ValueError(
             f"'{spec}' resolved to {type(resolved).__name__}, not a callable"
         )
-    return cast(Callable[..., object], resolved)
+    return resolved
 
 
 def load_class_from_name(name: str, search_modules: list[str]) -> type:

--- a/sieval/cli/resolution.py
+++ b/sieval/cli/resolution.py
@@ -310,16 +310,14 @@ def load_class_from_path(class_path: str) -> type:
 def resolve_key_function(spec: str) -> Callable[..., object]:
     """Resolve ``'pkg.module.function'`` to the callable it names.
 
-    The config counterpart of handing a Python caller a function directly —
+    The config counterpart of passing a function directly —
     ``dataset.filter(by=my_key, ...)`` in Python, ``by: {callable:
-    'pkg.module.my_key'}`` in YAML — so neither surface can express a selection
-    the other cannot. YAML cannot hold a function body, so it names one, exactly
-    as ``class:`` names a class rather than defining it.
+    'pkg.module.my_key'}`` in YAML. YAML cannot hold a function body, so it
+    names one, exactly as ``class:`` names a class rather than defining it.
 
     A full dotted path is required: unlike a dataset or task class there is no
-    registry of key functions to search a bare name in, and silently importing
-    ``my_key`` from wherever it first appeared would make the resolved function
-    depend on import order.
+    registry to search a bare name in, and importing ``my_key`` from wherever
+    it first appeared would make the resolved function depend on import order.
     """
     if not isinstance(spec, str):
         raise ValueError(f"Callable reference must be a string, got {spec!r}")

--- a/sieval/cli/validation.py
+++ b/sieval/cli/validation.py
@@ -18,6 +18,7 @@ from typing import Any, NotRequired, TypedDict, cast
 
 import yaml
 
+from sieval.cli._filter_spec import check_by, check_values_source
 from sieval.cli.leaderboard.session import RootConfigDict
 from sieval.cli.resolution import (
     binding_resource_argument_paths,
@@ -415,48 +416,19 @@ def _validate_filter_args(
     imports are all questions for the session, which has the dataset and the
     config's directory. What is worth catching here is a config that could not
     run whatever the data turned out to be.
-    """
-    by = op_args.get("by")
-    if by is None:
-        result.errors.append(f"Dataset '{dataset_name}': 'filter' requires 'by'")
-    elif isinstance(by, list):
-        if not by or not all(isinstance(col, str) for col in by):
-            result.errors.append(
-                f"Dataset '{dataset_name}': 'filter' 'by' as a list must name "
-                f"one or more columns as strings; got {by!r}"
-            )
-    elif isinstance(by, dict):
-        if set(by) != {"callable"} or not isinstance(by.get("callable"), str):
-            result.errors.append(
-                f"Dataset '{dataset_name}': 'filter' 'by' as a mapping takes "
-                f"exactly one key, 'callable', naming a dotted path; got {by!r}"
-            )
-    elif not isinstance(by, str):
-        result.errors.append(
-            f"Dataset '{dataset_name}': 'filter' 'by' must be a column name, a "
-            f"list of column names, or {{callable: 'pkg.module.fn'}}; got {by!r}"
-        )
 
-    # Presence, not truthiness: `value: 0` and `value: false` are legitimate
-    # column values and must not read as "omitted".
-    has_value = "value" in op_args
-    has_file = op_args.get("values_file") is not None
-    if has_value == has_file:
-        result.errors.append(
-            f"Dataset '{dataset_name}': 'filter' requires exactly one of "
-            f"'value' or 'values_file'"
-        )
-    if has_file and not isinstance(op_args["values_file"], str):
-        result.errors.append(
-            f"Dataset '{dataset_name}': 'filter' 'values_file' must be a path; "
-            f"got {op_args['values_file']!r}"
-        )
-    require_all = op_args.get("require_all")
-    if require_all is not None and not isinstance(require_all, bool):
-        result.errors.append(
-            f"Dataset '{dataset_name}': 'filter' 'require_all' must be a "
-            f"boolean; got {require_all!r}"
-        )
+    The questions themselves live in :mod:`sieval.cli._filter_spec`, shared with
+    the session that applies the operation. The difference between the surfaces
+    is what they do with an answer: every problem is collected here, where the
+    session raises on the first.
+    """
+    problem = check_by(op_args.get("by"))
+    if problem is not None:
+        result.errors.append(f"Dataset '{dataset_name}': {problem}")
+    result.errors.extend(
+        f"Dataset '{dataset_name}': {problem}"
+        for problem in check_values_source(op_args)
+    )
 
 
 def _validate_tasks(cfg: dict, result: ValidationResult) -> None:

--- a/sieval/cli/validation.py
+++ b/sieval/cli/validation.py
@@ -18,7 +18,7 @@ from typing import Any, NotRequired, TypedDict, cast
 
 import yaml
 
-from sieval.cli._filter_spec import check_by, check_values_source
+from sieval.cli._filter_spec import check_by, check_by_digest, check_values_source
 from sieval.cli.leaderboard.session import RootConfigDict
 from sieval.cli.resolution import (
     binding_resource_argument_paths,
@@ -425,7 +425,7 @@ def _validate_filter_args(
         result.errors.append(f"Dataset '{dataset_name}': {problem}")
     result.errors.extend(
         f"Dataset '{dataset_name}': {problem}"
-        for problem in check_values_source(op_args)
+        for problem in check_values_source(op_args) + check_by_digest(op_args)
     )
 
 

--- a/sieval/cli/validation.py
+++ b/sieval/cli/validation.py
@@ -417,13 +417,9 @@ def _validate_filter_args(
 ) -> None:
     """Shape-check a ``filter`` operation.
 
-    Shape only — whether a column exists, a file is readable or a dotted path
-    imports are questions for the session, which has the dataset and the
-    config's directory. What is worth catching here is a config that could not
-    run whatever the data turned out to be.
-
-    The questions live in :mod:`sieval.cli._filter_spec`; this surface collects
-    every problem where the session raises on the first.
+    The checks are :mod:`sieval.cli._filter_spec`'s, which says what each one
+    answers and what it leaves to the session. What is worth catching *here* is
+    a config that could not run whatever the data turned out to be.
     """
     problem = check_by(op_args.get("by"))
     if problem is not None:

--- a/sieval/cli/validation.py
+++ b/sieval/cli/validation.py
@@ -402,6 +402,61 @@ def _validate_operations(
                 f"Dataset '{dataset_name}': operation '{op_name}' "
                 f"args must be a dict or null"
             )
+        elif op_name == "filter" and isinstance(op_args, dict):
+            _validate_filter_args(op_args, dataset_name, result)
+
+
+def _validate_filter_args(
+    op_args: dict, dataset_name: str, result: ValidationResult
+) -> None:
+    """Shape-check a ``filter`` operation.
+
+    Shape only: whether a column exists, a file is readable or a dotted path
+    imports are all questions for the session, which has the dataset and the
+    config's directory. What is worth catching here is a config that could not
+    run whatever the data turned out to be.
+    """
+    by = op_args.get("by")
+    if by is None:
+        result.errors.append(f"Dataset '{dataset_name}': 'filter' requires 'by'")
+    elif isinstance(by, list):
+        if not by or not all(isinstance(col, str) for col in by):
+            result.errors.append(
+                f"Dataset '{dataset_name}': 'filter' 'by' as a list must name "
+                f"one or more columns as strings; got {by!r}"
+            )
+    elif isinstance(by, dict):
+        if set(by) != {"callable"} or not isinstance(by.get("callable"), str):
+            result.errors.append(
+                f"Dataset '{dataset_name}': 'filter' 'by' as a mapping takes "
+                f"exactly one key, 'callable', naming a dotted path; got {by!r}"
+            )
+    elif not isinstance(by, str):
+        result.errors.append(
+            f"Dataset '{dataset_name}': 'filter' 'by' must be a column name, a "
+            f"list of column names, or {{callable: 'pkg.module.fn'}}; got {by!r}"
+        )
+
+    # Presence, not truthiness: `value: 0` and `value: false` are legitimate
+    # column values and must not read as "omitted".
+    has_value = "value" in op_args
+    has_file = op_args.get("values_file") is not None
+    if has_value == has_file:
+        result.errors.append(
+            f"Dataset '{dataset_name}': 'filter' requires exactly one of "
+            f"'value' or 'values_file'"
+        )
+    if has_file and not isinstance(op_args["values_file"], str):
+        result.errors.append(
+            f"Dataset '{dataset_name}': 'filter' 'values_file' must be a path; "
+            f"got {op_args['values_file']!r}"
+        )
+    require_all = op_args.get("require_all")
+    if require_all is not None and not isinstance(require_all, bool):
+        result.errors.append(
+            f"Dataset '{dataset_name}': 'filter' 'require_all' must be a "
+            f"boolean; got {require_all!r}"
+        )
 
 
 def _validate_tasks(cfg: dict, result: ValidationResult) -> None:

--- a/sieval/cli/validation.py
+++ b/sieval/cli/validation.py
@@ -412,15 +412,13 @@ def _validate_filter_args(
 ) -> None:
     """Shape-check a ``filter`` operation.
 
-    Shape only: whether a column exists, a file is readable or a dotted path
-    imports are all questions for the session, which has the dataset and the
+    Shape only — whether a column exists, a file is readable or a dotted path
+    imports are questions for the session, which has the dataset and the
     config's directory. What is worth catching here is a config that could not
     run whatever the data turned out to be.
 
-    The questions themselves live in :mod:`sieval.cli._filter_spec`, shared with
-    the session that applies the operation. The difference between the surfaces
-    is what they do with an answer: every problem is collected here, where the
-    session raises on the first.
+    The questions live in :mod:`sieval.cli._filter_spec`; this surface collects
+    every problem where the session raises on the first.
     """
     problem = check_by(op_args.get("by"))
     if problem is not None:

--- a/sieval/cli/validation.py
+++ b/sieval/cli/validation.py
@@ -18,7 +18,12 @@ from typing import Any, NotRequired, TypedDict, cast
 
 import yaml
 
-from sieval.cli._filter_spec import check_by, check_by_digest, check_values_source
+from sieval.cli._filter_spec import (
+    check_arg_names,
+    check_by,
+    check_by_digest,
+    check_values_source,
+)
 from sieval.cli.leaderboard.session import RootConfigDict
 from sieval.cli.resolution import (
     binding_resource_argument_paths,
@@ -425,7 +430,9 @@ def _validate_filter_args(
         result.errors.append(f"Dataset '{dataset_name}': {problem}")
     result.errors.extend(
         f"Dataset '{dataset_name}': {problem}"
-        for problem in check_values_source(op_args) + check_by_digest(op_args)
+        for problem in check_arg_names(op_args)
+        + check_values_source(op_args)
+        + check_by_digest(op_args)
     )
 
 

--- a/sieval/core/datasets/__init__.py
+++ b/sieval/core/datasets/__init__.py
@@ -1,4 +1,4 @@
-from .dataset import Dataset
+from .dataset import Dataset, TFilterKey
 from .meta import (
     Category,
     DatasetMeta,
@@ -11,5 +11,6 @@ __all__ = [
     "Dataset",
     "DatasetMeta",
     "Level1Category",
+    "TFilterKey",
     "sieval_dataset",
 ]

--- a/sieval/core/datasets/dataset.py
+++ b/sieval/core/datasets/dataset.py
@@ -6,7 +6,7 @@ import math
 import random
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterator, Mapping
-from typing import Literal, Self, cast, overload
+from typing import Literal, Self, overload
 
 from datasets import Dataset as HFDataset
 from datasets import DatasetDict as HFDatasetDict
@@ -536,11 +536,14 @@ def _derive_filter_keys(
         # A callable can read anything, so the rows must be materialised. The
         # column paths below read only the columns named, which is why they are
         # kept separate rather than routed through this one.
-        key_fn = cast(Callable[[Mapping[str, object]], object], by)
+        # by is the callable form here: `_filter_columns` returns None for
+        # nothing else. Excluding the column forms narrows to it; `callable(by)`
+        # does not, since a str subclass could carry a `__call__` too.
+        assert not isinstance(by, str | list)
         keys: list[object] = []
         for index, row in enumerate(hf):
             try:
-                keys.append(key_fn(row))
+                keys.append(by(row))
             except Exception as exc:
                 # `by` may name any importable function, so its failure is a
                 # config error, not an internal one — say which row and which

--- a/sieval/core/datasets/dataset.py
+++ b/sieval/core/datasets/dataset.py
@@ -118,38 +118,28 @@ class Dataset[TSample](ABC):
         *by* says how to read a row's key, in three forms:
 
         * a **column name** — the key is that column's value;
-        * a **list of column names** — the key is the tuple of their values, so
-          rows are selected on a composite identity no single column carries
-          (the same ``str | list[str]`` spelling ``stratified_sample`` uses, and
-          as there a single name still yields a scalar key, not a 1-tuple);
+        * a **list of column names** — the key is the tuple of their values,
+          selecting on a composite identity no single column carries;
         * a **callable** ``row -> key`` — the key is derived rather than stored,
-          which is what selecting on a content hash, a normalised id or a
-          concatenation of fields needs. It is handed the whole row as a mapping.
-          Driven from a config file the derived key must be a **scalar**:
+          which is what a content hash, a normalised id or a concatenation of
+          fields needs. Driven from a config the key must be a **scalar**:
           neither YAML nor JSON has a tuple, and the list each writes instead is
-          unhashable, so a key function written for ``by: {callable: ...}``
-          should join its parts into a string rather than return a tuple. From
-          Python, where the accepted values are passed directly, a tuple is fine.
+          unhashable. From Python a tuple is fine.
 
         *value* is one accepted key, or a list/tuple/set of them (membership
         test). A string is always one key, never a set of characters. Under a
         composite *by* each accepted key must itself be a sequence of the same
         length — ``value: [[a, b]]`` is one two-column key, ``value: [a, b]`` is
-        two one-column keys — so the two readings of a bare list can never be
-        confused for one another.
+        two one-column keys.
 
         Relative order among the kept rows is preserved, so a caller that
         narrows to one category gets the same sequence — and therefore the same
         sample ids — it would have got by loading that category alone.
 
-        *require_all* additionally demands that **every** requested key match at
-        least one row. It is off by default (a request may legitimately
-        over-cover a split), but any unmatched key is warned about, because the
-        case it guards is quiet: a stored list of ids is a pointer into a
-        dataset that can move under it, and four ids going stale out of a
-        thousand is a run that reports a number for a set nobody selected. Note
-        it is a check on the *keys*, not on the row count — one key may match
-        many rows (a session expanded into turns), and that is not an error.
+        *require_all* raises on a requested key that matches no row, where the
+        default only warns; a request may legitimately over-cover a split. It
+        checks the *keys*, not the row count — one key matching many rows is
+        not an error.
 
         Returns ``self`` unchanged if *split* is absent or empty. Raises if *by*
         names a column that does not exist, or if **nothing** matches: an empty
@@ -168,23 +158,22 @@ class Dataset[TSample](ABC):
         keys = _derive_filter_keys(hf, by, cols)
         raw = list(value) if isinstance(value, list | tuple | set) else [value]
         if isinstance(value, set):
-            # A set has no order of its own, so give it one: the messages below
-            # quote the requested keys, and an unordered quote would differ
-            # between runs of the same selection. Keys of mixed types are not
-            # orderable — those keep iteration order rather than failing here.
+            # A set has no order of its own; give it one, so the messages below
+            # quote the same keys in the same order across runs of the same
+            # selection. Mixed-type keys are not orderable — those keep
+            # iteration order rather than failing here.
             with contextlib.suppress(TypeError):
                 raw = sorted(raw)
         # Composite keys are tupled *before* the dedup below, which hashes them.
         if cols is not None and len(cols) > 1:
             raw = [_filter_composite_key(v, len(cols), label) for v in raw]
-        # Ordered and deduped: the set drives membership, the list fixes the
-        # order the two messages below quote — as the caller wrote it for a
-        # list or tuple, sorted for a set.
+        # Deduped but ordered: the set drives membership, the list fixes the
+        # order the messages below quote.
         try:
             requested = list(dict.fromkeys(raw))
         except TypeError as exc:
-            # The one shape that reaches here from a config file: a callable
-            # key whose accepted values were written as JSON/YAML lists.
+            # The one shape that reaches here from a config: a callable key
+            # whose accepted values were written as JSON/YAML lists.
             hint = (
                 " (a callable key driven from a config file must take scalar "
                 "accepted values — see the 'by' callable form in the docstring)"
@@ -506,8 +495,7 @@ def _filter_columns(by: TFilterKey, column_names: list[str]) -> list[str] | None
         raise ValueError(f"filter: 'by' must name columns as strings; got {by!r}")
     missing = [col for col in cols if col not in column_names]
     if missing:
-        # Singular wording for the single-column case, which is the overwhelming
-        # majority of calls and whose message predates the composite form.
+        # Unchanged wording for the single-column case, which is most calls.
         if isinstance(by, str):
             raise ValueError(
                 f"filter: column {by!r} not found; available columns: {column_names}"
@@ -533,12 +521,10 @@ def _derive_filter_keys(
 ) -> list[object]:
     """One key per row of *hf*, in row order."""
     if cols is None:
-        # A callable can read anything, so the rows must be materialised. The
-        # column paths below read only the columns named, which is why they are
-        # kept separate rather than routed through this one.
-        # by is the callable form here: `_filter_columns` returns None for
-        # nothing else. Excluding the column forms narrows to it; `callable(by)`
-        # does not, since a str subclass could carry a `__call__` too.
+        # A callable can read anything, so the rows must be materialised; the
+        # column paths below read only the columns named. `cols is None` is the
+        # callable form and nothing else — but `callable(by)` would not narrow
+        # to it, since a str subclass could carry `__call__`.
         assert not isinstance(by, str | list)
         keys: list[object] = []
         for index, row in enumerate(hf):
@@ -546,8 +532,8 @@ def _derive_filter_keys(
                 keys.append(by(row))
             except Exception as exc:
                 # `by` may name any importable function, so its failure is a
-                # config error, not an internal one — say which row and which
-                # function rather than letting a bare KeyError surface.
+                # config error — name the row and the function rather than
+                # letting a bare KeyError surface.
                 raise ValueError(
                     f"filter: key function {_filter_key_label(by)} raised on "
                     f"row {index} of {len(hf)}: {type(exc).__name__}: {exc}"
@@ -563,10 +549,9 @@ def _derive_filter_keys(
 def _filter_composite_key(value: object, n_cols: int, label: str) -> tuple:
     """*value* as a composite key of *n_cols* parts.
 
-    Rejects a scalar rather than promoting it, because the alternative is the
-    silent misreading this exists to prevent: under a two-column *by*,
-    ``[a, b]`` is two keys and ``[[a, b]]`` is one, and a scalar arriving here
-    means the caller wrote the first while meaning the second.
+    Rejects a scalar rather than promoting it: under a two-column *by*,
+    ``[a, b]`` is two keys and ``[[a, b]]`` is one, so a scalar here means the
+    caller wrote the first while meaning the second.
     """
     if isinstance(value, str) or not isinstance(value, list | tuple):
         raise ValueError(

--- a/sieval/core/datasets/dataset.py
+++ b/sieval/core/datasets/dataset.py
@@ -142,10 +142,10 @@ class Dataset[TSample](ABC):
         not an error.
 
         Returns ``self`` unchanged if *split* is absent or empty, warning that
-        nothing was filtered — a misspelled *split* otherwise keeps every row
-        while looking like a selection, which is the one failure here that
-        reports a plausible number. *require_all* raises on it: a caller who
-        asks for every key to land is not asking about one split in particular.
+        nothing was filtered: a misspelled *split* leaves the real one whole, so
+        this is the one failure here that keeps every row while still reporting
+        a plausible number. *require_all* raises on it — asking for every key to
+        land is not a question about one split.
 
         Raises if *by* names a column that does not exist, or if **nothing**
         matches: an empty result is a misspelled *value* far more often than an
@@ -502,12 +502,9 @@ class Dataset[TSample](ABC):
 
 
 def _report_nothing_filtered(detail: str, *, require_all: bool) -> None:
-    """Report a ``filter`` that could not run, having no split to run on.
+    """Report a ``filter`` left with no split to run on.
 
-    Silence is the wrong default here even though returning *self* is the right
-    behaviour: every other way ``filter`` fails leaves too few rows, which shows
-    up downstream, while this one leaves them all — a run scored on the whole
-    split while its config says otherwise.
+    Why this is not silent is in :meth:`Dataset.filter`, where a caller reads it.
     """
     detail = f"{detail}, so nothing was filtered"
     if require_all:

--- a/sieval/core/datasets/dataset.py
+++ b/sieval/core/datasets/dataset.py
@@ -141,16 +141,29 @@ class Dataset[TSample](ABC):
         checks the *keys*, not the row count — one key matching many rows is
         not an error.
 
-        Returns ``self`` unchanged if *split* is absent or empty. Raises if *by*
-        names a column that does not exist, or if **nothing** matches: an empty
-        result is a misspelled *value* far more often than an intended
-        selection, and it would otherwise surface as a run that silently scores
-        zero samples.
+        Returns ``self`` unchanged if *split* is absent or empty, warning that
+        nothing was filtered — a misspelled *split* otherwise keeps every row
+        while looking like a selection, which is the one failure here that
+        reports a plausible number. *require_all* raises on it: a caller who
+        asks for every key to land is not asking about one split in particular.
+
+        Raises if *by* names a column that does not exist, or if **nothing**
+        matches: an empty result is a misspelled *value* far more often than an
+        intended selection, and it would otherwise surface as a run that
+        silently scores zero samples.
         """
         if split not in self._dataset_dict:
+            _report_nothing_filtered(
+                f"filter: split {split!r} is not in this dataset "
+                f"(have: {sorted(self._dataset_dict)})",
+                require_all=require_all,
+            )
             return self
         hf = self._dataset_dict[split]
         if len(hf) == 0:
+            _report_nothing_filtered(
+                f"filter: split {split!r} is empty", require_all=require_all
+            )
             return self
 
         cols = _filter_columns(by, hf.column_names)
@@ -202,8 +215,16 @@ class Dataset[TSample](ABC):
             present = list(dict.fromkeys(keys))
             shown = present[:10]
             suffix = f", ... ({len(present)} distinct)" if len(present) > 10 else ""
+            # A `values_file` puts thousands of keys in `value`, and no overlap
+            # at all is exactly what a stale id list produces — truncate it the
+            # way the unmatched warning below already truncates its own.
+            asked = (
+                f"{requested[:10]}, ... ({len(requested)} requested)"
+                if len(requested) > 10
+                else repr(value)
+            )
             raise ValueError(
-                f"filter: no row of split {split!r} has {label}={value!r}; "
+                f"filter: no row of split {split!r} has {label}={asked}; "
                 f"present values: {shown}{suffix}"
             )
 
@@ -478,6 +499,20 @@ class Dataset[TSample](ABC):
             raise ValueError(f"Unknown mode: {mode}.")
 
         return iter(selected_ds) if lazy else list(selected_ds)
+
+
+def _report_nothing_filtered(detail: str, *, require_all: bool) -> None:
+    """Report a ``filter`` that could not run, having no split to run on.
+
+    Silence is the wrong default here even though returning *self* is the right
+    behaviour: every other way ``filter`` fails leaves too few rows, which shows
+    up downstream, while this one leaves them all — a run scored on the whole
+    split while its config says otherwise.
+    """
+    detail = f"{detail}, so nothing was filtered"
+    if require_all:
+        raise ValueError(detail)
+    logger.warning(detail)
 
 
 def _filter_columns(by: TFilterKey, column_names: list[str]) -> list[str] | None:

--- a/sieval/core/datasets/dataset.py
+++ b/sieval/core/datasets/dataset.py
@@ -4,8 +4,8 @@ import copy
 import math
 import random
 from abc import ABC, abstractmethod
-from collections.abc import Iterator
-from typing import Literal, Self, overload
+from collections.abc import Callable, Iterator, Mapping
+from typing import Literal, Self, cast, overload
 
 from datasets import Dataset as HFDataset
 from datasets import DatasetDict as HFDatasetDict
@@ -14,6 +14,10 @@ from loguru import logger
 from sieval.core.utils.hf import maybe_resolve_hf_path
 
 TRetrieveStrategy = Literal["random", "fixed"]
+
+#: How :meth:`Dataset.filter` reads a row's key: a column name, a list of column
+#: names forming a composite key, or a callable deriving one from the whole row.
+TFilterKey = str | list[str] | Callable[[Mapping[str, object]], object]
 
 
 class Dataset[TSample](ABC):
@@ -102,23 +106,50 @@ class Dataset[TSample](ABC):
 
     def filter(
         self,
-        by: str,
+        by: TFilterKey,
         value: object,
         *,
+        require_all: bool = False,
         split: str = "test",
     ) -> Self:
-        """Return a shallow clone of *split* keeping rows whose *by* column matches.
+        """Return a shallow clone of *split* keeping rows whose key is accepted.
 
-        *value* is one accepted value, or a list/tuple/set of them (membership
-        test). A string is always one value, never a set of characters. Relative
-        order among the kept rows is preserved, so a caller that narrows to one
-        category gets the same sequence — and therefore the same sample ids — it
-        would have got by loading that category alone.
+        *by* says how to read a row's key, in three forms:
+
+        * a **column name** — the key is that column's value;
+        * a **list of column names** — the key is the tuple of their values, so
+          rows are selected on a composite identity no single column carries
+          (the same ``str | list[str]`` spelling ``stratified_sample`` uses, and
+          as there a single name still yields a scalar key, not a 1-tuple);
+        * a **callable** ``row -> key`` — the key is derived rather than stored,
+          which is what selecting on a content hash, a normalised id or a
+          concatenation of fields needs. It is handed the whole row as a mapping.
+
+        *value* is one accepted key, or a list/tuple/set of them (membership
+        test). A string is always one key, never a set of characters. Under a
+        composite *by* each accepted key must itself be a sequence of the same
+        length — ``value: [[a, b]]`` is one two-column key, ``value: [a, b]`` is
+        two one-column keys — so the two readings of a bare list can never be
+        confused for one another.
+
+        Relative order among the kept rows is preserved, so a caller that
+        narrows to one category gets the same sequence — and therefore the same
+        sample ids — it would have got by loading that category alone.
+
+        *require_all* additionally demands that **every** requested key match at
+        least one row. It is off by default (a request may legitimately
+        over-cover a split), but any unmatched key is warned about, because the
+        case it guards is quiet: a stored list of ids is a pointer into a
+        dataset that can move under it, and four ids going stale out of a
+        thousand is a run that reports a number for a set nobody selected. Note
+        it is a check on the *keys*, not on the row count — one key may match
+        many rows (a session expanded into turns), and that is not an error.
 
         Returns ``self`` unchanged if *split* is absent or empty. Raises if *by*
-        is not a column, or if **nothing** matches: an empty result is a
-        misspelled *value* far more often than an intended selection, and it
-        would otherwise surface as a run that silently scores zero samples.
+        names a column that does not exist, or if **nothing** matches: an empty
+        result is a misspelled *value* far more often than an intended
+        selection, and it would otherwise surface as a run that silently scores
+        zero samples.
         """
         if split not in self._dataset_dict:
             return self
@@ -126,24 +157,62 @@ class Dataset[TSample](ABC):
         if len(hf) == 0:
             return self
 
-        if by not in hf.column_names:
+        cols = _filter_columns(by, hf.column_names)
+        label = _filter_key_label(by)
+        keys = _derive_filter_keys(hf, by, cols)
+        raw = list(value) if isinstance(value, list | tuple | set) else [value]
+        # Composite keys are tupled *before* the dedup below, which hashes them.
+        if cols is not None and len(cols) > 1:
+            raw = [_filter_composite_key(v, len(cols), label) for v in raw]
+        # Ordered and deduped: the set drives membership, the list keeps the
+        # order the caller wrote for the two messages below, so a diagnostic
+        # never depends on set iteration order.
+        try:
+            requested = list(dict.fromkeys(raw))
+        except TypeError as exc:
             raise ValueError(
-                f"filter: column {by!r} not found; available columns: {hf.column_names}"
+                f"filter: accepted values must be hashable; {exc}"
+            ) from exc
+        if not requested:
+            raise ValueError(
+                f"filter: no accepted values given for {label}; an empty "
+                "selection would keep no rows at all"
             )
+        accepted = set(requested)
 
-        accepted = set(value) if isinstance(value, list | tuple | set) else {value}
-        kept = hf.filter(lambda v: v in accepted, input_columns=by)
-        if len(kept) == 0:
-            present = hf.unique(by)
+        try:
+            kept_indices = [i for i, key in enumerate(keys) if key in accepted]
+        except TypeError as exc:
+            raise ValueError(
+                f"filter: {label} produced a key that cannot be compared for "
+                f"membership ({exc}); keys must be hashable"
+            ) from exc
+
+        if not kept_indices:
+            present = list(dict.fromkeys(keys))
             shown = present[:10]
             suffix = f", ... ({len(present)} distinct)" if len(present) > 10 else ""
             raise ValueError(
-                f"filter: no row of split {split!r} has {by}={value!r}; "
+                f"filter: no row of split {split!r} has {label}={value!r}; "
                 f"present values: {shown}{suffix}"
             )
 
+        matched = {keys[i] for i in kept_indices}
+        unmatched = [key for key in requested if key not in matched]
+        if unmatched:
+            shown = unmatched[:10]
+            suffix = ", ..." if len(unmatched) > 10 else ""
+            detail = (
+                f"filter: {len(unmatched)} of {len(requested)} requested keys "
+                f"match no row of split {split!r} on {label}; "
+                f"unmatched: {shown}{suffix}"
+            )
+            if require_all:
+                raise ValueError(detail)
+            logger.warning(detail)
+
         new_dict = HFDatasetDict(self.dataset_dict)
-        new_dict[split] = kept
+        new_dict[split] = hf.select(kept_indices)
         return self._clone_with_new_dict(new_dict)
 
     def stratified_sample(
@@ -399,3 +468,79 @@ class Dataset[TSample](ABC):
             raise ValueError(f"Unknown mode: {mode}.")
 
         return iter(selected_ds) if lazy else list(selected_ds)
+
+
+def _filter_columns(by: TFilterKey, column_names: list[str]) -> list[str] | None:
+    """The columns *by* reads, or ``None`` when it is a callable.
+
+    Callables are handed the whole row, so there is nothing to check up front —
+    the columns they touch are not knowable without running them.
+    """
+    if callable(by):
+        return None
+    cols = [by] if isinstance(by, str) else list(by)
+    if not cols:
+        raise ValueError("filter: 'by' must name at least one column")
+    if not all(isinstance(col, str) for col in cols):
+        raise ValueError(f"filter: 'by' must name columns as strings; got {by!r}")
+    missing = [col for col in cols if col not in column_names]
+    if missing:
+        # Singular wording for the single-column case, which is the overwhelming
+        # majority of calls and whose message predates the composite form.
+        if isinstance(by, str):
+            raise ValueError(
+                f"filter: column {by!r} not found; available columns: {column_names}"
+            )
+        raise ValueError(
+            f"filter: column(s) {missing!r} not found; "
+            f"available columns: {column_names}"
+        )
+    return cols
+
+
+def _filter_key_label(by: TFilterKey) -> str:
+    """How *by* is named in diagnostics."""
+    if callable(by):
+        return f"{getattr(by, '__qualname__', None) or type(by).__name__}()"
+    if isinstance(by, str):
+        return by
+    return f"({', '.join(by)})"
+
+
+def _derive_filter_keys(
+    hf: HFDataset, by: TFilterKey, cols: list[str] | None
+) -> list[object]:
+    """One key per row of *hf*, in row order."""
+    if cols is None:
+        # A callable can read anything, so the rows must be materialised. The
+        # column paths below read only the columns named, which is why they are
+        # kept separate rather than routed through this one.
+        key_fn = cast(Callable[[Mapping[str, object]], object], by)
+        return [key_fn(row) for row in hf]
+    if len(cols) == 1:
+        return list(hf[cols[0]])
+    column_data = [hf[col] for col in cols]
+    return [tuple(col[index] for col in column_data) for index in range(len(hf))]
+
+
+def _filter_composite_key(value: object, n_cols: int, label: str) -> tuple:
+    """*value* as a composite key of *n_cols* parts.
+
+    Rejects a scalar rather than promoting it, because the alternative is the
+    silent misreading this exists to prevent: under a two-column *by*,
+    ``[a, b]`` is two keys and ``[[a, b]]`` is one, and a scalar arriving here
+    means the caller wrote the first while meaning the second.
+    """
+    if isinstance(value, str) or not isinstance(value, list | tuple):
+        raise ValueError(
+            f"filter: {label} is a composite key, so each accepted value must "
+            f"be a sequence of its {n_cols} parts (e.g. value: [[a, b]] for one "
+            f"key, not value: [a, b]); got {value!r}"
+        )
+    key = tuple(value)
+    if len(key) != n_cols:
+        raise ValueError(
+            f"filter: {label} has {n_cols} parts but the accepted value "
+            f"{value!r} has {len(key)}"
+        )
+    return key

--- a/sieval/core/datasets/dataset.py
+++ b/sieval/core/datasets/dataset.py
@@ -1,5 +1,6 @@
 """Abstract Dataset base class backed by HuggingFace DatasetDict."""
 
+import contextlib
 import copy
 import math
 import random
@@ -124,6 +125,11 @@ class Dataset[TSample](ABC):
         * a **callable** ``row -> key`` — the key is derived rather than stored,
           which is what selecting on a content hash, a normalised id or a
           concatenation of fields needs. It is handed the whole row as a mapping.
+          Driven from a config file the derived key must be a **scalar**:
+          neither YAML nor JSON has a tuple, and the list each writes instead is
+          unhashable, so a key function written for ``by: {callable: ...}``
+          should join its parts into a string rather than return a tuple. From
+          Python, where the accepted values are passed directly, a tuple is fine.
 
         *value* is one accepted key, or a list/tuple/set of them (membership
         test). A string is always one key, never a set of characters. Under a
@@ -161,17 +167,32 @@ class Dataset[TSample](ABC):
         label = _filter_key_label(by)
         keys = _derive_filter_keys(hf, by, cols)
         raw = list(value) if isinstance(value, list | tuple | set) else [value]
+        if isinstance(value, set):
+            # A set has no order of its own, so give it one: the messages below
+            # quote the requested keys, and an unordered quote would differ
+            # between runs of the same selection. Keys of mixed types are not
+            # orderable — those keep iteration order rather than failing here.
+            with contextlib.suppress(TypeError):
+                raw = sorted(raw)
         # Composite keys are tupled *before* the dedup below, which hashes them.
         if cols is not None and len(cols) > 1:
             raw = [_filter_composite_key(v, len(cols), label) for v in raw]
-        # Ordered and deduped: the set drives membership, the list keeps the
-        # order the caller wrote for the two messages below, so a diagnostic
-        # never depends on set iteration order.
+        # Ordered and deduped: the set drives membership, the list fixes the
+        # order the two messages below quote — as the caller wrote it for a
+        # list or tuple, sorted for a set.
         try:
             requested = list(dict.fromkeys(raw))
         except TypeError as exc:
+            # The one shape that reaches here from a config file: a callable
+            # key whose accepted values were written as JSON/YAML lists.
+            hint = (
+                " (a callable key driven from a config file must take scalar "
+                "accepted values — see the 'by' callable form in the docstring)"
+                if cols is None and any(isinstance(v, list) for v in raw)
+                else ""
+            )
             raise ValueError(
-                f"filter: accepted values must be hashable; {exc}"
+                f"filter: accepted values must be hashable; {exc}{hint}"
             ) from exc
         if not requested:
             raise ValueError(
@@ -516,11 +537,24 @@ def _derive_filter_keys(
         # column paths below read only the columns named, which is why they are
         # kept separate rather than routed through this one.
         key_fn = cast(Callable[[Mapping[str, object]], object], by)
-        return [key_fn(row) for row in hf]
+        keys: list[object] = []
+        for index, row in enumerate(hf):
+            try:
+                keys.append(key_fn(row))
+            except Exception as exc:
+                # `by` may name any importable function, so its failure is a
+                # config error, not an internal one — say which row and which
+                # function rather than letting a bare KeyError surface.
+                raise ValueError(
+                    f"filter: key function {_filter_key_label(by)} raised on "
+                    f"row {index} of {len(hf)}: {type(exc).__name__}: {exc}"
+                ) from exc
+        return keys
     if len(cols) == 1:
         return list(hf[cols[0]])
-    column_data = [hf[col] for col in cols]
-    return [tuple(col[index] for col in column_data) for index in range(len(hf))]
+    # zip over whole columns: building each tuple from a per-row generator
+    # instead costs ~4.5x on a 200k-row split for an identical result.
+    return list(zip(*(hf[col] for col in cols), strict=True))
 
 
 def _filter_composite_key(value: object, n_cols: int, label: str) -> tuple:

--- a/tests/unit/cli/leaderboard/test_session.py
+++ b/tests/unit/cli/leaderboard/test_session.py
@@ -18,7 +18,7 @@ import anyio
 import pytest
 import yaml
 
-from sieval.cli._filter_spec import DIGEST_KEY, compute_values_digest
+from sieval.cli._filter_spec import VALUES_DIGEST_KEY, compute_values_digest
 from sieval.cli.leaderboard.session import (
     _NONMATCH_RUNNER_KEYS,
     _STRICT_RUNNER_KEYS,
@@ -1192,7 +1192,9 @@ datasets:
         # _reified_config is what _persist_effective_config dumps, so this is
         # the view the resume gate compares.
         session = self._session(tmp_path, '["a", "b"]')
-        assert self._op(session)[DIGEST_KEY] == compute_values_digest(b'["a", "b"]')
+        assert self._op(session)[VALUES_DIGEST_KEY] == (
+            compute_values_digest(b'["a", "b"]')
+        )
 
     def test_the_path_is_still_stored_verbatim(self, tmp_path):
         # Portability is why the path is not resolved: effective_config.yaml
@@ -1206,7 +1208,7 @@ datasets:
         before = self._op(self._session(tmp_path, '["a", "b"]'))
         after = self._op(self._session(tmp_path, '["a"]'))
         assert before != after
-        assert before[DIGEST_KEY] != after[DIGEST_KEY]
+        assert before[VALUES_DIGEST_KEY] != after[VALUES_DIGEST_KEY]
 
     def test_resume_aborts_when_the_values_file_changed(self, tmp_path):
         # End to end through the real gate: persist, edit the file, resume.

--- a/tests/unit/cli/leaderboard/test_session.py
+++ b/tests/unit/cli/leaderboard/test_session.py
@@ -411,6 +411,32 @@ class TestDatasetOperations:
                 "test_ds",
             )
 
+    # -- key names --------------------------------------------------------
+
+    def test_a_misspelled_optional_key_is_rejected_rather_than_ignored(self):
+        # The failure this closes: `require_all_keys` reads as `require_all`
+        # left at its default, so the run proceeds with the assertion silently
+        # disarmed — and reports a plausible number on a partial selection.
+        runner = self._make_runner()
+        with pytest.raises(
+            ValueError, match=r"unknown key\(s\) \['require_all_keys'\]"
+        ):
+            runner._apply_dataset_operations(
+                MagicMock(),
+                [{"filter": {"by": "id", "value": "a", "require_all_keys": True}}],
+                "test_ds",
+            )
+
+    def test_split_must_be_a_split_name(self):
+        # A non-string `split` matches no split, which keeps every row.
+        runner = self._make_runner()
+        with pytest.raises(ValueError, match="'split' must be a split name"):
+            runner._apply_dataset_operations(
+                MagicMock(),
+                [{"filter": {"by": "id", "value": "a", "split": ["test"]}}],
+                "test_ds",
+            )
+
     def test_chained_operations(self):
         runner = self._make_runner()
         ds = MagicMock()

--- a/tests/unit/cli/leaderboard/test_session.py
+++ b/tests/unit/cli/leaderboard/test_session.py
@@ -44,6 +44,7 @@ from sieval.cli.leaderboard.session import (
     unwrap_proxies,
 )
 from sieval.cli.resolution import derive_model_type
+from sieval.cli.validation import _VALID_OPERATIONS
 from sieval.core.models.model import Model
 from sieval.core.models.reconcile import CheckStage, Configured, DeferredCheck
 from sieval.core.models.requirements import (
@@ -57,6 +58,14 @@ from sieval.core.models.requirements import (
 from sieval.core.runners import TaskRunnerConfig
 from sieval.core.runners.multi_runner import MultiTaskRunner
 from tests.conftest import MockChatModel
+
+
+def example_row_key(row: dict) -> str:
+    """A stand-in for a real key function, referenced by dotted path below."""
+    return f"{row.get('subset')}::{row.get('key')}"
+
+
+NOT_CALLABLE = "I am a string, not a function"
 
 
 def _write_yaml_config(tmp_path: Path, filename: str, content: str) -> Path:
@@ -125,14 +134,14 @@ class TestDatasetOperations:
                 {"by": "subset", "value": "gsm8k"},
                 "filter",
                 ("subset", "gsm8k"),
-                {"split": "test"},
+                {"require_all": False, "split": "test"},
             ),
             (
                 "filter",
                 {"by": "subset", "value": ["gsm8k", "svamp"]},
                 "filter",
                 ("subset", ["gsm8k", "svamp"]),
-                {"split": "test"},
+                {"require_all": False, "split": "test"},
             ),
         ],
     )
@@ -184,7 +193,11 @@ class TestDatasetOperations:
             ("slice", {}, "'slice' requires 'num'"),
             ("repeat", {}, "'repeat' requires 'times'"),
             ("filter", {}, "'filter' requires 'by'"),
-            ("filter", {"by": "subset"}, "'filter' requires 'value'"),
+            (
+                "filter",
+                {"by": "subset"},
+                "'filter' requires exactly one of 'value' or 'values_file'",
+            ),
         ],
     )
     def test_operation_required_args(self, op, missing_args, error_match):
@@ -205,7 +218,197 @@ class TestDatasetOperations:
         runner._apply_dataset_operations(
             ds, [{"filter": {"by": "n", "value": value}}], "test_ds"
         )
-        ds.filter.assert_called_once_with("n", value, split="test")
+        ds.filter.assert_called_once_with("n", value, require_all=False, split="test")
+
+    def test_the_unknown_operation_message_lists_every_valid_operation(self):
+        # This message omitted 'filter' for as long as 'filter' had existed, so
+        # a user who mistyped an operation was told it was not among four when
+        # it was among five. Derived from the validator's set rather than
+        # restated by hand, because a hand-written list is what drifted.
+        runner = self._make_runner()
+        with pytest.raises(ValueError, match="Unknown operation") as excinfo:
+            runner._apply_dataset_operations(MagicMock(), [{"nope": {}}], "test_ds")
+        listed = str(excinfo.value).split("Valid operations:")[1]
+        assert {op.strip() for op in listed.split(",")} == _VALID_OPERATIONS
+
+    # -- `by` in its three config forms -----------------------------------
+
+    def test_filter_by_a_list_of_columns_is_passed_through(self):
+        runner = self._make_runner()
+        ds = MagicMock()
+        ds.filter.return_value = ds
+
+        runner._apply_dataset_operations(
+            ds, [{"filter": {"by": ["a", "b"], "value": [["x", "y"]]}}], "test_ds"
+        )
+        ds.filter.assert_called_once_with(
+            ["a", "b"], [["x", "y"]], require_all=False, split="test"
+        )
+
+    def test_filter_by_a_callable_reference_resolves_to_the_function(self):
+        # The parity claim at its narrowest: what YAML names, `filter` receives
+        # as the very object a Python caller would have passed.
+        runner = self._make_runner()
+        ds = MagicMock()
+        ds.filter.return_value = ds
+
+        by = {"callable": f"{__name__}.example_row_key"}
+        runner._apply_dataset_operations(
+            ds, [{"filter": {"by": by, "value": "k"}}], "test_ds"
+        )
+        assert ds.filter.call_args.args[0] is example_row_key
+
+    @pytest.mark.parametrize(
+        "by,error_match",
+        [
+            ({"callable": "no_dots_here"}, "could not be resolved"),
+            ({"callable": ".relative"}, "could not be resolved"),
+            ({"callable": f"{__name__}.does_not_exist"}, "could not be resolved"),
+            ({"callable": f"{__name__}.NOT_CALLABLE"}, "not a callable"),
+            ({"callable": "x.y", "extra": 1}, "exactly one key, 'callable'"),
+            (42, "must be a column name"),
+            ([], "must name one or more columns"),
+            (["a", 2], "must name one or more columns"),
+        ],
+    )
+    def test_filter_by_rejects_a_reference_it_cannot_use(self, by, error_match):
+        runner = self._make_runner()
+        with pytest.raises(ValueError, match=error_match):
+            runner._apply_dataset_operations(
+                MagicMock(), [{"filter": {"by": by, "value": "k"}}], "test_ds"
+            )
+
+    def test_filter_by_callable_failure_names_the_dataset(self):
+        # Same obligation the other operation errors carry: a config with many
+        # datasets has to say which one is wrong.
+        runner = self._make_runner()
+        with pytest.raises(ValueError, match="Dataset 'ds7'"):
+            runner._apply_dataset_operations(
+                MagicMock(),
+                [{"filter": {"by": {"callable": "no_such_pkg.fn"}, "value": "k"}}],
+                "ds7",
+            )
+
+    # -- `values_file` ----------------------------------------------------
+
+    def _runner_at(self, config_dir):
+        runner = self._make_runner()
+        runner.config_path = Path(config_dir) / "eval.yaml"
+        return runner
+
+    def _filtered_values(self, tmp_path, filename, text):
+        (tmp_path / filename).write_text(text, encoding="utf-8")
+        runner = self._runner_at(tmp_path)
+        ds = MagicMock()
+        ds.filter.return_value = ds
+        runner._apply_dataset_operations(
+            ds, [{"filter": {"by": "id", "values_file": filename}}], "test_ds"
+        )
+        return ds.filter.call_args.args[1]
+
+    def test_values_file_reads_a_json_list(self, tmp_path):
+        assert self._filtered_values(tmp_path, "k.json", '["a", "b"]') == ["a", "b"]
+
+    def test_values_file_reads_a_json_object_as_its_keys(self, tmp_path):
+        # A selection usually arrives as a map from id to whatever justified
+        # picking it. Requiring it be stripped to a bare list first would mean
+        # the file that is kept is not the file the config reads.
+        assert self._filtered_values(
+            tmp_path, "k.json", '{"a": {"why": "x"}, "b": {"why": "y"}}'
+        ) == ["a", "b"]
+
+    def test_values_file_reads_one_value_per_line(self, tmp_path):
+        assert self._filtered_values(
+            tmp_path, "k.txt", "# picked by hand\na\n\n  b  \n"
+        ) == ["a", "b"]
+
+    def test_values_file_resolves_against_the_config_directory(self, tmp_path):
+        # The same rule `alignment.card` follows: stored verbatim, resolved
+        # relative to the config that named it.
+        (tmp_path / "sub").mkdir()
+        (tmp_path / "sub" / "k.json").write_text('["a"]', encoding="utf-8")
+        runner = self._runner_at(tmp_path)
+        ds = MagicMock()
+        ds.filter.return_value = ds
+
+        runner._apply_dataset_operations(
+            ds, [{"filter": {"by": "id", "values_file": "sub/k.json"}}], "test_ds"
+        )
+        assert ds.filter.call_args.args[1] == ["a"]
+
+    def test_values_file_accepts_an_absolute_path(self, tmp_path):
+        target = tmp_path / "elsewhere.json"
+        target.write_text('["a"]', encoding="utf-8")
+        runner = self._runner_at(tmp_path / "cfg")
+        ds = MagicMock()
+        ds.filter.return_value = ds
+
+        runner._apply_dataset_operations(
+            ds, [{"filter": {"by": "id", "values_file": str(target)}}], "test_ds"
+        )
+        assert ds.filter.call_args.args[1] == ["a"]
+
+    @pytest.mark.parametrize(
+        "filename,text,error_match",
+        [
+            ("k.json", "{not json", "not valid JSON"),
+            ("k.json", '"a string"', "must hold a JSON list"),
+        ],
+    )
+    def test_values_file_rejects_a_file_it_cannot_read_as_values(
+        self, tmp_path, filename, text, error_match
+    ):
+        (tmp_path / filename).write_text(text, encoding="utf-8")
+        runner = self._runner_at(tmp_path)
+        with pytest.raises(ValueError, match=error_match):
+            runner._apply_dataset_operations(
+                MagicMock(),
+                [{"filter": {"by": "id", "values_file": filename}}],
+                "test_ds",
+            )
+
+    def test_values_file_missing_raises(self, tmp_path):
+        runner = self._runner_at(tmp_path)
+        with pytest.raises(ValueError, match="'values_file' not found"):
+            runner._apply_dataset_operations(
+                MagicMock(),
+                [{"filter": {"by": "id", "values_file": "gone.json"}}],
+                "test_ds",
+            )
+
+    def test_filter_rejects_both_value_and_values_file(self):
+        runner = self._make_runner()
+        with pytest.raises(ValueError, match="exactly one of 'value' or"):
+            runner._apply_dataset_operations(
+                MagicMock(),
+                [{"filter": {"by": "id", "value": "a", "values_file": "k.json"}}],
+                "test_ds",
+            )
+
+    # -- `require_all` ----------------------------------------------------
+
+    def test_require_all_is_passed_through(self):
+        runner = self._make_runner()
+        ds = MagicMock()
+        ds.filter.return_value = ds
+
+        runner._apply_dataset_operations(
+            ds,
+            [{"filter": {"by": "id", "value": ["a"], "require_all": True}}],
+            "test_ds",
+        )
+        assert ds.filter.call_args.kwargs["require_all"] is True
+
+    def test_require_all_must_be_a_boolean(self):
+        # `require_all: "no"` is truthy in Python, so a string would arm the
+        # check while reading as if it turned it off.
+        runner = self._make_runner()
+        with pytest.raises(ValueError, match="'require_all' must be a boolean"):
+            runner._apply_dataset_operations(
+                MagicMock(),
+                [{"filter": {"by": "id", "value": "a", "require_all": "no"}}],
+                "test_ds",
+            )
 
     def test_chained_operations(self):
         runner = self._make_runner()

--- a/tests/unit/cli/leaderboard/test_session.py
+++ b/tests/unit/cli/leaderboard/test_session.py
@@ -18,6 +18,7 @@ import anyio
 import pytest
 import yaml
 
+from sieval.cli._filter_spec import DIGEST_KEY, compute_values_digest
 from sieval.cli.leaderboard.session import (
     _NONMATCH_RUNNER_KEYS,
     _STRICT_RUNNER_KEYS,
@@ -1151,6 +1152,104 @@ class TestEvalSessionConfigLoading:
             runner._init_runner()
 
         assert multi_runner_cls.call_args.kwargs["deterministic"] is True
+
+
+# ===================================================================
+# filter values_file: pinned into the config the resume gate compares
+# ===================================================================
+class TestFilterValuesFilePinning:
+    """The selection lives outside the config, so the config must pin it.
+
+    ``effective_config.yaml`` records ``values_file`` as a path. Without a
+    digest beside it two runs whose persisted configs compare equal can score
+    different sample sets, and ``--resume`` accepts the second — the failure is
+    silent, which is what makes it worth a test at this level rather than a
+    unit test of the digest helper alone.
+    """
+
+    CONFIG = """
+result_dir: {result_dir}
+datasets:
+  curated:
+    class: fake.Dataset
+    operations:
+      - filter: {{by: id, values_file: picked.json}}
+"""
+
+    def _session(self, tmp_path, contents, *, result_dir="out"):
+        (tmp_path / "picked.json").write_text(contents, encoding="utf-8")
+        config_path = _write_yaml_config(
+            tmp_path,
+            "eval.yaml",
+            self.CONFIG.format(result_dir=str(tmp_path / result_dir)),
+        )
+        return EvalSession(config_path=str(config_path))
+
+    def _op(self, session):
+        return session._reified_config["datasets"]["curated"]["operations"][0]["filter"]
+
+    def test_the_digest_reaches_the_persisted_config(self, tmp_path):
+        # _reified_config is what _persist_effective_config dumps, so this is
+        # the view the resume gate compares.
+        session = self._session(tmp_path, '["a", "b"]')
+        assert self._op(session)[DIGEST_KEY] == compute_values_digest(b'["a", "b"]')
+
+    def test_the_path_is_still_stored_verbatim(self, tmp_path):
+        # Portability is why the path is not resolved: effective_config.yaml
+        # has to stay meaningful on another machine.
+        session = self._session(tmp_path, '["a"]')
+        assert self._op(session)["values_file"] == "picked.json"
+
+    def test_editing_the_file_changes_the_persisted_config(self, tmp_path):
+        # The gate compares config bodies. Before this pin both bodies were
+        # byte-identical while the selection differed.
+        before = self._op(self._session(tmp_path, '["a", "b"]'))
+        after = self._op(self._session(tmp_path, '["a"]'))
+        assert before != after
+        assert before[DIGEST_KEY] != after[DIGEST_KEY]
+
+    def test_resume_aborts_when_the_values_file_changed(self, tmp_path):
+        # End to end through the real gate: persist, edit the file, resume.
+        session = self._session(tmp_path, '["a", "b"]')
+        anyio.run(session._persist_effective_config)
+
+        resumed = self._session(tmp_path, '["a"]')
+        resumed.resume_override = True
+        with pytest.raises(RuntimeError, match="does not match current invocation"):
+            anyio.run(resumed._persist_effective_config)
+
+    def test_resume_is_accepted_when_the_values_file_is_untouched(self, tmp_path):
+        # The other half: an unchanged file must not start failing resumes.
+        session = self._session(tmp_path, '["a", "b"]')
+        anyio.run(session._persist_effective_config)
+
+        resumed = self._session(tmp_path, '["a", "b"]')
+        resumed.resume_override = True
+        anyio.run(resumed._persist_effective_config)
+
+    def test_rerunning_a_persisted_config_verifies_its_own_digest(self, tmp_path):
+        # `sieval run effective_config.yaml` after the values file moved: the
+        # digest it carries is checked rather than silently re-pinned.
+        session = self._session(tmp_path, '["a", "b"]')
+        anyio.run(session._persist_effective_config)
+        persisted = Path(str(tmp_path / "out")) / "effective_config.yaml"
+        (tmp_path / "out" / "picked.json").write_text('["a"]', encoding="utf-8")
+
+        with pytest.raises(ValueError, match="has changed since this config"):
+            EvalSession(config_path=str(persisted))
+
+    def test_a_missing_values_file_is_reported_at_load(self, tmp_path):
+        config_path = _write_yaml_config(
+            tmp_path, "eval.yaml", self.CONFIG.format(result_dir=str(tmp_path / "out"))
+        )
+        with pytest.raises(ValueError, match="'values_file' not found"):
+            EvalSession(config_path=str(config_path))
+
+    def test_the_read_rechecks_the_digest(self, tmp_path):
+        # Closes the window between the load-time read and the apply-time one.
+        session = self._session(tmp_path, '["a"]')
+        with pytest.raises(ValueError, match="changed while the run was starting"):
+            session._read_filter_values("picked.json", "curated", "sha256:" + "0" * 64)
 
 
 # ===================================================================

--- a/tests/unit/cli/test_filter_spec.py
+++ b/tests/unit/cli/test_filter_spec.py
@@ -1,9 +1,10 @@
 """
 Unit tests for sieval/cli/_filter_spec.py.
 
-Covers: key_function_spec, check_by, check_values_source, check_by_digest,
-resolve_values_path, compute_values_digest, compute_key_function_digest, and
-pin_filter_digests (inject / verify / reject, for both digests).
+Covers: key_function_spec, check_arg_names, check_by, check_values_source,
+check_by_digest, resolve_values_path, relative_values_files,
+compute_values_digest, compute_key_function_digest, and pin_filter_digests
+(inject / verify / reject, for both digests).
 
 AI-Generated Code - Claude Opus 5 (1M context) (Anthropic)
 """
@@ -20,6 +21,7 @@ import pytest
 from sieval.cli._filter_spec import (
     BY_DIGEST_KEY,
     VALUES_DIGEST_KEY,
+    check_arg_names,
     check_by,
     check_by_digest,
     check_values_source,
@@ -27,6 +29,7 @@ from sieval.cli._filter_spec import (
     compute_values_digest,
     key_function_spec,
     pin_filter_digests,
+    relative_values_files,
     resolve_values_path,
 )
 
@@ -123,6 +126,57 @@ class TestCheckBy:
     @pytest.mark.parametrize("by", [3, 1.5, True, object()])
     def test_rejects_other_types(self, by):
         assert "must be a column name" in (check_by(by) or "")
+
+
+class TestCheckArgNames:
+    def test_every_documented_key_is_accepted(self):
+        assert (
+            check_arg_names(
+                {
+                    "by": {"callable": "pkg.mod.fn"},
+                    "values_file": "picked.json",
+                    VALUES_DIGEST_KEY: f"sha256:{'0' * 64}",
+                    BY_DIGEST_KEY: f"sha256:{'1' * 64}",
+                    "require_all": True,
+                    "split": "validation",
+                }
+            )
+            == []
+        )
+
+    def test_rejects_an_unknown_key(self):
+        # A typo in an *optional* key is otherwise silent: this one reads as
+        # require_all simply left at its default, and the assertion is lost.
+        problems = check_arg_names({"by": "tag", "require_all_keys": True})
+        assert len(problems) == 1
+        assert "unknown key(s) ['require_all_keys']" in problems[0]
+
+    def test_names_every_unknown_key_at_once(self):
+        problems = check_arg_names({"by": "tag", "zzz": 1, "aaa": 2})
+        assert "['aaa', 'zzz']" in problems[0]
+
+    @pytest.mark.parametrize("split", [3, ["test"], {"name": "test"}, True])
+    def test_rejects_a_non_string_split(self, split):
+        problems = check_arg_names({"by": "tag", "split": split})
+        assert any("'split' must be a split name" in p for p in problems)
+
+    def test_an_absent_split_is_fine(self):
+        assert check_arg_names({"by": "tag", "value": "a"}) == []
+
+
+class TestRelativeValuesFiles:
+    def test_reports_only_the_relative_ones(self):
+        cfg = {
+            "datasets": {
+                "d1": {"operations": [{"filter": {"values_file": "picked.json"}}]},
+                "d2": {"operations": [{"filter": {"values_file": "/abs/picked.json"}}]},
+                "d3": {"operations": [{"filter": {"by": "tag", "value": "a"}}]},
+            }
+        }
+        assert relative_values_files(cfg) == ["picked.json"]
+
+    def test_no_filter_operations_is_empty(self):
+        assert relative_values_files({"datasets": {"d1": {}}}) == []
 
 
 class TestCheckValuesSource:

--- a/tests/unit/cli/test_filter_spec.py
+++ b/tests/unit/cli/test_filter_spec.py
@@ -1,24 +1,47 @@
 """
 Unit tests for sieval/cli/_filter_spec.py.
 
-Covers: check_by, check_values_source, resolve_values_path,
-compute_values_digest, and pin_values_files (inject / verify / reject).
+Covers: key_function_spec, check_by, check_values_source, check_by_digest,
+resolve_values_path, compute_values_digest, compute_key_function_digest, and
+pin_filter_digests (inject / verify / reject, for both digests).
 
 AI-Generated Code - Claude Opus 5 (1M context) (Anthropic)
 """
 
+import functools
 import hashlib
+import importlib
+import inspect
+import linecache
+import sys
 
 import pytest
 
 from sieval.cli._filter_spec import (
-    DIGEST_KEY,
+    BY_DIGEST_KEY,
+    VALUES_DIGEST_KEY,
     check_by,
+    check_by_digest,
     check_values_source,
+    compute_key_function_digest,
     compute_values_digest,
-    pin_values_files,
+    key_function_spec,
+    pin_filter_digests,
     resolve_values_path,
 )
+
+
+def sample_key(row):
+    """A key function the pin tests can name by dotted path."""
+    return row["id"]
+
+
+def other_key(row):
+    """A second one, so a digest can be shown to distinguish them."""
+    return row["id"].lower()
+
+
+_SAMPLE_KEY_PATH = "tests.unit.cli.test_filter_spec.sample_key"
 
 
 def _cfg(op_args: dict, dataset: str = "ds") -> dict:
@@ -27,6 +50,55 @@ def _cfg(op_args: dict, dataset: str = "ds") -> dict:
 
 def _op(cfg: dict, dataset: str = "ds") -> dict:
     return cfg["datasets"][dataset]["operations"][0]["filter"]
+
+
+@pytest.fixture
+def loguru_caplog(caplog):
+    """Bridge loguru warnings into pytest's caplog for the test duration."""
+    from loguru import logger as _logger
+
+    sink_id = _logger.add(caplog.handler, level="WARNING", format="{message}")
+    yield caplog
+    _logger.remove(sink_id)
+
+
+@pytest.fixture
+def temp_key_module(tmp_path, monkeypatch):
+    """A real importable module whose source the test can rewrite in place.
+
+    Editing a function on disk is the only way to exercise what the pin exists
+    for; comparing two different functions would pass even if the digest read
+    the name rather than the body.
+    """
+    names = ("sieval_test_keys", "sieval_test_keys.keys")
+    package = tmp_path / "sieval_test_keys"
+    package.mkdir()
+    (package / "__init__.py").write_text("", encoding="utf-8")
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    def write(body: str) -> None:
+        (package / "keys.py").write_text(body, encoding="utf-8")
+        for name in names:
+            sys.modules.pop(name, None)
+        linecache.clearcache()
+        importlib.invalidate_caches()
+
+    yield write
+
+    for name in names:
+        sys.modules.pop(name, None)
+
+
+class TestKeyFunctionSpec:
+    def test_reads_the_callable_form(self):
+        assert key_function_spec({"callable": "pkg.mod.fn"}) == "pkg.mod.fn"
+
+    @pytest.mark.parametrize(
+        "by",
+        ["col", ["a", "b"], None, 3, {}, {"callable": 3}, {"callable": "f", "x": 1}],
+    )
+    def test_returns_none_for_anything_else(self, by):
+        assert key_function_spec(by) is None
 
 
 class TestCheckBy:
@@ -82,11 +154,15 @@ class TestCheckValuesSource:
 
     @pytest.mark.parametrize("digest", ["sha256:abc", "abc", "sha256:" + "z" * 64, 7])
     def test_rejects_a_malformed_digest(self, digest):
-        problems = check_values_source({"values_file": "k.json", DIGEST_KEY: digest})
+        problems = check_values_source(
+            {"values_file": "k.json", VALUES_DIGEST_KEY: digest}
+        )
         assert any("sha256:<64 hex>" in p for p in problems)
 
     def test_rejects_a_digest_with_no_file_to_pin(self):
-        problems = check_values_source({"value": "a", DIGEST_KEY: "sha256:" + "a" * 64})
+        problems = check_values_source(
+            {"value": "a", VALUES_DIGEST_KEY: "sha256:" + "a" * 64}
+        )
         assert any("but none is given" in p for p in problems)
 
     def test_collects_every_problem_rather_than_the_first(self):
@@ -94,6 +170,28 @@ class TestCheckValuesSource:
         # messages instead of raising.
         problems = check_values_source({"values_file": 3, "require_all": "yes"})
         assert len(problems) == 2
+
+
+class TestCheckByDigest:
+    def test_absent_is_fine(self):
+        assert check_by_digest({"by": "id", "value": "a"}) == []
+
+    def test_accepts_a_pin_on_a_callable_by(self):
+        op_args = {
+            "by": {"callable": "pkg.mod.fn"},
+            BY_DIGEST_KEY: "sha256:" + "a" * 64,
+        }
+        assert check_by_digest(op_args) == []
+
+    @pytest.mark.parametrize("digest", ["sha256:abc", "abc", "sha256:" + "z" * 64, 7])
+    def test_rejects_a_malformed_digest(self, digest):
+        problems = check_by_digest({"by": {"callable": "f.g"}, BY_DIGEST_KEY: digest})
+        assert any("sha256:<64 hex>" in p for p in problems)
+
+    @pytest.mark.parametrize("by", ["id", ["a", "b"], None])
+    def test_rejects_a_pin_with_no_key_function_to_pin(self, by):
+        problems = check_by_digest({"by": by, BY_DIGEST_KEY: "sha256:" + "a" * 64})
+        assert any("does not name one" in p for p in problems)
 
 
 class TestComputeValuesDigest:
@@ -105,6 +203,25 @@ class TestComputeValuesDigest:
 
     def test_differs_on_a_one_byte_change(self):
         assert compute_values_digest(b'["a"]') != compute_values_digest(b'["b"]')
+
+
+class TestComputeKeyFunctionDigest:
+    def test_matches_sha256_of_the_source(self):
+        source = inspect.getsource(sample_key).encode("utf-8")
+        assert compute_key_function_digest(sample_key) == (
+            "sha256:" + hashlib.sha256(source).hexdigest()
+        )
+
+    def test_distinguishes_two_functions(self):
+        assert compute_key_function_digest(sample_key) != (
+            compute_key_function_digest(other_key)
+        )
+
+    @pytest.mark.parametrize("fn", [len, dict.get, functools.partial(sample_key)])
+    def test_unreadable_source_is_none_rather_than_an_error(self, fn):
+        # A builtin, a C-level descriptor and a partial are all legitimate keys
+        # from Python; refusing to run them would be worse than not pinning.
+        assert compute_key_function_digest(fn) is None
 
 
 class TestResolveValuesPath:
@@ -119,14 +236,14 @@ class TestResolveValuesPath:
         assert resolve_values_path(str(target), tmp_path / "other") == target
 
 
-class TestPinValuesFiles:
+class TestPinValuesFile:
     def test_injects_the_digest(self, tmp_path):
         (tmp_path / "k.json").write_text('["a"]', encoding="utf-8")
         cfg = _cfg({"by": "id", "values_file": "k.json"})
 
-        pin_values_files(cfg, tmp_path)
+        pin_filter_digests(cfg, tmp_path)
 
-        assert _op(cfg)[DIGEST_KEY] == compute_values_digest(b'["a"]')
+        assert _op(cfg)[VALUES_DIGEST_KEY] == compute_values_digest(b'["a"]')
 
     def test_the_digest_tracks_the_contents(self, tmp_path):
         # The point of the whole mechanism: two configs identical on disk must
@@ -134,45 +251,49 @@ class TestPinValuesFiles:
         path = tmp_path / "k.json"
         path.write_text('["a"]', encoding="utf-8")
         first = _cfg({"by": "id", "values_file": "k.json"})
-        pin_values_files(first, tmp_path)
+        pin_filter_digests(first, tmp_path)
 
         path.write_text('["a", "b"]', encoding="utf-8")
         second = _cfg({"by": "id", "values_file": "k.json"})
-        pin_values_files(second, tmp_path)
+        pin_filter_digests(second, tmp_path)
 
         assert first != second
 
     def test_an_existing_matching_digest_is_left_alone(self, tmp_path):
         (tmp_path / "k.json").write_text('["a"]', encoding="utf-8")
         digest = compute_values_digest(b'["a"]')
-        cfg = _cfg({"by": "id", "values_file": "k.json", DIGEST_KEY: digest})
+        cfg = _cfg({"by": "id", "values_file": "k.json", VALUES_DIGEST_KEY: digest})
 
-        pin_values_files(cfg, tmp_path)
+        pin_filter_digests(cfg, tmp_path)
 
-        assert _op(cfg)[DIGEST_KEY] == digest
+        assert _op(cfg)[VALUES_DIGEST_KEY] == digest
 
     def test_a_stale_digest_raises_and_names_the_dataset(self, tmp_path):
         # Re-running a persisted effective_config.yaml whose values file moved
         # under it. Silently re-pinning would score a different sample set.
         (tmp_path / "k.json").write_text('["a", "b"]', encoding="utf-8")
         cfg = _cfg(
-            {"by": "id", "values_file": "k.json", DIGEST_KEY: "sha256:" + "0" * 64},
+            {
+                "by": "id",
+                "values_file": "k.json",
+                VALUES_DIGEST_KEY: "sha256:" + "0" * 64,
+            },
             dataset="curated",
         )
 
         with pytest.raises(ValueError, match="Dataset 'curated'") as exc:
-            pin_values_files(cfg, tmp_path)
+            pin_filter_digests(cfg, tmp_path)
         assert "has changed since this config recorded it" in str(exc.value)
 
     def test_a_missing_file_raises(self, tmp_path):
         cfg = _cfg({"by": "id", "values_file": "gone.json"})
         with pytest.raises(ValueError, match="'values_file' not found"):
-            pin_values_files(cfg, tmp_path)
+            pin_filter_digests(cfg, tmp_path)
 
     def test_an_inline_value_is_untouched(self, tmp_path):
         cfg = _cfg({"by": "id", "value": "a"})
-        pin_values_files(cfg, tmp_path)
-        assert DIGEST_KEY not in _op(cfg)
+        pin_filter_digests(cfg, tmp_path)
+        assert VALUES_DIGEST_KEY not in _op(cfg)
 
     def test_pins_every_dataset_and_every_operation(self, tmp_path):
         (tmp_path / "a.json").write_text('["a"]', encoding="utf-8")
@@ -191,10 +312,10 @@ class TestPinValuesFiles:
             }
         }
 
-        pin_values_files(cfg, tmp_path)
+        pin_filter_digests(cfg, tmp_path)
 
-        assert _op(cfg, "one")[DIGEST_KEY] == compute_values_digest(b'["a"]')
-        assert cfg["datasets"]["two"]["operations"][1]["filter"][DIGEST_KEY] == (
+        assert _op(cfg, "one")[VALUES_DIGEST_KEY] == compute_values_digest(b'["a"]')
+        assert cfg["datasets"]["two"]["operations"][1]["filter"][VALUES_DIGEST_KEY] == (
             compute_values_digest(b'["b"]')
         )
 
@@ -209,8 +330,134 @@ class TestPinValuesFiles:
             {"datasets": {"ds": {"operations": [{"a": 1, "b": 2}]}}},
             {"datasets": {"ds": {"operations": [{"filter": "nope"}]}}},
             {"datasets": {"ds": {"operations": [{"filter": {"values_file": 3}}]}}},
+            {"datasets": {"ds": {"operations": [{"filter": {"by": {"callable": 3}}}]}}},
         ],
     )
     def test_malformed_configs_are_left_for_the_validator(self, cfg, tmp_path):
         # A shape error raised here would pre-empt cli.validation's better one.
-        pin_values_files(cfg, tmp_path)
+        pin_filter_digests(cfg, tmp_path)
+
+
+class TestPinKeyFunction:
+    def test_injects_the_digest(self, tmp_path):
+        cfg = _cfg({"by": {"callable": _SAMPLE_KEY_PATH}, "value": "a"})
+
+        pin_filter_digests(cfg, tmp_path)
+
+        assert _op(cfg)[BY_DIGEST_KEY] == compute_key_function_digest(sample_key)
+
+    @pytest.mark.parametrize("by", ["id", ["a", "b"]])
+    def test_a_column_by_has_nothing_to_pin(self, by, tmp_path):
+        cfg = _cfg({"by": by, "value": "a"})
+        pin_filter_digests(cfg, tmp_path)
+        assert BY_DIGEST_KEY not in _op(cfg)
+
+    def test_an_existing_matching_digest_is_left_alone(self, tmp_path):
+        digest = compute_key_function_digest(sample_key)
+        cfg = _cfg(
+            {"by": {"callable": _SAMPLE_KEY_PATH}, "value": "a", BY_DIGEST_KEY: digest}
+        )
+
+        pin_filter_digests(cfg, tmp_path)
+
+        assert _op(cfg)[BY_DIGEST_KEY] == digest
+
+    def test_a_stale_digest_raises_and_names_the_dataset(self, tmp_path):
+        cfg = _cfg(
+            {
+                "by": {"callable": _SAMPLE_KEY_PATH},
+                "value": "a",
+                BY_DIGEST_KEY: "sha256:" + "0" * 64,
+            },
+            dataset="curated",
+        )
+
+        with pytest.raises(ValueError, match="Dataset 'curated'") as exc:
+            pin_filter_digests(cfg, tmp_path)
+        assert "has changed since this config recorded it" in str(exc.value)
+
+    def test_an_unresolvable_path_is_left_for_the_session(self, tmp_path):
+        # The session's message names the dataset and what could not be
+        # imported; raising here would replace it with a worse one.
+        cfg = _cfg({"by": {"callable": "no.such.module.fn"}, "value": "a"})
+
+        pin_filter_digests(cfg, tmp_path)
+
+        assert BY_DIGEST_KEY not in _op(cfg)
+
+    def test_an_unpinnable_callable_warns_rather_than_blocking(
+        self, tmp_path, loguru_caplog
+    ):
+        cfg = _cfg({"by": {"callable": "builtins.len"}, "value": "a"})
+
+        pin_filter_digests(cfg, tmp_path)
+
+        assert BY_DIGEST_KEY not in _op(cfg)
+        assert "no readable source" in loguru_caplog.text
+
+    def test_an_unpinnable_callable_under_an_existing_pin_raises(self, tmp_path):
+        # The pin cannot be checked, and an unverifiable pin is the one thing
+        # the resume contract cannot wave through.
+        cfg = _cfg(
+            {
+                "by": {"callable": "builtins.len"},
+                "value": "a",
+                BY_DIGEST_KEY: "sha256:" + "0" * 64,
+            }
+        )
+
+        with pytest.raises(ValueError, match="cannot be checked"):
+            pin_filter_digests(cfg, tmp_path)
+
+    def test_both_digests_are_pinned_on_one_operation(self, tmp_path):
+        (tmp_path / "k.json").write_text('["a"]', encoding="utf-8")
+        cfg = _cfg({"by": {"callable": _SAMPLE_KEY_PATH}, "values_file": "k.json"})
+
+        pin_filter_digests(cfg, tmp_path)
+
+        assert _op(cfg)[VALUES_DIGEST_KEY] == compute_values_digest(b'["a"]')
+        assert _op(cfg)[BY_DIGEST_KEY] == compute_key_function_digest(sample_key)
+
+
+class TestTheKeyFunctionPinTracksTheSource:
+    def test_editing_the_body_changes_the_digest(self, tmp_path, temp_key_module):
+        path = "sieval_test_keys.keys.key"
+        temp_key_module("def key(row):\n    return row['id']\n")
+        first = _cfg({"by": {"callable": path}, "value": "a"})
+        pin_filter_digests(first, tmp_path)
+
+        temp_key_module("def key(row):\n    return row['id'].lower()\n")
+        second = _cfg({"by": {"callable": path}, "value": "a"})
+        pin_filter_digests(second, tmp_path)
+
+        assert _op(first)[BY_DIGEST_KEY] != _op(second)[BY_DIGEST_KEY]
+
+    def test_an_edited_function_is_rejected_against_the_recorded_pin(
+        self, tmp_path, temp_key_module
+    ):
+        # What the mechanism is for: a persisted effective_config.yaml re-run
+        # after the function it names was edited must not resume silently.
+        path = "sieval_test_keys.keys.key"
+        temp_key_module("def key(row):\n    return row['id']\n")
+        cfg = _cfg({"by": {"callable": path}, "value": "a"})
+        pin_filter_digests(cfg, tmp_path)
+
+        temp_key_module("def key(row):\n    return row['id'].lower()\n")
+
+        with pytest.raises(ValueError, match="has changed since this config"):
+            pin_filter_digests(cfg, tmp_path)
+
+    def test_an_untouched_function_still_matches(self, tmp_path, temp_key_module):
+        # The other half: re-importing the same source must not trip the pin,
+        # or every resume of a callable filter would fail.
+        path = "sieval_test_keys.keys.key"
+        body = "def key(row):\n    return row['id']\n"
+        temp_key_module(body)
+        cfg = _cfg({"by": {"callable": path}, "value": "a"})
+        pin_filter_digests(cfg, tmp_path)
+        pinned = _op(cfg)[BY_DIGEST_KEY]
+
+        temp_key_module(body)
+        pin_filter_digests(cfg, tmp_path)
+
+        assert _op(cfg)[BY_DIGEST_KEY] == pinned

--- a/tests/unit/cli/test_filter_spec.py
+++ b/tests/unit/cli/test_filter_spec.py
@@ -1,0 +1,216 @@
+"""
+Unit tests for sieval/cli/_filter_spec.py.
+
+Covers: check_by, check_values_source, resolve_values_path,
+compute_values_digest, and pin_values_files (inject / verify / reject).
+
+AI-Generated Code - Claude Opus 5 (1M context) (Anthropic)
+"""
+
+import hashlib
+
+import pytest
+
+from sieval.cli._filter_spec import (
+    DIGEST_KEY,
+    check_by,
+    check_values_source,
+    compute_values_digest,
+    pin_values_files,
+    resolve_values_path,
+)
+
+
+def _cfg(op_args: dict, dataset: str = "ds") -> dict:
+    return {"datasets": {dataset: {"operations": [{"filter": op_args}]}}}
+
+
+def _op(cfg: dict, dataset: str = "ds") -> dict:
+    return cfg["datasets"][dataset]["operations"][0]["filter"]
+
+
+class TestCheckBy:
+    def test_accepts_the_three_forms(self):
+        assert check_by("subset") is None
+        assert check_by(["subset", "key"]) is None
+        assert check_by({"callable": "pkg.mod.fn"}) is None
+
+    def test_missing_by(self):
+        assert check_by(None) == "'filter' requires 'by'"
+
+    @pytest.mark.parametrize("by", [[], ["a", 2], [None]])
+    def test_rejects_a_bad_list(self, by):
+        assert "must name one or more columns as strings" in (check_by(by) or "")
+
+    @pytest.mark.parametrize(
+        "by", [{}, {"callable": 3}, {"callable": "f", "extra": 1}, {"fn": "f"}]
+    )
+    def test_rejects_a_bad_mapping(self, by):
+        assert "exactly one key, 'callable'" in (check_by(by) or "")
+
+    @pytest.mark.parametrize("by", [3, 1.5, True, object()])
+    def test_rejects_other_types(self, by):
+        assert "must be a column name" in (check_by(by) or "")
+
+
+class TestCheckValuesSource:
+    def test_value_alone_is_fine(self):
+        assert check_values_source({"value": "a"}) == []
+
+    def test_values_file_alone_is_fine(self):
+        assert check_values_source({"values_file": "k.json"}) == []
+
+    def test_neither_and_both_are_rejected(self):
+        assert "exactly one of" in check_values_source({})[0]
+        assert (
+            "exactly one of"
+            in check_values_source({"value": "a", "values_file": "k.json"})[0]
+        )
+
+    def test_falsy_value_is_still_a_value(self):
+        # Presence, not truthiness: `value: 0` / `value: false` are real keys.
+        assert check_values_source({"value": 0}) == []
+        assert check_values_source({"value": False}) == []
+
+    def test_values_file_must_be_a_path(self):
+        problems = check_values_source({"values_file": 3})
+        assert any("must be a path" in p for p in problems)
+
+    def test_require_all_must_be_a_bool(self):
+        problems = check_values_source({"value": "a", "require_all": "yes"})
+        assert any("must be a boolean" in p for p in problems)
+
+    @pytest.mark.parametrize("digest", ["sha256:abc", "abc", "sha256:" + "z" * 64, 7])
+    def test_rejects_a_malformed_digest(self, digest):
+        problems = check_values_source({"values_file": "k.json", DIGEST_KEY: digest})
+        assert any("sha256:<64 hex>" in p for p in problems)
+
+    def test_rejects_a_digest_with_no_file_to_pin(self):
+        problems = check_values_source({"value": "a", DIGEST_KEY: "sha256:" + "a" * 64})
+        assert any("but none is given" in p for p in problems)
+
+    def test_collects_every_problem_rather_than_the_first(self):
+        # The accumulate-vs-raise split is the whole reason these return
+        # messages instead of raising.
+        problems = check_values_source({"values_file": 3, "require_all": "yes"})
+        assert len(problems) == 2
+
+
+class TestComputeValuesDigest:
+    def test_matches_sha256_of_the_bytes(self):
+        data = b'["a", "b"]'
+        assert compute_values_digest(data) == (
+            "sha256:" + hashlib.sha256(data).hexdigest()
+        )
+
+    def test_differs_on_a_one_byte_change(self):
+        assert compute_values_digest(b'["a"]') != compute_values_digest(b'["b"]')
+
+
+class TestResolveValuesPath:
+    def test_relative_resolves_against_the_config_dir(self, tmp_path):
+        assert (
+            resolve_values_path("sub/k.json", tmp_path)
+            == (tmp_path / "sub" / "k.json").resolve()
+        )
+
+    def test_absolute_is_left_alone(self, tmp_path):
+        target = tmp_path / "k.json"
+        assert resolve_values_path(str(target), tmp_path / "other") == target
+
+
+class TestPinValuesFiles:
+    def test_injects_the_digest(self, tmp_path):
+        (tmp_path / "k.json").write_text('["a"]', encoding="utf-8")
+        cfg = _cfg({"by": "id", "values_file": "k.json"})
+
+        pin_values_files(cfg, tmp_path)
+
+        assert _op(cfg)[DIGEST_KEY] == compute_values_digest(b'["a"]')
+
+    def test_the_digest_tracks_the_contents(self, tmp_path):
+        # The point of the whole mechanism: two configs identical on disk must
+        # not compare equal once the file behind them differs.
+        path = tmp_path / "k.json"
+        path.write_text('["a"]', encoding="utf-8")
+        first = _cfg({"by": "id", "values_file": "k.json"})
+        pin_values_files(first, tmp_path)
+
+        path.write_text('["a", "b"]', encoding="utf-8")
+        second = _cfg({"by": "id", "values_file": "k.json"})
+        pin_values_files(second, tmp_path)
+
+        assert first != second
+
+    def test_an_existing_matching_digest_is_left_alone(self, tmp_path):
+        (tmp_path / "k.json").write_text('["a"]', encoding="utf-8")
+        digest = compute_values_digest(b'["a"]')
+        cfg = _cfg({"by": "id", "values_file": "k.json", DIGEST_KEY: digest})
+
+        pin_values_files(cfg, tmp_path)
+
+        assert _op(cfg)[DIGEST_KEY] == digest
+
+    def test_a_stale_digest_raises_and_names_the_dataset(self, tmp_path):
+        # Re-running a persisted effective_config.yaml whose values file moved
+        # under it. Silently re-pinning would score a different sample set.
+        (tmp_path / "k.json").write_text('["a", "b"]', encoding="utf-8")
+        cfg = _cfg(
+            {"by": "id", "values_file": "k.json", DIGEST_KEY: "sha256:" + "0" * 64},
+            dataset="curated",
+        )
+
+        with pytest.raises(ValueError, match="Dataset 'curated'") as exc:
+            pin_values_files(cfg, tmp_path)
+        assert "has changed since this config recorded it" in str(exc.value)
+
+    def test_a_missing_file_raises(self, tmp_path):
+        cfg = _cfg({"by": "id", "values_file": "gone.json"})
+        with pytest.raises(ValueError, match="'values_file' not found"):
+            pin_values_files(cfg, tmp_path)
+
+    def test_an_inline_value_is_untouched(self, tmp_path):
+        cfg = _cfg({"by": "id", "value": "a"})
+        pin_values_files(cfg, tmp_path)
+        assert DIGEST_KEY not in _op(cfg)
+
+    def test_pins_every_dataset_and_every_operation(self, tmp_path):
+        (tmp_path / "a.json").write_text('["a"]', encoding="utf-8")
+        (tmp_path / "b.json").write_text('["b"]', encoding="utf-8")
+        cfg = {
+            "datasets": {
+                "one": {
+                    "operations": [{"filter": {"by": "id", "values_file": "a.json"}}]
+                },
+                "two": {
+                    "operations": [
+                        {"slice": {"n": 2}},
+                        {"filter": {"by": "id", "values_file": "b.json"}},
+                    ]
+                },
+            }
+        }
+
+        pin_values_files(cfg, tmp_path)
+
+        assert _op(cfg, "one")[DIGEST_KEY] == compute_values_digest(b'["a"]')
+        assert cfg["datasets"]["two"]["operations"][1]["filter"][DIGEST_KEY] == (
+            compute_values_digest(b'["b"]')
+        )
+
+    @pytest.mark.parametrize(
+        "cfg",
+        [
+            {},
+            {"datasets": None},
+            {"datasets": {"ds": None}},
+            {"datasets": {"ds": {"operations": "nope"}}},
+            {"datasets": {"ds": {"operations": [None]}}},
+            {"datasets": {"ds": {"operations": [{"a": 1, "b": 2}]}}},
+            {"datasets": {"ds": {"operations": [{"filter": "nope"}]}}},
+            {"datasets": {"ds": {"operations": [{"filter": {"values_file": 3}}]}}},
+        ],
+    )
+    def test_malformed_configs_are_left_for_the_validator(self, cfg, tmp_path):
+        # A shape error raised here would pre-empt cli.validation's better one.
+        pin_values_files(cfg, tmp_path)

--- a/tests/unit/cli/test_resolution.py
+++ b/tests/unit/cli/test_resolution.py
@@ -22,6 +22,7 @@ from sieval.cli.resolution import (
     normalize_inline_model_binding,
     resolve_class,
     resolve_config_model_types,
+    resolve_key_function,
 )
 from sieval.core.models.requirements import (
     AggregatedTaskRequirements,
@@ -112,6 +113,57 @@ class TestLoadClassFromPath:
     def test_invalid_path_raises(self, class_path, error_type, error_match):
         with pytest.raises(error_type, match=error_match):
             load_class_from_path(class_path)
+
+
+# ===================================================================
+# resolve_key_function
+# ===================================================================
+class TestResolveKeyFunction:
+    """The config counterpart of handing a Python caller a function directly.
+
+    YAML cannot hold a function body, so it names one — exactly as `class:`
+    names a class rather than defining it. These tests pin that a config can
+    reach any callable a Python caller could pass, and nothing else.
+    """
+
+    def test_resolves_a_dotted_path_to_the_function_itself(self):
+        from sieval.cli.resolution import derive_model_type as expected
+
+        assert resolve_key_function("sieval.cli.resolution.derive_model_type") is (
+            expected
+        )
+
+    # (spec, expected_exception, expected_error_pattern)
+    @pytest.mark.parametrize(
+        "spec,error_type,error_match",
+        [
+            # A bare name has no registry to search, unlike a dataset or task
+            # class, so importing it from wherever it first appeared would make
+            # the resolved function depend on import order.
+            ("my_key", ValueError, "Invalid function path"),
+            (".relative", ValueError, "Relative import syntax"),
+            ("nonexistent.module.fn", ImportError, "Could not import"),
+            (
+                "sieval.cli.resolution.no_such_function",
+                AttributeError,
+                "has no function",
+            ),
+            # Resolvable, importable, and useless as a key: caught here rather
+            # than as a TypeError from deep inside the row loop.
+            ("sieval.cli.resolution.DATASET_MODULE", ValueError, "not a callable"),
+            (42, ValueError, "must be a string"),
+        ],
+    )
+    def test_a_spec_it_cannot_use_raises(self, spec, error_type, error_match):
+        with pytest.raises(error_type, match=error_match):
+            resolve_key_function(spec)
+
+    def test_a_class_is_accepted_because_a_class_is_callable(self):
+        # Nothing requires a key function be a `def`; a small callable class
+        # holding configuration is a legitimate way to write one.
+        from sieval.core.models.model import Model
+
+        assert resolve_key_function("sieval.core.models.model.Model") is Model
 
 
 # ===================================================================

--- a/tests/unit/cli/test_resolution.py
+++ b/tests/unit/cli/test_resolution.py
@@ -108,6 +108,14 @@ class TestLoadClassFromPath:
                 AttributeError,
                 "has no class",
             ),
+            # Resolves, but not to a class. The shared loader returns any
+            # attribute, so the declared `-> type` is only true because this
+            # is checked rather than asserted.
+            (
+                "sieval.cli.resolution.load_class_from_path",
+                ValueError,
+                "not a class",
+            ),
         ],
     )
     def test_invalid_path_raises(self, class_path, error_type, error_match):

--- a/tests/unit/cli/test_validation.py
+++ b/tests/unit/cli/test_validation.py
@@ -735,6 +735,59 @@ class TestValidateDatasets:
         result = validate_eval_config(cfg)
         assert result.ok
 
+    # -- filter -----------------------------------------------------------
+    # Shape only. Whether a column exists, a file is readable, or a dotted
+    # path imports are the session's questions — it has the dataset and the
+    # config's directory; the validator has neither.
+
+    @staticmethod
+    def _filter_cfg(args):
+        return {
+            "models": {},
+            "tasks": {},
+            "datasets": {"d": {"class": "X", "operations": [{"filter": args}]}},
+        }
+
+    @pytest.mark.parametrize(
+        "args",
+        [
+            {"by": "subset", "value": "gsm8k"},
+            {"by": "subset", "value": ["gsm8k", "svamp"]},
+            {"by": ["subset", "key"], "value": [["a", "b"]]},
+            {"by": {"callable": "pkg.module.my_key"}, "value": "k"},
+            {"by": "id", "values_file": "picked.json"},
+            {"by": "id", "value": ["a"], "require_all": True},
+            # Falsy but present: a value the validator must not read as absent.
+            {"by": "n", "value": 0},
+            {"by": "flag", "value": False},
+        ],
+    )
+    def test_valid_filter_operations(self, args):
+        assert validate_eval_config(self._filter_cfg(args)).ok
+
+    @pytest.mark.parametrize(
+        "args,error_match",
+        [
+            ({"value": "a"}, "requires 'by'"),
+            ({"by": "id"}, "exactly one of 'value' or 'values_file'"),
+            (
+                {"by": "id", "value": "a", "values_file": "k.json"},
+                "exactly one of 'value' or 'values_file'",
+            ),
+            ({"by": [], "value": "a"}, "must name one or more columns"),
+            ({"by": ["a", 2], "value": "a"}, "must name one or more columns"),
+            ({"by": {"fn": "pkg.m.f"}, "value": "a"}, "exactly one key, 'callable'"),
+            ({"by": {"callable": 7}, "value": "a"}, "exactly one key, 'callable'"),
+            ({"by": 42, "value": "a"}, "must be a column name"),
+            ({"by": "id", "values_file": 7}, "'values_file' must be a path"),
+            ({"by": "id", "value": "a", "require_all": "yes"}, "must be a boolean"),
+        ],
+    )
+    def test_invalid_filter_operations(self, args, error_match):
+        result = validate_eval_config(self._filter_cfg(args))
+        assert not result.ok
+        assert any(error_match in e for e in result.errors), result.errors
+
 
 # ---------------------------------------------------------------------------
 # Schema validation — tasks

--- a/tests/unit/cli/test_validation.py
+++ b/tests/unit/cli/test_validation.py
@@ -757,6 +757,7 @@ class TestValidateDatasets:
             {"by": {"callable": "pkg.module.my_key"}, "value": "k"},
             {"by": "id", "values_file": "picked.json"},
             {"by": "id", "value": ["a"], "require_all": True},
+            {"by": "id", "value": ["a"], "split": "validation"},
             # Falsy but present: a value the validator must not read as absent.
             {"by": "n", "value": 0},
             {"by": "flag", "value": False},
@@ -781,6 +782,13 @@ class TestValidateDatasets:
             ({"by": 42, "value": "a"}, "must be a column name"),
             ({"by": "id", "values_file": 7}, "'values_file' must be a path"),
             ({"by": "id", "value": "a", "require_all": "yes"}, "must be a boolean"),
+            # A typo in an optional key would otherwise read as that key left
+            # unset, so the config validates and the run quietly drops it.
+            (
+                {"by": "id", "value": "a", "require_all_keys": True},
+                r"unknown key(s) ['require_all_keys']",
+            ),
+            ({"by": "id", "value": "a", "split": 3}, "'split' must be a split name"),
         ],
     )
     def test_invalid_filter_operations(self, args, error_match):

--- a/tests/unit/core/test_datasets.py
+++ b/tests/unit/core/test_datasets.py
@@ -261,6 +261,13 @@ class TestFilter:
         with pytest.raises(ValueError, match="column 'nope' not found"):
             ds.filter("nope", "a")
 
+    def test_filter_non_string_column_raises(self):
+        # Only reachable from Python: the config surface never gets here
+        # because `check_by` rejects a non-string element first.
+        ds = _make_tagged(["a"])
+        with pytest.raises(ValueError, match="must name columns as strings"):
+            ds.filter(["tag", 2], "a")
+
     def test_filter_no_match_raises_and_lists_present_values(self):
         # An empty split would otherwise become a run that scores zero samples.
         ds = _make_tagged(["a", "b"])
@@ -293,6 +300,53 @@ class TestFilter:
             _hf_dict=HFDatasetDict({"test": HFDataset.from_dict({})})
         )
         assert ds.filter("tag", "a") is ds
+
+    def test_filter_warns_that_a_missing_split_filtered_nothing(self):
+        # The one failure that keeps EVERY row while looking like a selection:
+        # a misspelled split leaves the real one untouched, so the run scores
+        # the whole set and reports a plausible number.
+        ds = _make_tagged(["a", "b", "c"])
+        logs = _capture_logs(lambda: ds.filter("tag", "zzz", split="tst"))
+        assert "split 'tst' is not in this dataset" in logs
+        assert "nothing was filtered" in logs
+        assert "['test']" in logs
+
+    def test_filter_warns_that_an_empty_split_filtered_nothing(self):
+        ds = _BypassLoadDataset(
+            _hf_dict=HFDatasetDict({"test": HFDataset.from_dict({})})
+        )
+        logs = _capture_logs(lambda: ds.filter("tag", "a"))
+        assert "split 'test' is empty, so nothing was filtered" in logs
+
+    def test_require_all_raises_rather_than_warning_on_a_missing_split(self):
+        # require_all promises every requested key lands; silently keeping all
+        # rows because the split name was wrong breaks that promise outright.
+        ds = _make_tagged(["a", "b", "c"])
+        with pytest.raises(ValueError, match=r"split 'tst' is not in this dataset"):
+            ds.filter("tag", "zzz", split="tst", require_all=True)
+
+    def test_require_all_raises_rather_than_warning_on_an_empty_split(self):
+        ds = _BypassLoadDataset(
+            _hf_dict=HFDatasetDict({"test": HFDataset.from_dict({})})
+        )
+        with pytest.raises(ValueError, match=r"split 'test' is empty"):
+            ds.filter("tag", "a", require_all=True)
+
+    def test_filter_no_match_truncates_a_wide_requested_list(self):
+        # A values_file puts thousands of keys in `value`, and a stale id list
+        # matches none of them — the message must not become the file.
+        ds = _make_tagged(["a", "b"])
+        with pytest.raises(ValueError) as excinfo:
+            ds.filter("tag", [f"missing_{i}" for i in range(1005)])
+        message = str(excinfo.value)
+        assert "... (1005 requested)" in message
+        assert "missing_1004" not in message
+        assert len(message) < 500
+
+    def test_filter_no_match_still_quotes_a_short_value_whole(self):
+        ds = _make_tagged(["a", "b"])
+        with pytest.raises(ValueError, match=r"has tag='z'"):
+            ds.filter("tag", "z")
 
     def test_filter_empty_value_list_raises(self):
         # An empty selection keeps nothing, so it would fail the no-match guard

--- a/tests/unit/core/test_datasets.py
+++ b/tests/unit/core/test_datasets.py
@@ -294,6 +294,167 @@ class TestFilter:
         )
         assert ds.filter("tag", "a") is ds
 
+    def test_filter_empty_value_list_raises(self):
+        # An empty selection keeps nothing, so it would fail the no-match guard
+        # anyway — but saying *why* matters, because the way this arrives in
+        # practice is a key file that read as empty, not a value anyone typed.
+        ds = _make_tagged(["a", "b"])
+        with pytest.raises(ValueError, match="no accepted values given for tag"):
+            ds.filter("tag", [])
+
+
+# ===================================================================
+# filter — composite keys
+# ===================================================================
+def _make_pairs(pairs):
+    """A _ListDataset with 'tag' and 'lang' columns."""
+    return _ListDataset(
+        [{"id": i, "tag": t, "lang": g} for i, (t, g) in enumerate(pairs)]
+    )
+
+
+class TestFilterCompositeKey:
+    def test_selects_on_the_tuple_of_columns(self):
+        # Neither column alone identifies the row: 'a' spans two langs and 'en'
+        # spans two tags, so this is a selection no single-column filter makes.
+        ds = _make_pairs([("a", "en"), ("a", "fr"), ("b", "en")])
+        kept = ds.filter(["tag", "lang"], [("a", "fr")]).test_set
+        assert [r["id"] for r in kept] == [1]
+
+    def test_a_one_element_list_matches_the_bare_column_name(self):
+        # `stratified_sample` keeps a single column's key scalar rather than a
+        # 1-tuple; filter follows, so the two spellings cannot diverge.
+        ds = _make_pairs([("a", "en"), ("b", "en")])
+        assert [r["id"] for r in ds.filter(["tag"], "a").test_set] == [
+            r["id"] for r in ds.filter("tag", "a").test_set
+        ]
+
+    def test_a_scalar_value_is_rejected_rather_than_promoted(self):
+        # The whole ambiguity: under a 2-column `by`, [a, b] is two keys and
+        # [[a, b]] is one. A scalar arriving here means the caller wrote the
+        # first meaning the second, and quietly guessing would select the wrong
+        # rows while still reporting a plausible count.
+        ds = _make_pairs([("a", "en"), ("b", "fr")])
+        with pytest.raises(ValueError, match=r"value: \[\[a, b\]\] for one key"):
+            ds.filter(["tag", "lang"], ["a", "en"])
+
+    def test_a_wrong_length_key_is_rejected(self):
+        ds = _make_pairs([("a", "en")])
+        with pytest.raises(ValueError, match="has 2 parts but the accepted value"):
+            ds.filter(["tag", "lang"], [("a", "en", "extra")])
+
+    def test_unknown_column_names_every_missing_one(self):
+        ds = _make_pairs([("a", "en")])
+        with pytest.raises(ValueError, match=r"column\(s\) \['nope'\] not found"):
+            ds.filter(["tag", "nope"], [("a", "en")])
+
+    def test_empty_column_list_raises(self):
+        ds = _make_pairs([("a", "en")])
+        with pytest.raises(ValueError, match="must name at least one column"):
+            ds.filter([], "a")
+
+    def test_no_match_error_names_the_composite(self):
+        ds = _make_pairs([("a", "en")])
+        with pytest.raises(ValueError, match=r"has \(tag, lang\)="):
+            ds.filter(["tag", "lang"], [("z", "zz")])
+
+
+# ===================================================================
+# filter — derived keys (callable)
+# ===================================================================
+def _tag_key(row):
+    """A module-level key function, as a config-referenced one would be."""
+    return row["tag"]
+
+
+class TestFilterCallableKey:
+    def test_selects_on_a_key_the_dataset_does_not_store(self):
+        # The case that motivated the callable: the selection is a list of
+        # content hashes, and no column holds one.
+        ds = _ListDataset([{"id": i, "text": t} for i, t in enumerate("abc")])
+        digests = {"a": "d0", "b": "d1", "c": "d2"}
+        kept = ds.filter(lambda row: digests[row["text"]], ["d0", "d2"]).test_set
+        assert kept is not None
+        assert [r["id"] for r in kept] == [0, 2]
+
+    def test_the_callable_receives_the_whole_row(self):
+        ds = _make_pairs([("a", "en"), ("b", "fr")])
+        seen: list[dict] = []
+
+        def key(row):
+            seen.append(dict(row))
+            return row["tag"]
+
+        ds.filter(key, "a")
+        assert {"id", "tag", "lang"} <= set(seen[0])
+
+    def test_no_column_check_applies(self):
+        # A callable may read nothing, or read columns conditionally, so there
+        # is no column list to validate up front.
+        ds = _make_tagged(["a", "b"])
+        assert len(ds.filter(lambda row: "always", "always").test_set) == 2
+
+    def test_no_match_error_names_the_function(self):
+        # A module-level function, which is the only kind the config surface can
+        # reference — its qualname is the name a reader wrote in the YAML.
+        ds = _make_tagged(["a", "b"])
+        with pytest.raises(ValueError, match=r"has _tag_key\(\)="):
+            ds.filter(_tag_key, "z")
+
+    def test_an_unhashable_derived_key_is_reported_as_such(self):
+        # Returning a list is the easy mistake for a derived composite key, and
+        # the bare TypeError from the membership test names nothing useful.
+        ds = _make_pairs([("a", "en")])
+        with pytest.raises(ValueError, match="cannot be compared for membership"):
+            ds.filter(lambda row: [row["tag"], row["lang"]], "a")
+
+
+# ===================================================================
+# filter — require_all
+# ===================================================================
+class TestFilterRequireAll:
+    def test_raises_when_a_requested_key_matches_nothing(self):
+        # The failure this exists for: 3 of 4 ids still resolve, so without it
+        # the run scores a set nobody selected and reports a plausible number.
+        ds = _make_tagged(["a", "b", "c"])
+        with pytest.raises(ValueError, match=r"1 of 4 requested keys match no row"):
+            ds.filter("tag", ["a", "b", "c", "gone"], require_all=True)
+
+    def test_names_the_unmatched_keys(self):
+        ds = _make_tagged(["a"])
+        with pytest.raises(ValueError, match=r"unmatched: \['x', 'y'\]"):
+            ds.filter("tag", ["a", "x", "y"], require_all=True)
+
+    def test_passes_when_every_key_matches(self):
+        ds = _make_tagged(["a", "b"])
+        assert len(ds.filter("tag", ["a", "b"], require_all=True).test_set) == 2
+
+    def test_counts_keys_not_rows(self):
+        # Load-bearing. A row-count check would reject a correct selection
+        # wherever one key expands to many rows — a session into its turns, a
+        # problem into its languages. Two keys, five rows, and that is right.
+        ds = _make_tagged(["s1", "s1", "s1", "s2", "s2"])
+        assert len(ds.filter("tag", ["s1", "s2"], require_all=True).test_set) == 5
+
+    def test_is_off_by_default_but_warns(self):
+        # Off, because over-covering a split is a legitimate request; warned,
+        # because the alternative is a silently smaller run.
+        ds = _make_tagged(["a", "b"])
+        out = _capture_logs(lambda: ds.filter("tag", ["a", "gone"]))
+        assert "1 of 2 requested keys match no row" in out
+        assert len(ds.filter("tag", ["a", "gone"]).test_set) == 1
+
+    def test_a_fully_matched_selection_warns_about_nothing(self):
+        ds = _make_tagged(["a", "b"])
+        assert _capture_logs(lambda: ds.filter("tag", ["a", "b"])) == ""
+
+    def test_kept_rows_follow_dataset_order_not_the_order_asked_for(self):
+        # Worth pinning: a caller handing over an ordered key list might expect
+        # the rows back in that order. They come back in the split's order, so
+        # the selection stays reproducible however the list was written.
+        ds = _make_tagged(["a", "b", "c"])
+        assert [r["tag"] for r in ds.filter("tag", ["c", "a"]).test_set] == ["a", "c"]
+
 
 # ===================================================================
 # stratified_sample

--- a/tests/unit/core/test_datasets.py
+++ b/tests/unit/core/test_datasets.py
@@ -358,6 +358,29 @@ class TestFilterCompositeKey:
         with pytest.raises(ValueError, match=r"has \(tag, lang\)="):
             ds.filter(["tag", "lang"], [("z", "zz")])
 
+    def test_keys_pair_across_columns_row_by_row(self):
+        # Guards the zip: transposing the columns wrongly would still return a
+        # tuple per row, so only a case where the pairing itself matters can
+        # tell a correct transpose from a shifted one.
+        ds = _make_pairs([("a", "en"), ("b", "fr"), ("c", "de")])
+        kept = ds.filter(["tag", "lang"], [("b", "fr")]).test_set
+        assert [(r["tag"], r["lang"]) for r in kept] == [("b", "fr")]
+        # The mispairings a broken transpose would produce must match nothing.
+        for wrong in [("a", "fr"), ("b", "en"), ("b", "de"), ("c", "fr")]:
+            with pytest.raises(ValueError, match="no row of split"):
+                ds.filter(["tag", "lang"], [wrong])
+
+    def test_three_columns_pair_correctly_too(self):
+        ds = _ListDataset(
+            [
+                {"id": 0, "a": "1", "b": "2", "c": "3"},
+                {"id": 1, "a": "4", "b": "5", "c": "6"},
+            ]
+        )
+        kept = ds.filter(["a", "b", "c"], [("4", "5", "6")]).test_set
+        assert kept is not None
+        assert [r["id"] for r in kept] == [1]
+
 
 # ===================================================================
 # filter — derived keys (callable)
@@ -408,6 +431,36 @@ class TestFilterCallableKey:
         with pytest.raises(ValueError, match="cannot be compared for membership"):
             ds.filter(lambda row: [row["tag"], row["lang"]], "a")
 
+    def test_list_accepted_values_point_at_the_config_scalar_rule(self):
+        # The shape a config file produces for a tuple-returning key function:
+        # YAML/JSON write `[[a, b]]`, which is not hashable. Without the hint
+        # the message is a bare "unhashable type: 'list'".
+        ds = _make_pairs([("a", "en")])
+        with pytest.raises(ValueError, match="must take scalar"):
+            ds.filter(lambda row: (row["tag"], row["lang"]), [["a", "en"]])
+
+    def test_a_tuple_key_still_works_from_python(self):
+        # Only the config surface is constrained to scalars; passing the
+        # accepted values directly, a tuple key is fine.
+        ds = _make_pairs([("a", "en"), ("b", "fr")])
+        kept = ds.filter(lambda row: (row["tag"], row["lang"]), [("a", "en")]).test_set
+        assert [r["tag"] for r in kept] == ["a"]
+
+    def test_a_raising_key_function_names_the_row_and_the_function(self):
+        # `by` may name any importable function, so its failure is a config
+        # error; a bare KeyError from inside it says nothing about where.
+        ds = _make_tagged(["a", "b", "c"])
+
+        def key(row):
+            if row["tag"] == "b":
+                raise KeyError("missing_column")
+            return row["tag"]
+
+        with pytest.raises(ValueError, match=r"raised on row 1 of 3") as exc:
+            ds.filter(key, "a")
+        assert "key()" in str(exc.value)
+        assert "KeyError: 'missing_column'" in str(exc.value)
+
 
 # ===================================================================
 # filter — require_all
@@ -454,6 +507,21 @@ class TestFilterRequireAll:
         # the selection stays reproducible however the list was written.
         ds = _make_tagged(["a", "b", "c"])
         assert [r["tag"] for r in ds.filter("tag", ["c", "a"]).test_set] == ["a", "c"]
+
+    def test_the_warning_quotes_a_set_in_a_stable_order(self):
+        # A set has no order of its own, so quoting it as-iterated makes the
+        # diagnostic differ between runs of the same selection.
+        ds = _make_tagged(["a"])
+        out = _capture_logs(lambda: ds.filter("tag", {"a", "y", "x", "z"}))
+        assert "unmatched: ['x', 'y', 'z']" in out
+
+    def test_a_set_of_unorderable_keys_still_filters(self):
+        # Mixed types cannot be sorted; that must degrade to iteration order
+        # rather than raising out of a selection that is otherwise fine.
+        ds = _ListDataset([{"id": 0, "tag": "a"}, {"id": 1, "tag": "b"}])
+        kept = ds.filter("id", {0, "a"}).test_set
+        assert kept is not None
+        assert len(kept) == 1
 
 
 # ===================================================================


### PR DESCRIPTION
## Why

`Dataset.filter` selects rows whose column equals a value. Building a curated
subset ran into three selections it cannot express, and they turned out to be
one problem:

1. **A key spanning columns.** A row is identified by `(subset, key)`, and
   neither half alone picks it out — `subset` repeats across items, `key`
   repeats across subsets.
2. **A key no column holds.** The selection is a list of content hashes over
   the row, which is what keeps a curated item list valid across a dataset
   revision that renumbers ids.
3. **A thousand accepted values.** Inlining them in YAML is not reasonable.

The workaround was a private helper in the plugin doing its own row scan —
which meant a selection that the config file could describe but not perform.

## What

### `by: str | list[str] | Callable[[Mapping], object]`

Mirrors `stratified_sample`'s convention exactly, including that a single
column keeps a **scalar** key rather than a 1-tuple, so `by: [tag]` and
`by: tag` cannot diverge.

```yaml
operations:
  - filter: {by: subset, value: gsm8k}                    # column
  - filter: {by: [subset, key], value: [[math, q17]]}     # composite
  - filter: {by: {callable: mypkg.keys.row_digest},       # derived
             values_file: picked.json}
```

YAML reaches all three forms. It cannot hold a function body, so it **names**
one — the same way `class:` names a class rather than defining it
(`resolve_key_function`, sharing `load_class_from_path`'s import mechanism via
a small `load_object_from_path`). This was the point: neither surface can
express a selection the other cannot.

A full dotted path is required. Unlike a dataset or task class there is no
registry to search a bare name in, and importing `my_key` from wherever it
first appeared would make the resolved function depend on import order.

### `values_file`

A JSON list, a JSON object's **keys** (so a map from id to whatever justified
picking it is usable as-is, rather than needing to be stripped to a bare list
that then diverges from the file actually kept), or one value per line with
`#` comments.

Read in the session, **not** in `Dataset.filter`. The core transform never
learns where a config lives, which is what keeps the file form honest sugar
over passing the list from Python. Relative paths resolve against the config's
directory — the rule `alignment.card` already follows, stored verbatim so
`effective_config.yaml` stays portable.

### `require_all`

Raises when a requested key matches no row. It counts **keys, never rows**:
one session id expands into several turn rows, so a row-count assertion would
reject a correct selection.

Default `False` on **both** surfaces. A surface-dependent default would be
exactly the Python/YAML inconsistency this PR exists to remove, so instead
unmatched keys always `logger.warning`, and the footgun is loud without the
default differing:

```
filter: 1 of 1005 requested keys match no row of split 'test' on (subset, key);
unmatched: [('ifbench', 'q_0912')]
```

## The one ambiguity, and why it raises

Under a two-column `by`, `value: [a, b]` is *two* keys and `value: [[a, b]]`
is *one*. A scalar arriving where a composite is expected is **rejected**
rather than promoted — guessing would select the wrong rows and still report a
plausible count. The error names both readings.

## Compatibility

Single-column `filter` is unchanged, error text included (the singular
`column 'nope' not found` wording is preserved for that path). `filter` still
raises rather than returning empty. No config in the repo uses a `filter:`
operation today.

## Incidental fix

The unknown-operation message listed four operations and had omitted `filter`
for as long as `filter` had existed — a user who mistyped was told it was not
among four when it was among five. `test_the_unknown_operation_message_lists_
every_valid_operation` now derives the expected list from
`validation._VALID_OPERATIONS`, so it cannot drift again.

## Testing

- `tests/unit/core/test_datasets.py` — 20 new tests across `TestFilterCompositeKey`,
  `TestFilterCallableKey`, `TestFilterRequireAll`.
- `tests/unit/cli/leaderboard/test_session.py` — the three `by` forms, every
  `values_file` shape and failure, `require_all` pass-through and type check.
- `tests/unit/cli/test_resolution.py` — `resolve_key_function` resolution and
  its four rejections.
- `tests/unit/cli/test_validation.py` — `_validate_filter_args` shape checks
  (shape only; column existence, file readability and importability are the
  session's questions — it has the dataset and the config's directory).

`pytest tests/unit tests/integration` → **5255 passed**, 13 failed, all 13 the
pre-existing `rouge_score` import failures also present on `e472f74`.
`ruff format` / `ruff check` clean; `ty check` reports nothing under `sieval/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
