### PR TITLE
fix(dataset): report a missing split from every transform, not just filter

### DIFF
--- a/sieval/core/datasets/dataset.py
+++ b/sieval/core/datasets/dataset.py
@@ -5,7 +5,7 @@ import copy
 import math
 import random
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Iterator, Mapping
+from collections.abc import Callable, Iterable, Iterator, Mapping
 from typing import Literal, Self, overload
 
 from datasets import Dataset as HFDataset
@@ -73,9 +73,10 @@ class Dataset[TSample](ABC):
     def repeat(self, times: int, split: str = "test") -> Self:
         """Return a shallow clone with *split* repeated *times* times.
 
-        Returns ``self`` unchanged if *split* is absent.
+        Returns ``self`` unchanged if *split* is absent, warning that it did.
         """
         if split not in self._dataset_dict:
+            _report_unchanged("repeat", _absent_split(split, self._dataset_dict))
             return self
         new_dict = HFDatasetDict(self.dataset_dict)
         new_dict[split] = new_dict[split].repeat(times)
@@ -85,9 +86,12 @@ class Dataset[TSample](ABC):
         """Return a shallow clone with only the first *num* samples of *split*.
 
         Positional, deterministic prefix. Keeps all samples if *num* exceeds
-        split length. Returns ``self`` unchanged if *split* is absent.
+        split length. Returns ``self`` unchanged if *split* is absent, warning
+        that it did — an unnarrowed split is the failure that looks like a
+        selection, since every row survives and scores as if *num* had applied.
         """
         if split not in self._dataset_dict:
+            _report_unchanged("slice", _absent_split(split, self._dataset_dict))
             return self
         new_dict = HFDatasetDict(self.dataset_dict)
         num_to_keep = min(num, len(new_dict[split]))
@@ -97,9 +101,10 @@ class Dataset[TSample](ABC):
     def shuffle(self, seed: int = 0, split: str = "test") -> Self:
         """Return a shallow clone with *split* shuffled (deterministic via *seed*).
 
-        Returns ``self`` unchanged if *split* is absent.
+        Returns ``self`` unchanged if *split* is absent, warning that it did.
         """
         if split not in self._dataset_dict:
+            _report_unchanged("shuffle", _absent_split(split, self._dataset_dict))
             return self
         new_dict = HFDatasetDict(self.dataset_dict)
         new_dict[split] = new_dict[split].shuffle(seed=seed)
@@ -142,10 +147,9 @@ class Dataset[TSample](ABC):
         not an error.
 
         Returns ``self`` unchanged if *split* is absent or empty, warning that
-        nothing was filtered: a misspelled *split* leaves the real one whole, so
-        this is the one failure here that keeps every row while still reporting
-        a plausible number. *require_all* raises on it — asking for every key to
-        land is not a question about one split.
+        it did, as every transform here does. *require_all* escalates that to a
+        raise: asking for every key to land is not a question about one split,
+        and the flag would otherwise be defeated by a typo in it.
 
         Raises if *by* names a column that does not exist, or if **nothing**
         matches: an empty result is a misspelled *value* far more often than an
@@ -153,17 +157,13 @@ class Dataset[TSample](ABC):
         silently scores zero samples.
         """
         if split not in self._dataset_dict:
-            _report_nothing_filtered(
-                f"filter: split {split!r} is not in this dataset "
-                f"(have: {sorted(self._dataset_dict)})",
-                require_all=require_all,
+            _report_unchanged(
+                "filter", _absent_split(split, self._dataset_dict), strict=require_all
             )
             return self
         hf = self._dataset_dict[split]
         if len(hf) == 0:
-            _report_nothing_filtered(
-                f"filter: split {split!r} is empty", require_all=require_all
-            )
+            _report_unchanged("filter", f"split {split!r} is empty", strict=require_all)
             return self
 
         cols = _filter_columns(by, hf.column_names)
@@ -289,7 +289,9 @@ class Dataset[TSample](ABC):
         *seed*-driven shuffle, so the selection reproduces across runs and
         processes.
 
-        Returns ``self`` unchanged if *split* is absent or empty.
+        Returns ``self`` unchanged if *split* is absent or empty, warning that
+        it did — like :meth:`slice`, an unsubsampled split keeps every row and
+        scores as if the budget had applied.
         """
         budgets = [num, per_group, fraction]
         if sum(budget is not None for budget in budgets) != 1:
