### PR TITLE
feat(tasks): sysbench reports every breakdown rate's denominator, and counts what it used to drop

### DIFF
--- a/sieval/tasks/sysbench_0shot_gen.py
+++ b/sieval/tasks/sysbench_0shot_gen.py
@@ -696,12 +696,24 @@ class SysBenchZeroShotGenTask(
         # what upstream computes (`analysis_eval_results` appends the all-satisfied
         # indicator `是否可用` to its align buckets). `csr_*` is kept beside it because
         # it is the finer signal, but it is NOT the published column.
+        # Every rate below is reported with the count it was divided by. A breakdown
+        # cell is not readable without one: `csr_misalign` over 4 constraints and over
+        # 400 are the same number and a different claim, and the reader who wants to
+        # pool the cells back to the headline -- which is upstream's own `tab6_csr_full`
+        # pairing -- cannot weight them without the denominators. `turn_{t}_n_turns`
+        # already did this for one of the four families here; the other three, and the
+        # per-position CSR's own denominator, are the rest of that convention.
         for alignment, (satisfied, criteria, full_turns, cells) in sorted(
             by_alignment.items()
         ):
             if alignment and cells:
                 metrics[f"csr_{alignment}"] = satisfied / criteria * 100
                 metrics[f"isr_{alignment}"] = full_turns / cells * 100
+                # Two denominators, not one: `csr_*` pools over constraints while
+                # `isr_*` averages over turns, so neither is recoverable from the
+                # other's rate -- the same reason `by_alignment` carries both counts.
+                metrics[f"csr_{alignment}_n_criteria"] = float(criteria)
+                metrics[f"isr_{alignment}_n_turns"] = float(cells)
 
         # Per-turn-position cells: SysBench's subject is how adherence decays across a
         # conversation, and the headline averages that decay away. Computed here rather
@@ -719,6 +731,10 @@ class SysBenchZeroShotGenTask(
             # against the wrong one looks like a different model.
             metrics[f"turn_{position}_isr"] = full_turns / cells * 100
             metrics[f"turn_{position}_n_turns"] = float(cells)
+            # `turn_{t}_csr`'s own denominator, which is NOT `n_turns`: turns carry
+            # different constraint counts, so the position's constraint total is a
+            # separate number and the one the CSR cell was divided by.
+            metrics[f"turn_{position}_n_criteria"] = float(criteria)
 
         # Table 4's `R_t`: the fraction of sessions whose first *t* turns ALL satisfied
         # every constraint -- upstream's `plot/tab4_turn.py`, which credits position
@@ -733,10 +749,38 @@ class SysBenchZeroShotGenTask(
                 prefix_cells[position][1] += 1
         for position, (hits, sessions) in sorted(prefix_cells.items()):
             metrics[f"turn_{position}_isr_cumulative"] = hits / sessions * 100
+            # A third denominator, different again from the two above: sessions that
+            # DECLARE at least `position` turns, where `turn_{t}_n_turns` counts turns
+            # that were reached and graded. A walk that died mid-session separates them,
+            # which is the case this series exists to punish -- so reporting one as if
+            # it were the other would hide exactly the sessions R_t is about.
+            metrics[f"turn_{position}_isr_cumulative_n_sessions"] = float(sessions)
 
         # Per constraint category, pooled over constraints rather than turns.
+        #
+        # `total` cannot be 0 -- a bucket is created by the increment that fills it --
+        # so the live half of the old `if name and total` guard was `name`, and what it
+        # dropped was every constraint upstream left untyped. That drop was SILENT and
+        # it breaks the invariant the type cells exist to support: the cells pooled to
+        # less than the headline, with nothing in the report saying by how much or that
+        # anything was missing. A category is still not invented for them -- upstream's
+        # six are upstream's six -- so the residual is reported as a count instead.
+        n_criteria_untyped = 0
         for name, (satisfied, total) in sorted(type_totals.items()):
-            if name and total:
-                metrics[f"csr_type_{name}"] = satisfied / total * 100
+            if not name:
+                n_criteria_untyped += total
+                continue
+            metrics[f"csr_type_{name}"] = satisfied / total * 100
+            metrics[f"csr_type_{name}_n_criteria"] = float(total)
+        # Always emitted, including as 0.0: a reader who has to distinguish "none were
+        # untyped" from "this build does not report it" is back to guessing, and a key
+        # that appears only in the bad case is a key nobody has a baseline for.
+        metrics["n_criteria_untyped"] = float(n_criteria_untyped)
+        # The same silence on the other axis: a turn whose alignment label is missing is
+        # in `csr`/`isr` and in no alignment cell. `by_alignment` is keyed by the label,
+        # so an unlabelled turn lands under "" and the guard above skips it. Read with
+        # `.get`, because `by_alignment` is a defaultdict and indexing it here would
+        # create the bucket as a side effect of asking whether it exists.
+        metrics["n_turns_unaligned"] = float(by_alignment.get("", (0, 0, 0, 0))[3])
 
         return metrics | health_metrics(finals)

--- a/sieval/tasks/sysbench_0shot_gen.py
+++ b/sieval/tasks/sysbench_0shot_gen.py
@@ -642,9 +642,13 @@ class SysBenchZeroShotGenTask(
                     graded[1] += n_turn_criteria
                     n_graded_turns += 1
                 for cid, verdict in verdicts.items():
-                    bucket = type_totals[
-                        _CONSTRAINT_TYPES.get(types.get(cid, ""), types.get(cid, ""))
-                    ]
+                    # Coerced: the loader normalises `alignment` but stores
+                    # `criteria` raw, so `criteria_type: null` would key this
+                    # bucket under None and make the `sorted()` below raise --
+                    # losing the report, not one constraint. Absent and null
+                    # both mean untyped here.
+                    raw_type = str(types.get(cid) or "")
+                    bucket = type_totals[_CONSTRAINT_TYPES.get(raw_type, raw_type)]
                     bucket[0] += bool(verdict)
                     bucket[1] += 1
 
@@ -776,11 +780,14 @@ class SysBenchZeroShotGenTask(
         # untyped" from "this build does not report it" is back to guessing, and a key
         # that appears only in the bad case is a key nobody has a baseline for.
         metrics["n_criteria_untyped"] = float(n_criteria_untyped)
-        # The same silence on the other axis: a turn whose alignment label is missing is
-        # in `csr`/`isr` and in no alignment cell. `by_alignment` is keyed by the label,
-        # so an unlabelled turn lands under "" and the guard above skips it. Read with
-        # `.get`, because `by_alignment` is a defaultdict and indexing it here would
-        # create the bucket as a side effect of asking whether it exists.
-        metrics["n_turns_unaligned"] = float(by_alignment.get("", (0, 0, 0, 0))[3])
+        # The same silence on the other axis, and it takes BOTH counts for the
+        # reason the alignment cells take two denominators: an unlabelled turn
+        # (which lands under "", so the guard above skips it) leaves `csr_*` short
+        # by constraints and `isr_*` short by turns, and neither count sizes the
+        # other. `.get`, because indexing this defaultdict would create the bucket
+        # as a side effect of asking whether it exists.
+        unaligned = by_alignment.get("", (0, 0, 0, 0))
+        metrics["n_criteria_unaligned"] = float(unaligned[1])
+        metrics["n_turns_unaligned"] = float(unaligned[3])
 
         return metrics | health_metrics(finals)

--- a/tests/unit/tasks/test_sysbench_0shot_gen.py
+++ b/tests/unit/tasks/test_sysbench_0shot_gen.py
@@ -856,27 +856,73 @@ def test_the_untyped_count_is_reported_as_zero_rather_than_omitted():
     m = _report([_judged_session(1, [({"1": True}, {"1": "格式约束"}, "align")])])
     assert m["n_criteria_untyped"] == 0
     assert m["n_turns_unaligned"] == 0
+    assert m["n_criteria_unaligned"] == 0
+
+
+def test_a_constraint_typed_null_is_counted_untyped_rather_than_killing_the_report():
+    """An explicit null type must not reach the bucket key.
+
+    `criteria` is stored raw by the loader, so ``criteria_type: null`` keys a
+    bucket under None and the sort over type buckets raises `TypeError` -- losing
+    the whole report rather than one constraint.
+    """
+    m = _report(
+        [
+            _judged_session(
+                1,
+                [
+                    (
+                        {"1": True, "2": False},
+                        {"1": "格式约束", "2": None},
+                        "align",
+                    )
+                ],
+            )
+        ]
+    )
+    assert m["csr"] == pytest.approx(50.0)
+    assert m["csr_type_format_n_criteria"] == 1
+    assert m["n_criteria_untyped"] == 1
+    # No bucket keyed by the null itself, under any spelling.
+    assert not [k for k in m if k.startswith("csr_type_") and "None" in k]
+    assert (
+        m["csr_type_format_n_criteria"] + m["n_criteria_untyped"]
+        == m["n_criteria_graded"]
+    )
 
 
 def test_a_turn_with_no_alignment_label_is_counted_not_dropped():
-    # The turn is in `csr`, `isr` and `n_turns`; it is in neither alignment cell,
-    # so without this count the two cells silently fail to cover the headline.
+    """It is in ``csr``, ``isr`` and ``n_turns`` and in neither alignment cell.
+
+    The unlabelled turn carries 3 constraints against the labelled turn's 1, which
+    is what gives this test teeth: with one apiece both residuals are 1, so
+    reporting either count for both would pass.
+    """
     m = _report(
         [
             _judged_session(
                 1,
                 [
                     ({"1": True}, {"1": "格式约束"}, "align"),
-                    ({"1": False}, {"1": "格式约束"}, ""),
+                    (
+                        {"1": False, "2": False, "3": False},
+                        {"1": "格式约束", "2": "格式约束", "3": "格式约束"},
+                        "",
+                    ),
                 ],
             )
         ]
     )
     assert m["n_turns"] == 2
-    assert m["csr"] == pytest.approx(50.0)
-    assert m["isr_align_n_turns"] == 1
-    assert "csr_" not in [k for k in m if k == "csr_"]
+    assert m["csr"] == pytest.approx(25.0)
+    assert "csr_" not in m
     assert m["n_turns_unaligned"] == 1
+    assert m["n_criteria_unaligned"] == 3
+    # Both alignment axes close to the headline using only reported numbers.
+    assert m["isr_align_n_turns"] + m["n_turns_unaligned"] == m["n_turns"]
+    assert (
+        m["csr_align_n_criteria"] + m["n_criteria_unaligned"] == m["n_criteria_graded"]
+    )
 
 
 def test_the_judge_prompt_carries_the_system_prompt_criteria_and_both_turns():

--- a/tests/unit/tasks/test_sysbench_0shot_gen.py
+++ b/tests/unit/tasks/test_sysbench_0shot_gen.py
@@ -737,6 +737,148 @@ def test_the_cumulative_turn_series_is_table_4s_r_columns_and_averages_to_ssr():
     )
 
 
+def test_every_breakdown_rate_reports_the_count_it_was_divided_by():
+    """A breakdown cell without its denominator is a number, not a measurement.
+
+    ``csr_misalign`` over 4 constraints and over 400 are the same value and a
+    different claim, and this is the check that would have caught the report
+    emitting one of the four families' denominators and none of the rest.
+    """
+    m = _report(
+        [
+            _judged_session(
+                1,
+                [
+                    ({"1": True}, {"1": "格式约束"}, "align"),
+                    (
+                        {"1": False, "2": True},
+                        {"1": "格式约束", "2": "内容约束"},
+                        "misalign",
+                    ),
+                ],
+            )
+        ]
+    )
+    # Every rate key maps to the key naming its own denominator. Written as a
+    # table rather than a loop over `m`, because the point is that a NEW rate
+    # added without one has to appear here to be believed.
+    for rate, denominator in (
+        ("csr_align", "csr_align_n_criteria"),
+        ("isr_align", "isr_align_n_turns"),
+        ("csr_misalign", "csr_misalign_n_criteria"),
+        ("isr_misalign", "isr_misalign_n_turns"),
+        ("turn_1_csr", "turn_1_n_criteria"),
+        ("turn_1_isr", "turn_1_n_turns"),
+        ("turn_2_csr", "turn_2_n_criteria"),
+        ("turn_1_isr_cumulative", "turn_1_isr_cumulative_n_sessions"),
+        ("csr_type_format", "csr_type_format_n_criteria"),
+        ("csr_type_content", "csr_type_content_n_criteria"),
+    ):
+        assert rate in m, rate
+        assert denominator in m, f"{rate} has no denominator key {denominator}"
+        assert m[denominator] > 0, denominator
+    # And the three denominators are genuinely different counts, which is why one
+    # of them cannot stand in for the others: turn 2 holds 2 constraints in 1 turn.
+    assert m["turn_2_n_criteria"] == 2
+    assert m["turn_2_n_turns"] == 1
+    assert m["turn_2_isr_cumulative_n_sessions"] == 1
+
+
+def test_the_type_cells_pool_to_the_headline_using_only_reported_numbers():
+    """The same invariant as ``..._come_from_one_total``, weighted from the report.
+
+    That test has to hardcode the per-category constraint counts, so it passes on
+    a report a consumer cannot check. With the denominators emitted, the pooling
+    is a reduction over the report alone -- and it fails if a cell goes missing.
+    """
+    m = _report(
+        [
+            _judged_session(
+                1,
+                [
+                    ({"1": True}, {"1": "格式约束"}, "align"),
+                    (
+                        {"1": True, "2": False},
+                        {"1": "格式约束", "2": "内容约束"},
+                        "misalign",
+                    ),
+                ],
+            )
+        ]
+    )
+    cells = [
+        k for k in m if k.startswith("csr_type_") and not k.endswith("_n_criteria")
+    ]
+    satisfied = sum(m[k] / 100 * m[f"{k}_n_criteria"] for k in cells)
+    total = sum(m[f"{k}_n_criteria"] for k in cells) + m["n_criteria_untyped"]
+    assert total == m["n_criteria_graded"]
+    assert m["csr"] == pytest.approx(satisfied / total * 100)
+
+
+def test_a_constraint_upstream_left_untyped_is_counted_not_dropped():
+    """It is in ``csr``, so it must be visible in the breakdown's arithmetic.
+
+    Silently skipping it made the type cells pool to less than the headline with
+    nothing saying so: 2 satisfied of 4 reads as ``csr`` 50.0 beside a lone
+    ``csr_type_format`` of 100.0, which is the shape of a model that aced the only
+    category measured rather than one that failed half the constraints.
+    """
+    m = _report(
+        [
+            _judged_session(
+                1,
+                [
+                    (
+                        {"1": True, "2": True, "3": False, "4": False},
+                        {"1": "格式约束", "2": "格式约束", "3": "", "4": ""},
+                        "align",
+                    )
+                ],
+            )
+        ]
+    )
+    assert m["csr"] == pytest.approx(50.0)
+    assert m["csr_type_format"] == pytest.approx(100.0)
+    assert m["csr_type_format_n_criteria"] == 2
+    # No invented category for them -- upstream's six stay upstream's six.
+    assert not [k for k in m if k.startswith("csr_type_") and "untyped" in k]
+    # The residual is what makes the 50.0 and the 100.0 reconcilable.
+    assert m["n_criteria_untyped"] == 2
+    assert (
+        m["csr_type_format_n_criteria"] + m["n_criteria_untyped"]
+        == m["n_criteria_graded"]
+    )
+
+
+def test_the_untyped_count_is_reported_as_zero_rather_than_omitted():
+    # A key present only in the bad case gives a reader no baseline, and absence
+    # then has to be read as either "clean" or "old build".
+    m = _report([_judged_session(1, [({"1": True}, {"1": "格式约束"}, "align")])])
+    assert m["n_criteria_untyped"] == 0
+    assert m["n_turns_unaligned"] == 0
+
+
+def test_a_turn_with_no_alignment_label_is_counted_not_dropped():
+    # The turn is in `csr`, `isr` and `n_turns`; it is in neither alignment cell,
+    # so without this count the two cells silently fail to cover the headline.
+    m = _report(
+        [
+            _judged_session(
+                1,
+                [
+                    ({"1": True}, {"1": "格式约束"}, "align"),
+                    ({"1": False}, {"1": "格式约束"}, ""),
+                ],
+            )
+        ]
+    )
+    assert m["n_turns"] == 2
+    assert m["csr"] == pytest.approx(50.0)
+    assert m["isr_align_n_turns"] == 1
+    assert "csr_" not in [k for k in m if k == "csr_"]
+    assert m["n_turns_unaligned"] == 1
+
+
 def test_the_judge_prompt_carries_the_system_prompt_criteria_and_both_turns():
     messages = [
         {"role": "system", "content": "SYS"},


### PR DESCRIPTION
`report` publishes four families of breakdown cells and emitted the denominator
for one of them -- `turn_{t}_n_turns` -- so the other three cells were numbers a
reader could not size. `csr_misalign` over 4 constraints and over 400 are the
same value and a different claim.

Additive: no existing key changes value or disappears, `score` included.

  turn_{t}_n_criteria                     `turn_{t}_csr`'s own denominator, which
                                          is NOT n_turns -- turns carry different
                                          constraint counts
  csr_{alignment}_n_criteria              two denominators, because `csr_*` pools
  isr_{alignment}_n_turns                 over constraints and `isr_*` averages
                                          over turns; neither is recoverable from
                                          the other's rate
  turn_{t}_isr_cumulative_n_sessions      a third count again: sessions DECLARING
                                          >= t turns, where n_turns counts turns
                                          reached. A walk that died mid-session is
                                          exactly what separates them
  csr_type_{name}_n_criteria              per category
  n_criteria_untyped                      the residual, always emitted
  n_turns_unaligned                       the same residual on the other axis

The repo's own test showed the gap: `test_csr_and_the_constraint_type_breakdown_
come_from_one_total` asserts the type cells pool to the headline, and has to
hardcode the weights (`* 2`, `* 1`) to do it -- so it passes on a report whose
consumer cannot check the same invariant. The new test performs that reduction
from the report alone.

And `if name and total` was hiding a second defect. `total` cannot be 0: a bucket
is created by the increment that fills it, so the live half of that guard was
`name`, and what it dropped was every constraint upstream left untyped
(`criteria_type` absent -> "" at the record layer). Silently:

    4 constraints, 2 satisfied, 2 of them untyped
      csr             50.0
      csr_type_format 100.0        <- the only cell reported
      (nothing saying 2 constraints are missing from the breakdown)

which is the shape of a model that aced the one category measured, not one that
failed half its constraints. No category is invented for them -- upstream's six
stay upstream's six -- so the residual is a count, and `n_criteria_untyped` is
emitted as 0.0 in the clean case too: a key that appears only when something is
wrong gives a reader no baseline, and its absence then means either "clean" or
"old build".

Whether the released split contains untyped constraints I could not measure --
the data is not on this machine -- so this is a latent defect for the shipped
file and a live one for any hand-placed or extended copy, which the loader
supports (`name_or_path` may be the JSON file itself). The unlabelled-alignment
case is the same shape: the turn is in `csr`, `isr` and `n_turns`, and in neither
alignment cell.

5 new tests, each verified to fail without this change (KeyError on the missing
denominators; the untyped case failing on the pooling arithmetic). 47 pass in
tests/unit/{tasks,datasets}/*sysbench*, ruff and ty clean.
