### PR TITLE
fix(tasks): IFBench stops instead of scoring a biased subset without NLTK data

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,12 @@ env:
   # adds ~one wheel and keeps the reimplemented IHEval graders under test.
   # `ifbench` earns its place the same way: emoji + syllapy on top of the nltk
   # `ifeval` already pulls, and the repaired IFBench checkers are first-party
-  # code, untestable without the vendored fork they subclass. Its NLTK corpora
-  # are still fetched on demand by the vendored code at import time, exactly as
-  # `multi_if` and the `ruler` dataset do in this job -- no staged copy of the
-  # corpus list lives here to drift from them. The cache step below keeps that
-  # fetch off the network on all but the first run; making it concurrency safe
-  # is `tests/unit/tasks/conftest.py`'s job, because the race is between test
-  # imports and shows up under any `-n`, not only here.
+  # code, untestable without the vendored fork they subclass. Its NLTK corpora are
+  # still fetched on demand by the vendored code, as `multi_if` and the `ruler`
+  # dataset also do here -- no copy of the corpus list lives in this file. The
+  # cache step below keeps that fetch off the network; making it concurrency safe
+  # is `tests/unit/tasks/conftest.py`'s job, since the race is between test
+  # imports and fires under any `-n`, not only here.
   INSTALL_GROUPS: >-
     -G drop -G ifbench -G ifeval -G iheval -G math -G scicode -G test -G dev
 
@@ -118,23 +117,19 @@ jobs:
         run: pdm install --check --frozen-lockfile ${{ env.INSTALL_GROUPS }}
       - name: Preflight (registration, version, deps, links, meta-drift)
         run: pdm run python scripts/check_preflight.py
-      # The graders fetch their NLTK corpora on demand, from the `nltk_data`
-      # GitHub repo -- the one dependency in this job that no lockfile pins and
-      # no hash covers. Restoring them makes the common run hermetic; a miss
-      # just falls back to the same on-demand fetch the code already does.
+      # The graders fetch their NLTK corpora on demand from the `nltk_data` GitHub
+      # repo -- the one dependency here that no lockfile pins and no hash covers.
+      # A miss just falls back to that same fetch.
       #
       # Two paths because the families resolve differently: the vendored IFBench
-      # fork redirects NLTK_DATA into the sieval cache so downloads never land
-      # in the source tree, while `multi_if` and `ruler` use NLTK's default. That
-      # first path is spelled by `sieval/community/ifbench/instructions.py`, which
-      # nothing here can key on -- move the cache dir there and this step silently
-      # restores nothing. It goes cold, not wrong, which is why it is a comment
-      # and not a guard.
+      # fork redirects NLTK_DATA into the sieval cache so downloads never land in
+      # the source tree, while `multi_if` and `ruler` use NLTK's default. That
+      # first path is spelled by `sieval/community/ifbench/instructions.py` and
+      # keyed on nothing here: move it there and this step goes cold, not wrong.
       #
-      # Keyed on the files that decide *which* corpora get fetched, so adding
-      # one invalidates the cache on its own. A hand-written version key would
-      # be the second copy of the corpus list this job has deliberately avoided
-      # keeping -- one someone must remember to bump.
+      # Keyed on the files that decide *which* corpora get fetched, so adding one
+      # invalidates the cache on its own -- a hand-written version key would be the
+      # second copy of the corpus list this job avoids keeping.
       - name: Restore the NLTK corpora the graders fetch on demand
         uses: actions/cache@v4
         with:
@@ -146,10 +141,9 @@ jobs:
             'sieval/community/ifbench/instructions_util.py',
             'sieval/tasks/multi_if_0shot_gen.py',
             'sieval/datasets/ruler/_shared.py') }}
-          # Editing any of those files for an unrelated reason misses the exact
-          # key while the corpora themselves are unchanged. Falling back to the
-          # newest previous entry keeps that run off the network for everything
-          # already staged; only a genuinely new corpus is fetched.
+          # An unrelated edit to those files misses the exact key while the corpora
+          # are unchanged; falling back to the newest entry still stages everything
+          # but a genuinely new corpus.
           restore-keys: nltk-${{ runner.os }}-
       # `benchmark` deselected: shared runners cannot hold wall-clock
       # thresholds calibrated on a dedicated box. The rest is deterministic.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,11 @@ jobs:
       #
       # Two paths because the families resolve differently: the vendored IFBench
       # fork redirects NLTK_DATA into the sieval cache so downloads never land
-      # in the source tree, while `multi_if` and `ruler` use NLTK's default.
+      # in the source tree, while `multi_if` and `ruler` use NLTK's default. That
+      # first path is spelled by `sieval/community/ifbench/instructions.py`, which
+      # nothing here can key on -- move the cache dir there and this step silently
+      # restores nothing. It goes cold, not wrong, which is why it is a comment
+      # and not a guard.
       #
       # Keyed on the files that decide *which* corpora get fetched, so adding
       # one invalidates the cache on its own. A hand-written version key would

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,10 @@ env:
   # code, untestable without the vendored fork they subclass. Its NLTK corpora
   # are still fetched on demand by the vendored code at import time, exactly as
   # `multi_if` and the `ruler` dataset do in this job -- no staged copy of the
-  # corpus list lives here to drift from them. That fetch is not concurrency
-  # safe, though, so the parallel test step is preceded by one serial warm-up
-  # import; see the step below for why.
+  # corpus list lives here to drift from them. The cache step below keeps that
+  # fetch off the network on all but the first run; making it concurrency safe
+  # is `tests/unit/tasks/conftest.py`'s job, because the race is between test
+  # imports and shows up under any `-n`, not only here.
   INSTALL_GROUPS: >-
     -G drop -G ifbench -G ifeval -G iheval -G math -G scicode -G test -G dev
 
@@ -117,22 +118,35 @@ jobs:
         run: pdm install --check --frozen-lockfile ${{ env.INSTALL_GROUPS }}
       - name: Preflight (registration, version, deps, links, meta-drift)
         run: pdm run python scripts/check_preflight.py