@@ -319,9 +321,13 @@ class Dataset[TSample](ABC):
             )
 
         if split not in self._dataset_dict:
+            _report_unchanged(
+                "stratified_sample", _absent_split(split, self._dataset_dict)
+            )
             return self
         hf = self._dataset_dict[split]
         if len(hf) == 0:
+            _report_unchanged("stratified_sample", f"split {split!r} is empty")
             return self
 
         cols = [by] if isinstance(by, str) else list(by)
@@ -501,13 +507,31 @@ class Dataset[TSample](ABC):
         return iter(selected_ds) if lazy else list(selected_ds)
 
 
-def _report_nothing_filtered(detail: str, *, require_all: bool) -> None:
-    """Report a ``filter`` left with no split to run on.
+def _absent_split(split: str, have: Iterable) -> str:
+    """Why a transform had nothing to act on, when the split is not there.
 
-    Why this is not silent is in :meth:`Dataset.filter`, where a caller reads it.
+    *have* is bare rather than ``Iterable[str]`` because every caller passes a
+    ``DatasetDict``, whose upstream stub does not parameterise ``dict`` — so the
+    element type would be a claim the checker cannot see, not one it verifies.
     """
-    detail = f"{detail}, so nothing was filtered"
-    if require_all:
+    return f"split {split!r} is not in this dataset (have: {sorted(have)})"
+
+
+def _report_unchanged(op: str, why: str, *, strict: bool = False) -> None:
+    """Report a transform that returned its dataset untouched.
+
+    Returning *self* is right — a config may name a split only some datasets
+    carry — but silence is not. These transforms exist to *narrow* a split, and
+    a misspelled ``split`` skips the narrowing while leaving the data whole, so
+    the run scores every row and reports a number that looks reasonable. That
+    is the opposite of how they fail once the split is found, where too few
+    rows show up downstream.
+
+    Only :meth:`Dataset.filter` passes *strict*, because only it has a flag
+    (``require_all``) that already promised the selection landed.
+    """
+    detail = f"{op}: {why}, so the dataset is unchanged"
+    if strict:
         raise ValueError(detail)
     logger.warning(detail)
 

--- a/sieval/core/datasets/dataset.py
+++ b/sieval/core/datasets/dataset.py
@@ -482,11 +482,10 @@ class Dataset[TSample](ABC):
         * ``"random"`` — shuffle with *seed*, take first *k*.
         * ``"fixed"`` — select by *indices* (default ``0..k-1``); out-of-range dropped.
 
-        Returns a list or, if *lazy*, an iterator. Empty if *split* is missing or
-        empty, warning that it was: returning nothing here turns a k-shot prompt
-        into a 0-shot one, which the run reports as a plausible number rather
-        than a failure. Every current caller guards the split and raises first,
-        so this is the net under them, not their only defence.
+        Returns a list or, if *lazy*, an iterator. Empty if *split* is missing
+        or empty, warning that it was: returning nothing serves a k-shot prompt
+        as 0-shot, which the run reports as a plausible number. Every caller
+        guards the split and raises first, so this is the net under them.
         """
         ds = self._dataset_dict.get(split)
         if ds is None or len(ds) == 0:
@@ -535,22 +534,14 @@ def _report_no_op(
     """Report an operation a missing or empty split left with nothing to do.
 
     Returning early is right — a config may name a split only some datasets
-    carry — but silence is not. How much the silence costs differs by caller:
+    carry — but silence is not, and it costs differently per caller:
 
-    * :meth:`Dataset.slice`, :meth:`Dataset.filter` and
-      :meth:`Dataset.stratified_sample` exist to *narrow* a split. Skipping the
-      narrowing leaves the data whole, so the run scores every row and reports
-      a number that looks reasonable — the opposite of how they fail once the
-      split is found, where too few rows show up downstream.
-    * :meth:`Dataset.repeat` and :meth:`Dataset.shuffle` fail toward fewer rows
-      or unchanged order, which surfaces downstream on its own. They report for
-      the contract, not the danger.
-    * :meth:`Dataset.retrieve_samples` returns no examples, turning a k-shot
-      prompt into a 0-shot one while the run still reports a plausible number.
-      Its callers each guard the split and raise before reaching here, so this
-      is a net beneath them rather than the only line of defence — which is why
-      *outcome* is overridden there: nothing was "unchanged", the caller simply
-      got nothing back.
+    * ``slice``, ``filter`` and ``stratified_sample`` exist to *narrow*, so a
+      skipped narrowing keeps every row and the run reports a plausible number.
+    * ``repeat`` and ``shuffle`` fail toward fewer rows or unchanged order,
+      which surfaces downstream. They report for the contract, not the danger.
+    * ``retrieve_samples`` returns nothing, serving a k-shot prompt as 0-shot.
+      It overrides *outcome*: nothing was "unchanged", the caller got nothing.
 
     Only :meth:`Dataset.filter` passes *strict*, because only it has a flag
     (``require_all``) that already promised the selection landed.

--- a/sieval/core/datasets/dataset.py
+++ b/sieval/core/datasets/dataset.py
@@ -76,7 +76,7 @@ class Dataset[TSample](ABC):
         Returns ``self`` unchanged if *split* is absent, warning that it did.
         """
         if split not in self._dataset_dict:
-            _report_unchanged("repeat", _absent_split(split, self._dataset_dict))
+            _report_no_op("repeat", _absent_split(split, self._dataset_dict))
             return self
         new_dict = HFDatasetDict(self.dataset_dict)
         new_dict[split] = new_dict[split].repeat(times)
@@ -91,7 +91,7 @@ class Dataset[TSample](ABC):
         selection, since every row survives and scores as if *num* had applied.
         """
         if split not in self._dataset_dict:
-            _report_unchanged("slice", _absent_split(split, self._dataset_dict))
+            _report_no_op("slice", _absent_split(split, self._dataset_dict))
             return self
         new_dict = HFDatasetDict(self.dataset_dict)
         num_to_keep = min(num, len(new_dict[split]))
@@ -104,7 +104,7 @@ class Dataset[TSample](ABC):
         Returns ``self`` unchanged if *split* is absent, warning that it did.
         """
         if split not in self._dataset_dict:
-            _report_unchanged("shuffle", _absent_split(split, self._dataset_dict))
+            _report_no_op("shuffle", _absent_split(split, self._dataset_dict))
             return self
         new_dict = HFDatasetDict(self.dataset_dict)
         new_dict[split] = new_dict[split].shuffle(seed=seed)
@@ -157,13 +157,13 @@ class Dataset[TSample](ABC):
         silently scores zero samples.
         """
         if split not in self._dataset_dict:
-            _report_unchanged(
+            _report_no_op(
                 "filter", _absent_split(split, self._dataset_dict), strict=require_all
             )
             return self
         hf = self._dataset_dict[split]
         if len(hf) == 0:
-            _report_unchanged("filter", f"split {split!r} is empty", strict=require_all)
+            _report_no_op("filter", f"split {split!r} is empty", strict=require_all)
             return self
 
         cols = _filter_columns(by, hf.column_names)
@@ -321,13 +321,11 @@ class Dataset[TSample](ABC):
             )
 
         if split not in self._dataset_dict:
-            _report_unchanged(
-                "stratified_sample", _absent_split(split, self._dataset_dict)
-            )
+            _report_no_op("stratified_sample", _absent_split(split, self._dataset_dict))
             return self
         hf = self._dataset_dict[split]
         if len(hf) == 0:
-            _report_unchanged("stratified_sample", f"split {split!r} is empty")
+            _report_no_op("stratified_sample", f"split {split!r} is empty")
             return self
 
         cols = [by] if isinstance(by, str) else list(by)
@@ -484,10 +482,20 @@ class Dataset[TSample](ABC):
         * ``"random"`` — shuffle with *seed*, take first *k*.
         * ``"fixed"`` — select by *indices* (default ``0..k-1``); out-of-range dropped.
 
-        Returns a list or, if *lazy*, an iterator.  Empty if the split is missing.
+        Returns a list or, if *lazy*, an iterator. Empty if *split* is missing or
+        empty, warning that it was: returning nothing here turns a k-shot prompt
+        into a 0-shot one, which the run reports as a plausible number rather
+        than a failure. Every current caller guards the split and raises first,
+        so this is the net under them, not their only defence.
         """
         ds = self._dataset_dict.get(split)
         if ds is None or len(ds) == 0:
+            why = (
+                _absent_split(split, self._dataset_dict)
+                if ds is None
+                else f"split {split!r} is empty"
+            )
+            _report_no_op("retrieve_samples", why, outcome="no samples are returned")
             return iter([]) if lazy else []
 
         k = min(k, len(ds))
@@ -508,7 +516,7 @@ class Dataset[TSample](ABC):
 
 
 def _absent_split(split: str, have: Iterable) -> str:
-    """Why a transform had nothing to act on, when the split is not there.
+    """Why an operation had nothing to act on, when the split is not there.
 
     *have* is bare rather than ``Iterable[str]`` because every caller passes a
     ``DatasetDict``, whose upstream stub does not parameterise ``dict`` — so the
@@ -517,20 +525,37 @@ def _absent_split(split: str, have: Iterable) -> str:
     return f"split {split!r} is not in this dataset (have: {sorted(have)})"
 
 
-def _report_unchanged(op: str, why: str, *, strict: bool = False) -> None:
-    """Report a transform that returned its dataset untouched.
+def _report_no_op(
+    op: str,
+    why: str,
+    *,
+    outcome: str = "the dataset is unchanged",
+    strict: bool = False,
+) -> None:
+    """Report an operation a missing or empty split left with nothing to do.
 
-    Returning *self* is right — a config may name a split only some datasets
-    carry — but silence is not. These transforms exist to *narrow* a split, and
-    a misspelled ``split`` skips the narrowing while leaving the data whole, so
-    the run scores every row and reports a number that looks reasonable. That
-    is the opposite of how they fail once the split is found, where too few
-    rows show up downstream.
+    Returning early is right — a config may name a split only some datasets
+    carry — but silence is not. How much the silence costs differs by caller:
+
+    * :meth:`Dataset.slice`, :meth:`Dataset.filter` and
+      :meth:`Dataset.stratified_sample` exist to *narrow* a split. Skipping the
+      narrowing leaves the data whole, so the run scores every row and reports
+      a number that looks reasonable — the opposite of how they fail once the
+      split is found, where too few rows show up downstream.
+    * :meth:`Dataset.repeat` and :meth:`Dataset.shuffle` fail toward fewer rows
+      or unchanged order, which surfaces downstream on its own. They report for
+      the contract, not the danger.
+    * :meth:`Dataset.retrieve_samples` returns no examples, turning a k-shot
+      prompt into a 0-shot one while the run still reports a plausible number.
+      Its callers each guard the split and raise before reaching here, so this
+      is a net beneath them rather than the only line of defence — which is why
+      *outcome* is overridden there: nothing was "unchanged", the caller simply
+      got nothing back.
 
     Only :meth:`Dataset.filter` passes *strict*, because only it has a flag
     (``require_all``) that already promised the selection landed.
     """
-    detail = f"{op}: {why}, so the dataset is unchanged"
+    detail = f"{op}: {why}, so {outcome}"
     if strict:
         raise ValueError(detail)
     logger.warning(detail)

--- a/tests/unit/core/test_datasets.py
+++ b/tests/unit/core/test_datasets.py
@@ -20,10 +20,9 @@ from sieval.core.datasets import Dataset
 
 def _capture_logs(fn) -> str:
     sink = io.StringIO()
-    # `level` is load-bearing, not a default worth tidying away: a sink without
-    # it captures DEBUG upward, so downgrading a `logger.warning` under test to
-    # `logger.debug` would keep every assertion below green while going silent
-    # in production, where the console sink is INFO unless `--verbose`.
+    # `level` is load-bearing: without it the sink takes DEBUG upward, so
+    # downgrading a `logger.warning` under test would stay green here while
+    # going silent in a normal run (console sink is INFO unless `--verbose`).
     logger_id = logger.add(sink, format="{message}", level="WARNING")
     try:
         fn()
@@ -961,19 +960,14 @@ class TestStratifiedFraction:
 class TestMissingSplitIsReported:
     """One contract over every ``split``-taking operation, so none goes quiet.
 
-    The five transforms each return ``self`` when their split is absent, and
-    :meth:`Dataset.retrieve_samples` returns nothing — both right, since a
-    config may name a split only some datasets carry. What they must not do is
-    keep it to themselves.
+    The five transforms return ``self`` when their split is absent and
+    ``retrieve_samples`` returns nothing — both right, since a config may name
+    a split only some datasets carry. Saying nothing about it is not.
 
-    The cost of that silence is not uniform, which is why the transforms are
-    covered together but argued separately: ``slice``, ``filter`` and
-    ``stratified_sample`` exist to *narrow*, so a skipped narrowing leaves the
-    data whole and the run scores every row — a plausible number rather than an
-    obviously wrong one. ``repeat`` and ``shuffle`` fail toward fewer rows or
-    unchanged order, which surfaces downstream; they are here for the contract.
-    ``retrieve_samples`` sits with the first group: no examples means a k-shot
-    prompt silently served as 0-shot.
+    ``slice``, ``filter``, ``stratified_sample`` and ``retrieve_samples`` are
+    the dangerous ones: a skipped narrowing keeps every row, and no few-shot
+    examples means a k-shot prompt served as 0-shot — both report a plausible
+    number. ``repeat`` and ``shuffle`` are here for the contract.
     """
 
     @staticmethod
@@ -1038,13 +1032,12 @@ class TestMissingSplitIsReported:
         for op, call in self.TRANSFORMS:
             if op == "filter":
                 continue
-            # Reaching the next iteration *is* the assertion; what each one
-            # returns is pinned by `test_still_returns_self_untouched` above.
+            # Reaching the next iteration is the assertion; the return value is
+            # pinned by `test_still_returns_self_untouched`.
             call(ds)
 
-    # `retrieve_samples` is not a transform — it returns samples, not a clone,
-    # so it carries neither the `self` contract nor `require_all`. It takes the
-    # same `split` and went just as quiet without these.
+    # Not a transform — it returns samples, not a clone — so it carries neither
+    # the `self` contract nor `require_all`, but it takes the same `split`.
     def test_retrieve_samples_reports_a_missing_split(self):
         ds = self._dataset()
         logs = _capture_logs(lambda: ds.retrieve_samples(2, split="tst"))

--- a/tests/unit/core/test_datasets.py
+++ b/tests/unit/core/test_datasets.py
@@ -20,7 +20,11 @@ from sieval.core.datasets import Dataset
 
 def _capture_logs(fn) -> str:
     sink = io.StringIO()
-    logger_id = logger.add(sink, format="{message}")
+    # `level` is load-bearing, not a default worth tidying away: a sink without
+    # it captures DEBUG upward, so downgrading a `logger.warning` under test to
+    # `logger.debug` would keep every assertion below green while going silent
+    # in production, where the console sink is INFO unless `--verbose`.
+    logger_id = logger.add(sink, format="{message}", level="WARNING")
     try:
         fn()
     finally:
@@ -952,16 +956,24 @@ class TestStratifiedFraction:
 
 
 # ===================================================================
-# a missing split is reported by every transform
+# a missing split is reported by every operation that takes one
 # ===================================================================
 class TestMissingSplitIsReported:
-    """One contract over all five transforms, so none can drift back to silence.
+    """One contract over every ``split``-taking operation, so none goes quiet.
 
-    Each returns ``self`` when its split is absent — right, since a config may
-    name a split only some datasets carry. But every one of them exists to
-    *narrow* a split, so skipping the narrowing leaves the data whole and the
-    run scores every row: the only failure mode here that reports a plausible
-    number instead of an obviously wrong one.
+    The five transforms each return ``self`` when their split is absent, and
+    :meth:`Dataset.retrieve_samples` returns nothing — both right, since a
+    config may name a split only some datasets carry. What they must not do is
+    keep it to themselves.
+
+    The cost of that silence is not uniform, which is why the transforms are
+    covered together but argued separately: ``slice``, ``filter`` and
+    ``stratified_sample`` exist to *narrow*, so a skipped narrowing leaves the
+    data whole and the run scores every row — a plausible number rather than an
+    obviously wrong one. ``repeat`` and ``shuffle`` fail toward fewer rows or
+    unchanged order, which surfaces downstream; they are here for the contract.
+    ``retrieve_samples`` sits with the first group: no examples means a k-shot
+    prompt silently served as 0-shot.
     """
 
     @staticmethod
@@ -1026,7 +1038,30 @@ class TestMissingSplitIsReported:
         for op, call in self.TRANSFORMS:
             if op == "filter":
                 continue
-            assert call(ds) is ds, f"{op} must not raise"
+            # Reaching the next iteration *is* the assertion; what each one
+            # returns is pinned by `test_still_returns_self_untouched` above.
+            call(ds)
+
+    # `retrieve_samples` is not a transform — it returns samples, not a clone,
+    # so it carries neither the `self` contract nor `require_all`. It takes the
+    # same `split` and went just as quiet without these.
+    def test_retrieve_samples_reports_a_missing_split(self):
+        ds = self._dataset()
+        logs = _capture_logs(lambda: ds.retrieve_samples(2, split="tst"))
+        assert "retrieve_samples: split 'tst' is not in this dataset" in logs
+        assert "['test']" in logs
+        # Not "unchanged": nothing was transformed, the caller got nothing back.
+        assert "no samples are returned" in logs
+
+    def test_retrieve_samples_reports_an_empty_split(self):
+        ds = _BypassLoadDataset(
+            _hf_dict=HFDatasetDict({"test": HFDataset.from_dict({})})
+        )
+        logs = _capture_logs(lambda: ds.retrieve_samples(2, split="test"))
+        assert (
+            "retrieve_samples: split 'test' is empty, so no samples are returned"
+            in logs
+        )
 
 
 # ===================================================================

--- a/tests/unit/core/test_datasets.py
+++ b/tests/unit/core/test_datasets.py
@@ -308,7 +308,7 @@ class TestFilter:
         ds = _make_tagged(["a", "b", "c"])
         logs = _capture_logs(lambda: ds.filter("tag", "zzz", split="tst"))
         assert "split 'tst' is not in this dataset" in logs
-        assert "nothing was filtered" in logs
+        assert "the dataset is unchanged" in logs
         assert "['test']" in logs
 
     def test_filter_warns_that_an_empty_split_filtered_nothing(self):
@@ -316,7 +316,7 @@ class TestFilter:
             _hf_dict=HFDatasetDict({"test": HFDataset.from_dict({})})
         )
         logs = _capture_logs(lambda: ds.filter("tag", "a"))
-        assert "split 'test' is empty, so nothing was filtered" in logs
+        assert "split 'test' is empty, so the dataset is unchanged" in logs
 
     def test_require_all_raises_rather_than_warning_on_a_missing_split(self):
         # require_all promises every requested key lands; silently keeping all
@@ -949,6 +949,84 @@ class TestStratifiedFraction:
             ds.stratified_sample(by="subject", fraction=0.5, split="train", seed=0)
             is ds
         )
+
+
+# ===================================================================
+# a missing split is reported by every transform
+# ===================================================================
+class TestMissingSplitIsReported:
+    """One contract over all five transforms, so none can drift back to silence.
+
+    Each returns ``self`` when its split is absent — right, since a config may
+    name a split only some datasets carry. But every one of them exists to
+    *narrow* a split, so skipping the narrowing leaves the data whole and the
+    run scores every row: the only failure mode here that reports a plausible
+    number instead of an obviously wrong one.
+    """
+
+    @staticmethod
+    def _dataset():
+        return _BypassLoadDataset(
+            _hf_dict=HFDatasetDict(
+                {"test": HFDataset.from_list([{"id": i, "g": "a"} for i in range(6)])}
+            )
+        )
+
+    # (label, call) — every transform that takes a `split`.
+    TRANSFORMS = [
+        ("repeat", lambda ds: ds.repeat(2, split="tst")),
+        ("slice", lambda ds: ds.slice(2, split="tst")),
+        ("shuffle", lambda ds: ds.shuffle(seed=0, split="tst")),
+        ("filter", lambda ds: ds.filter("id", [0], split="tst")),
+        (
+            "stratified_sample",
+            lambda ds: ds.stratified_sample(by="g", num=2, split="tst"),
+        ),
+    ]
+
+    @pytest.mark.parametrize("op,call", TRANSFORMS, ids=[t[0] for t in TRANSFORMS])
+    def test_warns_and_names_the_splits_it_does_have(self, op, call):
+        ds = self._dataset()
+        logs = _capture_logs(lambda: call(ds))
+        assert f"{op}: split 'tst' is not in this dataset" in logs
+        # The splits it *does* have — without them the warning cannot be acted on.
+        assert "['test']" in logs
+        assert "the dataset is unchanged" in logs
+
+    @pytest.mark.parametrize("op,call", TRANSFORMS, ids=[t[0] for t in TRANSFORMS])
+    def test_still_returns_self_untouched(self, op, call):
+        # Warning is the whole change: the no-op contract is deliberately kept,
+        # so a config naming a split some datasets lack still runs.
+        ds = self._dataset()
+        assert call(ds) is ds
+
+    @pytest.mark.parametrize(
+        "op,call",
+        [
+            ("filter", lambda ds: ds.filter("id", [0])),
+            ("stratified_sample", lambda ds: ds.stratified_sample(by="g", num=2)),
+        ],
+    )
+    def test_an_empty_split_is_reported_too(self, op, call):
+        # The two transforms that bail on an empty split rather than letting
+        # the underlying op no-op harmlessly.
+        ds = _BypassLoadDataset(
+            _hf_dict=HFDatasetDict({"test": HFDataset.from_dict({})})
+        )
+        logs = _capture_logs(lambda: call(ds))
+        assert f"{op}: split 'test' is empty, so the dataset is unchanged" in logs
+
+    def test_only_filter_escalates_to_a_raise(self):
+        # `require_all` is filter's alone, so it is the only transform with a
+        # promise strong enough to turn the warning into an error. The others
+        # have no such flag and must not grow one silently.
+        ds = self._dataset()
+        with pytest.raises(ValueError, match="split 'tst' is not in this dataset"):
+            ds.filter("id", [0], split="tst", require_all=True)
+        for op, call in self.TRANSFORMS:
+            if op == "filter":
+                continue
+            assert call(ds) is ds, f"{op} must not raise"
 
 
 # ===================================================================