-      # `sieval/community/ifbench/instructions_util.py` calls
-      # `download_nltk_resources()` at module scope, so the corpora are fetched
-      # by whoever imports the vendored fork first. Serial that was fine. Under
-      # `-n auto` several workers collect `test__ifbench_fixed_checkers.py` at
-      # the same moment and race to unzip into one shared NLTK_DATA: the losers
-      # read a half-written archive and die with FileExistsError / EOFError /
-      # LookupError -- none of them the LookupError that helper catches -- and
-      # a collection error takes the whole run with it. Reproduced outside CI:
-      # 4 concurrent cold imports, 3 fail; warmed first, 4 pass.
+      # The graders fetch their NLTK corpora on demand, from the `nltk_data`
+      # GitHub repo -- the one dependency in this job that no lockfile pins and
+      # no hash covers. Restoring them makes the common run hermetic; a miss
+      # just falls back to the same on-demand fetch the code already does.
       #
-      # This imports the module the tests do, in the same job and environment,
-      # so it populates whichever directory the code resolves to rather than a
-      # guess -- and it asks for exactly the corpora the code asks for, so
-      # there is no second copy of the list here to drift from it.
-      - name: Warm the NLTK corpora the vendored IFBench graders fetch on import
-        run: pdm run python -c "import sieval.community.ifbench.instructions"
+      # Two paths because the families resolve differently: the vendored IFBench
+      # fork redirects NLTK_DATA into the sieval cache so downloads never land
+      # in the source tree, while `multi_if` and `ruler` use NLTK's default.
+      #
+      # Keyed on the files that decide *which* corpora get fetched, so adding
+      # one invalidates the cache on its own. A hand-written version key would
+      # be the second copy of the corpus list this job has deliberately avoided
+      # keeping -- one someone must remember to bump.
+      - name: Restore the NLTK corpora the graders fetch on demand
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/sieval/ifbench_nltk_data
+            ~/nltk_data
+          key: >-
+            nltk-${{ runner.os }}-${{ hashFiles(
+            'sieval/community/ifbench/instructions_util.py',
+            'sieval/tasks/multi_if_0shot_gen.py',
+            'sieval/datasets/ruler/_shared.py') }}
+          # Editing any of those files for an unrelated reason misses the exact
+          # key while the corpora themselves are unchanged. Falling back to the
+          # newest previous entry keeps that run off the network for everything
+          # already staged; only a genuinely new corpus is fetched.
+          restore-keys: nltk-${{ runner.os }}-
       # `benchmark` deselected: shared runners cannot hold wall-clock
       # thresholds calibrated on a dedicated box. The rest is deterministic.
       #

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev", "drop", "hle", "ifbench", "ifeval", "iheval", "math", "multi-if", "ruler", "ruler-gen", "scicode", "t-eval", "test"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:141eab4fb885b4c4df9710d9ae33e2d4eda4295f5221dfb4871c4643b39f32e9"
+content_hash = "sha256:f967a7eb48f5d293c88909872a7893443289ec5d6c58c7e2710d86267cd43bf2"
 
 [[metadata.targets]]
 requires_python = ">=3.12,<3.15"
@@ -585,7 +585,7 @@ name = "filelock"
 version = "3.20.0"
 requires_python = ">=3.10"
 summary = "A platform independent file lock."
-groups = ["default", "dev", "ruler", "t-eval"]
+groups = ["default", "dev", "ruler", "t-eval", "test"]
 files = [
     {file = "filelock-3.20.0-py3-none-any.whl", hash = "sha256:339b4732ffda5cd79b13f4e2711a31b0365ce445d95d243bb996273d072546a2"},
     {file = "filelock-3.20.0.tar.gz", hash = "sha256:711e943b4ec6be42e1d4e6690b48dc175c822967466bb31c0c293f34334c13f4"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,10 +130,8 @@ dev = [
   "types-tqdm>=4.67.0.20250809",
 ]
 test = [
-  # Direct, not just via datasets/huggingface-hub: tests/unit/tasks/conftest.py
-  # imports FileLock to serialize the one cold NLTK import across xdist workers.
-  # Declared so that tree does not fail collection if a transitive owner drops it
-  # -- check_dep_coverage scans only tasks/ and datasets/, so nothing else looks.
+  # Direct: tests/unit/tasks/conftest.py locks the cold NLTK import across xdist
+  # workers. Otherwise only transitive, and check_dep_coverage does not scan tests.
   "filelock>=3.20.0",
   "mutmut>=3.5.0",
   "psutil>=7.2.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,11 @@ dev = [
   "types-tqdm>=4.67.0.20250809",
 ]
 test = [
+  # Direct, not just via datasets/huggingface-hub: tests/unit/tasks/conftest.py
+  # imports FileLock to serialize the one cold NLTK import across xdist workers.
+  # Declared so that tree does not fail collection if a transitive owner drops it
+  # -- check_dep_coverage scans only tasks/ and datasets/, so nothing else looks.
+  "filelock>=3.20.0",
   "mutmut>=3.5.0",
   "psutil>=7.2.2",
   "pytest>=9.0",

--- a/sieval/tasks/ifbench_0shot_gen.py
+++ b/sieval/tasks/ifbench_0shot_gen.py
@@ -55,12 +55,21 @@ from sieval.datasets import IFBenchDatasetSample
 # is the headline; the shape is otherwise identical.
 _GRADES = ("strict", "loose")
 
-# The NLTK data the vendored checkers reach for, as ``nltk.data.find`` lookup
-# paths. Upstream IFBench stages these itself -- `download_nltk_resources()` runs
-# at import of the vendored `instructions_util` -- so nothing here downloads
-# them; this list exists only to *verify* that staging. It is a second copy of
-# upstream's list, and a test drives that helper with every lookup failing to
-# assert the two ask for the same set, so they cannot drift apart silently.
+# What upstream's `download_nltk_resources()` stages, as ``nltk.data.find``
+# lookup paths. It runs at import of the vendored `instructions_util`, so nothing
+# here downloads them; this list exists only to *verify* that staging. It is a
+# second copy of upstream's list, and a test drives that helper with every lookup
+# failing to assert the two ask for the same set, so they cannot drift silently.
+#
+# Upstream's download list, deliberately -- not the narrower set the checkers
+# actually need. On nltk >= 3.9 `tokenizers/punkt` is dead weight: every NLTK
+# call site in the vendored fork resolves through `punkt_tab`, including the
+# explicit `nltk.data.load("nltk:tokenizers/punkt/english.pickle")` in
+# `instructions_util`. Verifying it anyway keeps the drift pin an equality rather
+# than a subset, so a corpus added upstream cannot slip in unverified. The cost
+# is that a box hand-staged with only what grading needs is refused -- but the
+# error message names `punkt`, and both routes that stage these automatically
+# (upstream's helper, the Docker image) fetch all four regardless.
 _NLTK_RESOURCES = (
     "tokenizers/punkt",
     "tokenizers/punkt_tab",
@@ -84,8 +93,10 @@ def _ensure_nltk_resources() -> None:
     so the score is computed over the subset whose constraints never touched NLTK
     -- a biased remainder published under the full benchmark's name. Checking all
     four resources once, unconditionally, converts that into a total failure: every
-    sample stops here naming what is missing, `fails` equals the set size, and no
-    partial score is reported.
+    sample stops here naming what is missing and `fails` equals the set size, so
+    nothing is scored over a subset. The run still writes a report -- one whose
+    rates are all `0.0` beside a full failure count. `fails` is what separates
+    that from a model which genuinely followed no constraint.
 
     Verification only, no download: upstream already tried, and a second attempt
     would just spend the same timeout again. The Multi-IF sibling *does* download

--- a/sieval/tasks/ifbench_0shot_gen.py
+++ b/sieval/tasks/ifbench_0shot_gen.py
@@ -19,11 +19,14 @@ decoding via the model config, not in this task.
 Infra: scoring lazily fetches the NLTK corpora it needs (punkt, stopwords,
 averaged_perceptron_tagger_eng) on first use if absent — an eval-time network
 dependency. The Docker image pre-bakes them; offline runs must pre-stage them
-(see SIEVAL_IFBENCH_NLTK_DATA in sieval.community.ifbench).
+(see SIEVAL_IFBENCH_NLTK_DATA in sieval.community.ifbench). That fetch cannot
+report its own failure (see ``_ensure_nltk_resources``), so this task verifies
+it before grading.
 
 AI-Generated Code - GPT-5 (OpenAI)
 """
 
+from functools import cache
 from typing import Any, override
 
 from sieval.core.models import ModelOutput
@@ -51,6 +54,68 @@ from sieval.datasets import IFBenchDatasetSample
 # `score` is loose prompt-level accuracy) -- the opposite of IFEval, where strict
 # is the headline; the shape is otherwise identical.
 _GRADES = ("strict", "loose")
+
+# The NLTK data the vendored checkers reach for, as ``nltk.data.find`` lookup
+# paths. Upstream IFBench stages these itself -- `download_nltk_resources()` runs
+# at import of the vendored `instructions_util` -- so nothing here downloads
+# them; this list exists only to *verify* that staging. It is a second copy of
+# upstream's list, and a test drives that helper with every lookup failing to
+# assert the two ask for the same set, so they cannot drift apart silently.
+_NLTK_RESOURCES = (
+    "tokenizers/punkt",
+    "tokenizers/punkt_tab",
+    "corpora/stopwords",
+    "taggers/averaged_perceptron_tagger_eng",
+)
+
+
+@cache
+def _ensure_nltk_resources() -> None:
+    """Stop loudly if the corpora the vendored checkers need are not staged.
+
+    Upstream's `download_nltk_resources()` calls `nltk.download(..., quiet=True)`
+    and never re-checks. `nltk.download` defaults to ``raise_on_error=False``, so
+    an offline or rate-limited box gets `False` back and the import completes as
+    if the data were there. The absence then surfaces one `LookupError` at a time,
+    deep inside whichever checkers happen to reach NLTK.
+
+    Left alone that is not a failed run but a *wrong* one: those samples raise out
+    of `feedback()` into `fails`, and `report()`'s denominator is the judged set,
+    so the score is computed over the subset whose constraints never touched NLTK
+    -- a biased remainder published under the full benchmark's name. Checking all
+    four resources once, unconditionally, converts that into a total failure: every
+    sample stops here naming what is missing, `fails` equals the set size, and no
+    partial score is reported.
+
+    Verification only, no download: upstream already tried, and a second attempt
+    would just spend the same timeout again. The Multi-IF sibling *does* download
+    in its own `_ensure_punkt_tab`, because upstream Multi-IF ships no such helper
+    and its vendored files stay free of anything upstream lacks. The shapes differ
+    because the two upstreams do; the guarantee they leave the caller is the same.
+
+    `ifbench_0shot_gen_fixed` subclasses this task and overrides only the checker
+    registry, so it inherits this check with the rest of `feedback()`.
+
+    Cached: on success this runs once per process rather than once per sample --
+    `nltk.data.find` walks every entry on `nltk.data.path`. `functools.cache`
+    stores return values only, so a failing box keeps raising on every sample
+    instead of being silently marked done.
+    """
+    import nltk
+
+    missing = []
+    for resource in _NLTK_RESOURCES:
+        try:
+            nltk.data.find(resource)
+        except LookupError:
+            missing.append(resource)
+    if missing:
+        raise LookupError(
+            "IFBench grading needs NLTK data that is not staged: "
+            f"{', '.join(missing)}. The vendored checkers fetch it on import, so "
+            "this means the download failed -- most likely no network access. "
+            "Pre-stage the corpora and point SIEVAL_IFBENCH_NLTK_DATA at them."
+        )
 
 
 @sieval_task(
@@ -150,6 +215,11 @@ class IFBenchZeroShotGenTask(
             test_instruction_following_loose,
             test_instruction_following_strict,
         )
+
+        # After the import, not before: importing the vendored fork is what
+        # triggers upstream's staging attempt, so there is nothing to verify
+        # until it has run.
+        _ensure_nltk_resources()
 
         graders = {
             "strict": test_instruction_following_strict,

--- a/sieval/tasks/ifbench_0shot_gen.py
+++ b/sieval/tasks/ifbench_0shot_gen.py
@@ -55,21 +55,16 @@ from sieval.datasets import IFBenchDatasetSample
 # is the headline; the shape is otherwise identical.
 _GRADES = ("strict", "loose")
 
-# What upstream's `download_nltk_resources()` stages, as ``nltk.data.find``
-# lookup paths. It runs at import of the vendored `instructions_util`, so nothing
-# here downloads them; this list exists only to *verify* that staging. It is a
-# second copy of upstream's list, and a test drives that helper with every lookup
-# failing to assert the two ask for the same set, so they cannot drift silently.
+# Upstream's download list -- what `download_nltk_resources()` stages at import of
+# the vendored `instructions_util` -- as ``nltk.data.find`` lookup paths. Nothing
+# here downloads; this only *verifies* that staging, and a test drives upstream's
+# helper with every lookup failing to pin the two sets equal.
 #
-# Upstream's download list, deliberately -- not the narrower set the checkers
-# actually need. On nltk >= 3.9 `tokenizers/punkt` is dead weight: every NLTK
-# call site in the vendored fork resolves through `punkt_tab`, including the
-# explicit `nltk.data.load("nltk:tokenizers/punkt/english.pickle")` in
-# `instructions_util`. Verifying it anyway keeps the drift pin an equality rather
-# than a subset, so a corpus added upstream cannot slip in unverified. The cost
-# is that a box hand-staged with only what grading needs is refused -- but the
-# error message names `punkt`, and both routes that stage these automatically
-# (upstream's helper, the Docker image) fetch all four regardless.
+# Deliberately upstream's list, not the narrower set grading needs: on nltk >= 3.9
+# `tokenizers/punkt` is dead weight -- every call site resolves through punkt_tab,
+# including the explicit `nltk.data.load("nltk:tokenizers/punkt/english.pickle")`.
+# Keeping it holds the pin at equality, so a corpus added upstream cannot slip in
+# unverified; the price is refusing a box staged with only what grading needs.
 _NLTK_RESOURCES = (
     "tokenizers/punkt",
     "tokenizers/punkt_tab",
@@ -82,35 +77,26 @@ _NLTK_RESOURCES = (
 def _ensure_nltk_resources() -> None:
     """Stop loudly if the corpora the vendored checkers need are not staged.
 
-    Upstream's `download_nltk_resources()` calls `nltk.download(..., quiet=True)`
-    and never re-checks. `nltk.download` defaults to ``raise_on_error=False``, so
-    an offline or rate-limited box gets `False` back and the import completes as
-    if the data were there. The absence then surfaces one `LookupError` at a time,
-    deep inside whichever checkers happen to reach NLTK.
+    Upstream's `download_nltk_resources()` calls `nltk.download(..., quiet=True)`,
+    which defaults to ``raise_on_error=False``, and never re-checks -- so offline
+    the import completes as if the data were there, and the absence surfaces one
+    `LookupError` at a time, only in the checkers that reach NLTK.
 
-    Left alone that is not a failed run but a *wrong* one: those samples raise out
-    of `feedback()` into `fails`, and `report()`'s denominator is the judged set,
-    so the score is computed over the subset whose constraints never touched NLTK
-    -- a biased remainder published under the full benchmark's name. Checking all
-    four resources once, unconditionally, converts that into a total failure: every
-    sample stops here naming what is missing and `fails` equals the set size, so
-    nothing is scored over a subset. The run still writes a report -- one whose
-    rates are all `0.0` beside a full failure count. `fails` is what separates
-    that from a model which genuinely followed no constraint.
+    That is not a failed run but a *wrong* one: those samples land in `fails` while
+    `report()`'s judged denominator scores the remainder -- the subset whose
+    constraints never touched NLTK, published under the full benchmark's name.
+    Checking all four up front makes the failure total instead: `fails` equals the
+    set size and the report's rates are all `0.0`, which only `fails` tells apart
+    from a model that followed no constraint.
 
-    Verification only, no download: upstream already tried, and a second attempt
-    would just spend the same timeout again. The Multi-IF sibling *does* download
-    in its own `_ensure_punkt_tab`, because upstream Multi-IF ships no such helper
-    and its vendored files stay free of anything upstream lacks. The shapes differ
-    because the two upstreams do; the guarantee they leave the caller is the same.
+    Verification only -- upstream already spent the download attempt. The Multi-IF
+    sibling *does* download, in `_ensure_punkt_tab`, because its upstream ships no
+    such helper; the shapes differ because the two upstreams do.
 
-    `ifbench_0shot_gen_fixed` subclasses this task and overrides only the checker
-    registry, so it inherits this check with the rest of `feedback()`.
-
-    Cached: on success this runs once per process rather than once per sample --
-    `nltk.data.find` walks every entry on `nltk.data.path`. `functools.cache`
-    stores return values only, so a failing box keeps raising on every sample
-    instead of being silently marked done.
+    `ifbench_0shot_gen_fixed` overrides only the checker registry, so it inherits
+    this. `functools.cache` stores return values only: success costs one pass over
+    `nltk.data.path`, and a failing box keeps raising per sample rather than being
+    marked done by the first.
     """
     import nltk
 

--- a/sieval/tasks/multi_if_0shot_gen.py
+++ b/sieval/tasks/multi_if_0shot_gen.py
@@ -148,9 +148,11 @@ def _ensure_punkt_tab() -> None:
 
     Lives here, not in ``sieval/community/multi_if/``, for two reasons: the
     vendored checkers stay byte-identical to upstream, and a helper with a single
-    caller belongs in its caller's module. The IFBench sibling ensures the same
-    resource from *inside* its vendored module, because upstream IFBench ships that
-    download helper itself; Multi-IF's upstream ships none.
+    caller belongs in its caller's module. The IFBench sibling splits the same job
+    across both layers: it *downloads* from inside its vendored module, because
+    upstream IFBench ships that helper and Multi-IF's upstream ships none, but it
+    *verifies* from its task layer (``_ensure_nltk_resources``), because that
+    helper swallows its own failure. Two upstream shapes, one guarantee.
     """
     import nltk
 

--- a/sieval/tasks/multi_if_0shot_gen.py
+++ b/sieval/tasks/multi_if_0shot_gen.py
@@ -148,11 +148,10 @@ def _ensure_punkt_tab() -> None:
 
     Lives here, not in ``sieval/community/multi_if/``, for two reasons: the
     vendored checkers stay byte-identical to upstream, and a helper with a single
-    caller belongs in its caller's module. The IFBench sibling splits the same job
-    across both layers: it *downloads* from inside its vendored module, because
-    upstream IFBench ships that helper and Multi-IF's upstream ships none, but it
-    *verifies* from its task layer (``_ensure_nltk_resources``), because that
-    helper swallows its own failure. Two upstream shapes, one guarantee.
+    caller belongs in its caller's module. The IFBench sibling splits the job: it
+    downloads from inside its vendored module (upstream ships that helper; ours
+    does not) and verifies from its task layer, because that helper swallows its
+    own failure.
     """
     import nltk
 

--- a/tests/unit/tasks/conftest.py
+++ b/tests/unit/tasks/conftest.py
@@ -1,5 +1,38 @@
-"""Task-test collection tweaks for mutation testing.
+"""Task-test collection tweaks: NLTK staging under xdist, and mutation testing.
 
+**NLTK staging.** ``sieval/community/ifbench/instructions_util.py`` calls
+``download_nltk_resources()`` at module scope, so the corpora are fetched by
+whoever imports the vendored fork first. Serial that is fine. Under ``-n auto``
+several workers import it while collecting ``test__ifbench_fixed_checkers.py``
+and race to unzip into one shared NLTK data directory: the losers read a
+half-written archive and die with ``FileExistsError`` / ``EOFError`` /
+``LookupError`` — none of them the ``LookupError`` upstream's helper catches —
+and a collection error takes the whole run with it. Reproduced outside CI: 4
+concurrent cold imports, 3 fail; warmed first, 4 pass.
+
+This has to run at conftest *import* time, not in a fixture: the race is between
+test-module imports during collection, which finishes before any fixture runs.
+
+The block below therefore does one warm import while holding a cross-process
+lock, and does exactly two things to stay cheap:
+
+* It is skipped entirely outside xdist — a single process cannot race itself,
+  and the import costs ~3.4s that a plain ``pytest tests/unit/tasks/test_x.py``
+  should not pay.
+* Only the first worker to take the lock imports; the rest see the sentinel and
+  return immediately, so their own import happens during collection, in
+  parallel, against corpora already on disk. Serializing all of them would turn
+  ``worker_count × 3.4s`` of parallel work into the same amount of serial work.
+
+The sentinel is keyed on ``PYTEST_XDIST_TESTRUNUID`` so it cannot outlive the run
+that wrote it and vouch for corpora someone has since deleted.
+
+Importing the module the tests import — rather than naming corpora here — keeps
+the resource list in one place. ``ImportError`` is swallowed so that an
+environment without the ``ifbench`` extra fails where it already failed, at that
+one test module, instead of taking this whole directory down with it.
+
+**Mutation testing.**
 ``test_import_does_not_pull_the_optional_grader`` proves an optional dependency
 is lazy-imported, which only means anything in an interpreter where that
 dependency was never imported — so it runs one out of process
@@ -16,9 +49,55 @@ Skipping happens before fixture setup, so the probe interpreter never starts.
 AI-Generated Code - Claude Fable 5 (Anthropic)
 """
 
+import contextlib
 import os
+import tempfile
+from pathlib import Path
 
 import pytest
+from filelock import FileLock
+
+
+def _warm_stem() -> Path | None:
+    """Where this run's lock and sentinel live, or ``None`` outside xdist."""
+    if not os.environ.get("PYTEST_XDIST_WORKER"):
+        return None
+    run_id = os.environ.get("PYTEST_XDIST_TESTRUNUID", "unknown")
+    # Per-uid so two users on one box never contend for each other's lock file;
+    # per-run so the sentinel cannot vouch for a previous run's corpora.
+    return Path(tempfile.gettempdir()) / f"sieval-ifbench-nltk-{os.getuid()}-{run_id}"
+
+
+def _warm_ifbench_nltk_corpora() -> None:
+    stem = _warm_stem()
+    if stem is None:
+        return
+    sentinel = Path(f"{stem}.warm")
+    with FileLock(f"{stem}.lock"):
+        if sentinel.exists():
+            return
+        with contextlib.suppress(ImportError):
+            import sieval.community.ifbench.instructions  # noqa: F401
+        # Written even when the import failed. It records that the one serialized
+        # attempt happened, which is all the other workers are waiting on; an
+        # environment without the extra should not serialize them one at a time
+        # to reach the same ImportError.
+        sentinel.touch()
+
+
+_warm_ifbench_nltk_corpora()
+
+
+def pytest_sessionfinish():
+    # Collection is long over by now, so the sentinel has no readers left. Left
+    # behind, these would accumulate one pair per parallel run for as long as
+    # the box goes without a reboot.
+    stem = _warm_stem()
+    if stem is None:
+        return
+    for path in (Path(f"{stem}.warm"), Path(f"{stem}.lock")):
+        with contextlib.suppress(OSError):
+            path.unlink(missing_ok=True)
 
 
 def pytest_collection_modifyitems(items):

--- a/tests/unit/tasks/conftest.py
+++ b/tests/unit/tasks/conftest.py
@@ -1,36 +1,23 @@
 """Task-test collection tweaks: NLTK staging under xdist, and mutation testing.
 
 **NLTK staging.** ``sieval/community/ifbench/instructions_util.py`` calls
-``download_nltk_resources()`` at module scope, so the corpora are fetched by
-whoever imports the vendored fork first. Serial that is fine. Under ``-n auto``
-several workers import it while collecting ``test__ifbench_fixed_checkers.py``
-and race to unzip into one shared NLTK data directory: the losers read a
-half-written archive and die with ``FileExistsError`` / ``EOFError`` /
-``LookupError`` — none of them the ``LookupError`` upstream's helper catches —
-and a collection error takes the whole run with it. Reproduced outside CI: 4
-concurrent cold imports, 3 fail; warmed first, 4 pass.
+``download_nltk_resources()`` at module scope, so the corpora arrive with whoever
+imports the vendored fork first. Serial that is fine; under ``-n auto`` several
+workers import it while collecting ``test__ifbench_fixed_checkers.py`` and race to
+unzip into one shared directory. The losers read a half-written archive and die
+with ``FileExistsError`` / ``EOFError`` / ``LookupError`` — none of them the one
+upstream's helper catches — and a collection error takes the whole run with it.
+Repro outside CI: 4 concurrent cold imports, 3 fail; warmed first, 4 pass.
 
-This has to run at conftest *import* time, not in a fixture: the race is between
-test-module imports during collection, which finishes before any fixture runs.
-
-The block below therefore does one warm import while holding a cross-process
-lock, and does exactly two things to stay cheap:
-
-* It is skipped entirely outside xdist — a single process cannot race itself,
-  and the import costs ~3.4s that a plain ``pytest tests/unit/tasks/test_x.py``
-  should not pay.
-* Only the first worker to take the lock imports; the rest see the sentinel and
-  return immediately, so their own import happens during collection, in
-  parallel, against corpora already on disk. Serializing all of them would turn
-  ``worker_count × 3.4s`` of parallel work into the same amount of serial work.
-
-The sentinel is keyed on ``PYTEST_XDIST_TESTRUNUID`` so it cannot outlive the run
-that wrote it and vouch for corpora someone has since deleted.
-
-Importing the module the tests import — rather than naming corpora here — keeps
-the resource list in one place. ``ImportError`` is swallowed so that an
-environment without the ``ifbench`` extra fails where it already failed, at that
-one test module, instead of taking this whole directory down with it.
+The warm import below runs at conftest *import* time, not in a fixture: the race
+is between test-module imports during collection, which finishes before any
+fixture runs. It imports the module the tests import, so no second corpus list
+lives here. It is skipped outside xdist (one process cannot race itself, and the
+import costs ~3.4s), and only the first worker to take the lock imports — the rest
+return on a ``PYTEST_XDIST_TESTRUNUID``-keyed sentinel, so their imports still run
+in parallel against corpora already on disk, and the sentinel cannot outlive its
+run. ``ImportError`` is swallowed so a box without the ``ifbench`` extra still
+fails at that one test module rather than taking this directory down.
 
 **Mutation testing.**
 ``test_import_does_not_pull_the_optional_grader`` proves an optional dependency
@@ -78,10 +65,10 @@ def _warm_ifbench_nltk_corpora() -> None:
             return
         with contextlib.suppress(ImportError):
             import sieval.community.ifbench.instructions  # noqa: F401
-        # Written even when the import failed. It records that the one serialized
-        # attempt happened, which is all the other workers are waiting on; an
-        # environment without the extra should not serialize them one at a time
-        # to reach the same ImportError.
+        # Written even when the import failed: it records that the one serialized
+        # attempt happened, which is all the other workers wait on. Without the
+        # extra they would otherwise queue up one at a time for the same
+        # ImportError.
         sentinel.touch()
 
 
@@ -89,9 +76,8 @@ _warm_ifbench_nltk_corpora()
 
 
 def pytest_sessionfinish():
-    # Collection is long over by now, so the sentinel has no readers left. Left
-    # behind, these would accumulate one pair per parallel run for as long as
-    # the box goes without a reboot.
+    # Collection is long over, so the sentinel has no readers left. Left behind,
+    # these accumulate one pair per parallel run until the box reboots.
     stem = _warm_stem()
     if stem is None:
         return

--- a/tests/unit/tasks/test_ifbench_0shot_gen.py
+++ b/tests/unit/tasks/test_ifbench_0shot_gen.py
@@ -14,6 +14,7 @@ from datasets import DatasetDict as HFDatasetDict
 from sieval.core.models.chat_model import ChatModel
 from sieval.core.tasks import TaskContext, build_prediction_record
 from sieval.datasets.ifbench import IFBenchDataset
+from sieval.tasks import ifbench_0shot_gen as module
 from sieval.tasks.ifbench_0shot_gen import IFBenchZeroShotGenTask
 
 
@@ -105,6 +106,32 @@ def _install_fake_evaluator(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
 
+@pytest.fixture(autouse=True)
+def fresh_nltk_check():
+    """Keep `_ensure_nltk_resources`' cache from leaking between tests.
+
+    Autouse because the cache is process-global: a test that lets a success
+    through decides the outcome of every later one, whichever order they run in.
+    """
+    module._ensure_nltk_resources.cache_clear()
+    yield
+    module._ensure_nltk_resources.cache_clear()
+
+
+@pytest.fixture
+def staged_nltk(monkeypatch: pytest.MonkeyPatch):
+    """Report every corpus as present, so grading tests do not need real data.
+
+    `feedback()` verifies the corpora for real, which is the point of the check
+    -- but a test driving it through a faked evaluator should still pass on a box
+    that has never staged them.
+    """
+    import nltk
+
+    monkeypatch.setattr(nltk.data, "find", lambda path: path)
+
+
+@pytest.mark.usefixtures("staged_nltk")
 @pytest.mark.anyio
 async def test_report_scores_finals_and_counts_fails(monkeypatch: pytest.MonkeyPatch):
     _install_fake_evaluator(monkeypatch)
@@ -144,3 +171,138 @@ async def test_report_scores_finals_and_counts_fails(monkeypatch: pytest.MonkeyP
         "score_key": "loose_prompt_level_accuracy",
         "denominator_policy": "judged",
     }
+
+
+def test_ensure_nltk_resources_passes_when_every_resource_is_staged(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    import nltk
+
+    checked: list[str] = []
+
+    def fake_find(path):
+        checked.append(path)
+        return path
+
+    monkeypatch.setattr(nltk.data, "find", fake_find)
+    module._ensure_nltk_resources()
+    assert set(checked) == set(module._NLTK_RESOURCES)
+
+
+def test_ensure_nltk_resources_names_every_missing_resource(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    import nltk
+
+    absent = {"corpora/stopwords", "taggers/averaged_perceptron_tagger_eng"}
+
+    def fake_find(path):
+        if path in absent:
+            raise LookupError(path)
+        return path
+
+    monkeypatch.setattr(nltk.data, "find", fake_find)
+    with pytest.raises(LookupError) as excinfo:
+        module._ensure_nltk_resources()
+
+    message = str(excinfo.value)
+    # All of them, not just the first one to fail: stopping at the first would
+    # make an offline box stage its corpora one run at a time.
+    for resource in absent:
+        assert resource in message
+    # And nothing that *is* staged. `tokenizers/punkt` is a prefix of
+    # `tokenizers/punkt_tab`, so this one assertion rules out naming either.
+    assert "tokenizers/punkt" not in message
+
+
+def test_a_passing_check_runs_once_per_process(monkeypatch: pytest.MonkeyPatch):
+    import nltk
+
+    checked: list[str] = []
+
+    def fake_find(path):
+        checked.append(path)
+        return path
+
+    monkeypatch.setattr(nltk.data, "find", fake_find)
+    module._ensure_nltk_resources()
+    module._ensure_nltk_resources()
+    # `nltk.data.find` walks every entry on `nltk.data.path`, and `feedback()`
+    # calls this per sample -- 4 walks x set size is worth caching away.
+    assert len(checked) == len(module._NLTK_RESOURCES)
+
+
+def test_a_failing_check_is_not_cached(monkeypatch: pytest.MonkeyPatch):
+    import nltk
+
+    checked: list[str] = []
+
+    def fake_find(path):
+        checked.append(path)
+        raise LookupError(path)
+
+    monkeypatch.setattr(nltk.data, "find", fake_find)
+    for _ in range(2):
+        with pytest.raises(LookupError):
+            module._ensure_nltk_resources()
+
+    # `functools.cache` stores return values only, never raises. That is what
+    # keeps a broken box saying so on every sample instead of being marked done
+    # by the first one -- the whole reason the failure is total rather than a
+    # biased subset. A hand-rolled "checked already" flag would lose this.
+    assert len(checked) == 2 * len(module._NLTK_RESOURCES)
+
+
+def test_the_verified_resources_match_upstreams_download_helper(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    import nltk
+
+    # Reached through `instructions`, not imported directly: that module points
+    # NLTK at the sieval cache dir *before* loading `instructions_util`, and
+    # loading `instructions_util` is what runs the staging attempt.
+    from sieval.community.ifbench import instructions
+
+    looked_up: list[str] = []
+
+    def fake_find(path):
+        looked_up.append(path)
+        raise LookupError(path)
+
+    monkeypatch.setattr(nltk.data, "find", fake_find)
+    monkeypatch.setattr(nltk, "download", lambda name, **_kwargs: True)
+
+    instructions.instructions_util.download_nltk_resources()
+
+    # `_NLTK_RESOURCES` is a second copy of a list that belongs to upstream. This
+    # drives upstream's own helper with every lookup failing and records what it
+    # asks for, so a corpus added there without being added here fails here --
+    # rather than in a run, as one unverified resource.
+    assert set(looked_up) == set(module._NLTK_RESOURCES)
+    assert len(looked_up) == len(module._NLTK_RESOURCES)
+
+
+@pytest.mark.anyio
+async def test_feedback_stops_when_the_corpora_are_missing(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # Teeth for the call site rather than the helper: unwire the check from
+    # `feedback()` and this is what goes red. The faked evaluator grades happily
+    # with no NLTK data at all, which is exactly how the real one hid the
+    # problem -- only the checkers that reach NLTK ever noticed.
+    _install_fake_evaluator(monkeypatch)
+
+    import nltk
+
+    def fake_find(path):
+        raise LookupError(path)
+
+    monkeypatch.setattr(nltk.data, "find", fake_find)
+
+    task = _task()
+    with pytest.raises(LookupError) as excinfo:
+        await task.feedback(
+            build_prediction_record(["final response"]),
+            TaskContext(sample_id=0, raw_sample=_sample("ifbench-1", "final prompt")),
+        )
+    assert "SIEVAL_IFBENCH_NLTK_DATA" in str(excinfo.value)

--- a/tests/unit/tasks/test_ifbench_0shot_gen.py
+++ b/tests/unit/tasks/test_ifbench_0shot_gen.py
@@ -246,10 +246,9 @@ def test_a_failing_check_is_not_cached(monkeypatch: pytest.MonkeyPatch):
         with pytest.raises(LookupError):
             module._ensure_nltk_resources()
 
-    # `functools.cache` stores return values only, never raises. That is what
-    # keeps a broken box saying so on every sample instead of being marked done
-    # by the first one -- the whole reason the failure is total rather than a
-    # biased subset. A hand-rolled "checked already" flag would lose this.
+    # `functools.cache` stores return values only, never raises -- which is what
+    # keeps a broken box failing every sample instead of being marked done by the
+    # first. A hand-rolled "checked already" flag would lose that.
     assert len(checked) == 2 * len(module._NLTK_RESOURCES)
 
 
@@ -274,10 +273,9 @@ def test_the_verified_resources_match_upstreams_download_helper(
 
     instructions.instructions_util.download_nltk_resources()
 
-    # `_NLTK_RESOURCES` is a second copy of a list that belongs to upstream. This
-    # drives upstream's own helper with every lookup failing and records what it
-    # asks for, so a corpus added there without being added here fails here --
-    # rather than in a run, as one unverified resource.
+    # `_NLTK_RESOURCES` is a second copy of upstream's list. Driving upstream's own
+    # helper with every lookup failing records what it asks for, so a corpus added
+    # there but not here fails here rather than in a run.
     assert set(looked_up) == set(module._NLTK_RESOURCES)
     assert len(looked_up) == len(module._NLTK_RESOURCES)
 
@@ -286,10 +284,9 @@ def test_the_verified_resources_match_upstreams_download_helper(
 async def test_feedback_stops_when_the_corpora_are_missing(
     monkeypatch: pytest.MonkeyPatch,
 ):
-    # Teeth for the call site rather than the helper: unwire the check from
-    # `feedback()` and this is what goes red. The faked evaluator grades happily
-    # with no NLTK data at all, which is exactly how the real one hid the
-    # problem -- only the checkers that reach NLTK ever noticed.
+    # Teeth for the call site, not the helper: unwire the check from `feedback()`
+    # and this is what goes red. The faked evaluator grades happily with no NLTK
+    # data, which is exactly how the real one hid the problem.
     _install_fake_evaluator(monkeypatch)
 
     import nltk


### PR DESCRIPTION
## Type

- fix — bug fix or alignment correction

## Summary

Started as "why does CI have a bare `import sieval.community.ifbench.instructions`
step?" — and that step turned out not to be the problem. It only *serialized* a
fetch that happens either way. Chasing where the fetch could actually go wrong
surfaced a scoring bug.

- **IFBench scored a biased subset when its NLTK corpora were missing.** Upstream's
  `download_nltk_resources()` calls `nltk.download(..., quiet=True)` and never
  re-checks; `nltk.download` defaults to `raise_on_error=False`. Offline, the import
  completes as if the data were there and the absence surfaces one `LookupError` at a
  time, only in the checkers that reach NLTK. Those samples land in `fails` while
  `report()`'s `denominator_policy: judged` scores the remainder — a plausible-looking
  number over the subset whose constraints never touched NLTK. Not a failed run, a
  wrong one. `feedback()` now verifies all four resources first, so every sample stops
  naming what is missing and no partial score is reported.
- **The xdist collection race moves from `ci.yml` into `tests/unit/tasks/conftest.py`**,
  where it also covers a local `pytest -n auto`. It must run at conftest *import* time:
  the race is between test-module imports during collection, which finishes before any
  fixture runs.
- **CI caches the two corpus directories.** That on-demand fetch is the one dependency
  in the job no lockfile pins and no hash covers.

`sieval/community/` is untouched. It mirrors its upstream exactly, which is also why
the Multi-IF sibling looks different — upstream IFBench ships a download helper and
upstream Multi-IF ships none, so one bootstraps from inside `community/` and the other
from its task layer. Same guarantee to the caller, opposite shape. Deliberately not
extracted into a shared helper: different resource lists over different upstream
shapes is not the coupling that earns an abstraction.

## Related Issues

Refs #107 (whose CI warm-up step this replaces).

## Test Plan

### Automated

- [x] Lint/format clean (`ruff check && ruff format --check`)
- [x] Type check clean (`ty check`)
- [x] Unit tests pass — 5673 passed at CI's scope
      (`tests/unit tests/integration tests/acceptance -m "not stress and not benchmark" -n 4`),
      re-run after rebase onto `da8178e3`
- [x] `check_preflight.py` all green; `sync_meta_index.py --check` and
      `sync_package_stubs.py --check` both clean

### Manual

Both new assertions are **reverse-mutation checked** — a green suite alone would not
show they have teeth:

- [x] Replace the `_ensure_nltk_resources()` call in `feedback()` with `pass` →
      `test_feedback_stops_when_the_corpora_are_missing` fails (`DID NOT RAISE`).
      Everything else stays green, which is the point: the faked evaluator grades
      happily with no NLTK data at all, exactly how the real one hid this.
- [x] Delete `corpora/stopwords` from `_NLTK_RESOURCES` → the drift pin
      (`test_the_verified_resources_match_upstreams_download_helper`) and the
      missing-resource test both fail. That pin drives *upstream's own helper* with
      every lookup failing and compares what it asks for, so a corpus added upstream
      without being added here fails in CI rather than in a run.

The conftest warm path is verified out of band (a fixture-free module-scope block is
not reachable from a test):

- [x] Outside xdist: inert — no import, no files.
- [x] Four concurrent workers sharing one run id: **exactly one** does the import, three
      skip via the sentinel; sentinel lands at the shared per-run path.
- [x] `pytest_sessionfinish` removes both files — verified `/tmp` is clean after a real
      `-n 4` run.
- [x] `PYTEST_XDIST_WORKER` and `PYTEST_XDIST_TESTRUNUID` confirmed present at conftest
      *import* time in each worker (and absent in the controller and in non-xdist runs),
      since the whole gate depends on that.

Not verified: a genuinely cold download under contention. Forcing one would mean
clearing this box's `~/nltk_data`, and `nltk.data.path` always includes it, so a scratch
`SIEVAL_IFBENCH_NLTK_DATA` still resolves from there. The serialization is verified
structurally instead (one importer out of four); #107 carries the cold-import repro.

## Checklist

### Required (all PRs)

- [x] PR title follows conventional format
- [x] No internal paths, credentials, or personal info in committed files (`sanitize.sh` clean)
- [x] AI-generated code has `AI-Generated Code - <model> (<provider>)` in module docstring
      — all three edited files already carry theirs; per repo convention the attribution
      is set at creation and not rewritten on edit
- [x] No new upper-layer dependencies added to `core/`
- [x] Deleted code verified — the removed CI step had no other caller; `filelock` is
      already in the `default` group (`pdm.lock`), so no dependency was added

### If: Breaking Change

- [x] Described what breaks and migration path in Summary — **a run that previously
      produced an IFBench number on a box with no NLTK corpora now fails outright.**
      The number it used to produce was wrong. Migration: pre-stage the corpora and
      point `SIEVAL_IFBENCH_NLTK_DATA` at them, which the error message says.
- [x] Existing tests updated to reflect new behavior — the one test driving `feedback()`
      through a faked evaluator now stages the corpora via a fixture, so it stays
      hermetic on a box that never downloaded them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