### PR DESCRIPTION
## Type

- fix — bug fix or alignment correction

## Summary

- Every `Dataset` operation that takes a `split` opens with an early return when it is absent, **silently**. #106 gave that a voice in `filter` alone; this extends it to `repeat`, `slice`, `shuffle`, `stratified_sample` and `retrieve_samples`.
- Returning early **stays** — a config may name a split only some datasets carry, which is what it is for. What changes is that it says so.
- The danger is not uniform, which is why "they all do it" was not a reason to leave them: `slice`, `filter` and `stratified_sample` exist to *narrow* a split, so skipping the narrowing keeps **every** row and the run scores the whole set, reporting a plausible number. `retrieve_samples` fails the same way from the other side — no few-shot examples means a k-shot prompt served as **0-shot**, also at a plausible number. `repeat` and `shuffle` fail toward fewer rows or unchanged order, which surfaces downstream; they are included for the contract, not the danger.
- Only `filter` escalates to a raise, and only under `require_all`, because only it has a flag that already promised the selection landed. No other operation grows a new keyword argument.
- `retrieve_samples`' five callers each guard the split and raise before reaching it (`hellaswag_kshot_ppl`, `arc/_base`, `drop_kshot_gen`, `openbookqa_kshot_gen`, `gsm8k_kshot_base_gen`), so its report is the net beneath them, not their only defence — a sixth caller that forgets the guard is what it is for.
- `_report_nothing_filtered` (#106) → `_report_unchanged` → `_report_no_op`: the name had to stop claiming "transform" once a non-transform called it, and its `outcome` is overridden there, since nothing was *unchanged* — the caller simply got nothing back.
- `TestMissingSplitIsReported` states the contract once, parametrised over the five transforms plus two cases for `retrieve_samples`, so a seventh operation or a regression in one cannot drift back quietly.

## Related Issues

Refs #106, which introduced the reporting helper this generalises. Rebased onto `main` at `760139d2` (#109), which shares no file with this PR; the two `core/datasets` blobs are byte-identical across the rebase and all fourteen probes below still turn the suite red with the same failure counts.

## Test Plan

### Automated

- [x] Lint/format clean (`ruff check && ruff format --check`)
- [x] Type check clean (`ty check` — `All checks passed!`)
- [x] Unit tests pass — 5688 under `-n 8` (CI's shape: `tests/unit tests/integration tests/acceptance`), 0 failed. CI green on all 9 checks.

### Manual

Verified **before** changing behaviour that no production caller depends on the silence:

- The only non-config transform call site is `sieval/tasks/gpqa_diamond_0shot_gen.py:72`, which uses the default `split="test"` that `Dataset.load`'s contract guarantees.
- Every other transform call site is config-driven (`session.py:3083/3091/3105/3178`), where a missing split means a misspelled config.
- No config in the repo runs an operation on a non-`test` split.
- All five `retrieve_samples` callers raise on a missing split before calling, so the new warning is unreachable from them and changes no existing behaviour.
- The existing `*_missing_split_returns_self` and `test_missing_split_returns_empty` tests still hold.

Fourteen reverse-mutation probes, each turning the suite red on its own:

| probe | result |
|---|---|
| drop `repeat` / `slice` / `shuffle` / `filter` / `stratified_sample` report | KILLED (5/5) |
| drop the two empty-split reports (`filter`, `stratified_sample`) | KILLED (2/2) |
| drop `retrieve_samples` report | KILLED |
| `retrieve_samples` `outcome` falls back to the default | KILLED |
| `retrieve_samples` missing/empty reason inverted | KILLED |
| make `strict` never raise | KILLED |
| let `repeat` raise under `strict` | KILLED |
| drop the available-split list from the message | KILLED |
| `_report_no_op` downgraded to `logger.debug` / `logger.info` | KILLED (2/2, 11 failures each) |

The last row is why `_capture_logs` now pins `level="WARNING"`. Without it the sink captured DEBUG upward, so downgrading the warning kept all 128 tests green while going silent in a normal run — the console sink is INFO unless `--verbose`. It was the one mutation that reverted this PR entirely, and it survived before this fix.

- [x] `scripts/check_preflight.py` — 25 PASS, 0 FAIL (1 SKIP: deep link check)
- [x] `sieval/core` coverage 99% (gate 95); `dataset.py` 99%, its one uncovered line pre-existing (`8719ef97`)

## Checklist

### Required (all PRs)

- [x] PR title follows conventional format (`type(scope): description`)
- [x] No internal paths, credentials, or personal info in committed files
- [x] AI-generated code has `AI-Generated Code - <model> (<provider>)` in module docstring
- [x] No new upper-layer dependencies added to `core/`
- [x] Deleted code verified — `_report_nothing_filtered` (added in #106, unreleased) is renamed to `_report_no_op`; no other call sites

### If: Breaking Change

- [x] Described what breaks and migration path in Summary — no return value, signature or exception changes. Five transforms and `retrieve_samples` now emit a `logger.warning` where they were silent; every public signature is untouched.
- [x] Existing tests updated to reflect new behavior — two `filter` assertions from #106 reworded to the now-shared "the dataset is unchanged" wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

