### PR TITLE
feat(tasks): iheval records name their row, not just their cell

### DIFF
--- a/sieval/tasks/iheval_0shot_gen.py
+++ b/sieval/tasks/iheval_0shot_gen.py
@@ -386,16 +386,14 @@ class IHEvalZeroShotGenTask(
         messages.append({"role": "user", "content": raw["instruction"]})
 
         extra: dict = {
-            # The stable per-row key, alongside the three cell components below.
-            # `(subtask, setting, variant)` names a CELL holding many rows, so on
-            # its own it cannot say which row a record came from -- and the
-            # record's `sample_id` is a positional index into the loaded test set
-            # (`Runner`: `range(dataset_size)`), which moves under `limit` or a
-            # dataset filter while pointing at a different row just as silently.
-            # `uid` is what the dataset builds for exactly this (see
-            # `IHEvalDatasetSample`: upstream ids are unique only within a cell),
-            # and `key` is already on the ifeval / ifbench / multi_if records.
-            "uid": raw["uid"],
+            # The stable per-row key, spelled `key` to match the ifeval /
+            # ifbench / multi_if records. Neither alternative names a row:
+            # `(subtask, setting, variant)` below names a CELL holding many, and
+            # the record's own `sample_id` is a positional index (`Runner`:
+            # `range(dataset_size)`) that moves under `limit` or a filter. The
+            # value is the dataset's composed `uid`, not upstream's `sample_id`,
+            # which repeats across cells (see `IHEvalDatasetSample`).
+            "key": raw["uid"],
             "subtask": raw["subtask"],
             "setting": raw["setting"],
             "variant": raw["variant"],
@@ -437,7 +435,7 @@ class IHEvalZeroShotGenTask(
 
         if subtask in ("single-turn", "multi-turn"):
             return self._judge_rule_following(raw, answer, prediction)
-        return self._judge_scored(subtask, answer, prediction, uid=raw["uid"])
+        return self._judge_scored(raw, answer, prediction)
 
     def _judge_rule_following(self, raw, answer, prediction: str):
         from sieval.community.instruction_following_eval.evaluation_lib import (
@@ -482,15 +480,13 @@ class IHEvalZeroShotGenTask(
             [build_rollout_judgement(0, correct, score=score, metrics=metrics)],
             score=score,
             metrics=metrics,
-            # `uid` travels on the judgement as well as the prompt record, the way
-            # ifeval / ifbench carry `key` on both: a judgements-only export is a
-            # normal way to read a run, and joining back to the prompt record on
-            # `sample_id` to recover the row identity defeats the point of having
-            # a stable one.
-            extra={"uid": raw["uid"], "follow_instruction_list": detail},
+            # On the judgement as well as the prompt record, the way ifeval /
+            # ifbench carry theirs: a judgements-only export is a normal way to
+            # read a run, and joining back on `sample_id` defeats the purpose.
+            extra={"key": raw["uid"], "follow_instruction_list": detail},
         )
 
-    def _judge_scored(self, subtask: str, answer, prediction: str, *, uid: str):
+    def _judge_scored(self, raw, answer, prediction: str):
         from sieval.community.iheval import (
             eval_lang_detect,
             eval_mixed,
@@ -500,6 +496,7 @@ class IHEvalZeroShotGenTask(
             eval_verb_extract,
         )
 
+        subtask = raw["subtask"]
         if subtask in ("user-prompt-hijack", "system-prompt-extract"):
             strict = float(eval_tensortrust(answer, prediction))
         elif subtask == "lang-detect":
@@ -534,11 +531,10 @@ class IHEvalZeroShotGenTask(
             [build_rollout_judgement(0, score >= 1.0, score=score, metrics=metrics)],
             score=score,
             metrics=metrics,
-            # This builder had no `extra` at all, so the row key is the whole of
-            # it. Some of these subtasks score continuously (ROUGE-L, word F1),
-            # and a fractional score is the kind a reader goes back to the source
-            # row for -- which is the case that needs the key most.
-            extra={"uid": uid},
+            # This builder had no `extra` at all. These subtasks include the
+            # continuous scorers (ROUGE-L, word F1), whose fractional scores are
+            # exactly what sends a reader back to the source row.
+            extra={"key": raw["uid"]},
         )
 
     @override

--- a/sieval/tasks/iheval_0shot_gen.py
+++ b/sieval/tasks/iheval_0shot_gen.py
@@ -386,6 +386,16 @@ class IHEvalZeroShotGenTask(
         messages.append({"role": "user", "content": raw["instruction"]})
 
         extra: dict = {
+            # The stable per-row key, alongside the three cell components below.
+            # `(subtask, setting, variant)` names a CELL holding many rows, so on
+            # its own it cannot say which row a record came from -- and the
+            # record's `sample_id` is a positional index into the loaded test set
+            # (`Runner`: `range(dataset_size)`), which moves under `limit` or a
+            # dataset filter while pointing at a different row just as silently.
+            # `uid` is what the dataset builds for exactly this (see
+            # `IHEvalDatasetSample`: upstream ids are unique only within a cell),
+            # and `key` is already on the ifeval / ifbench / multi_if records.
+            "uid": raw["uid"],
             "subtask": raw["subtask"],
             "setting": raw["setting"],
             "variant": raw["variant"],
@@ -427,7 +437,7 @@ class IHEvalZeroShotGenTask(
 
         if subtask in ("single-turn", "multi-turn"):
             return self._judge_rule_following(raw, answer, prediction)
-        return self._judge_scored(subtask, answer, prediction)
+        return self._judge_scored(subtask, answer, prediction, uid=raw["uid"])
 
     def _judge_rule_following(self, raw, answer, prediction: str):
         from sieval.community.instruction_following_eval.evaluation_lib import (
@@ -472,10 +482,15 @@ class IHEvalZeroShotGenTask(
             [build_rollout_judgement(0, correct, score=score, metrics=metrics)],
             score=score,
             metrics=metrics,
-            extra={"follow_instruction_list": detail},
+            # `uid` travels on the judgement as well as the prompt record, the way
+            # ifeval / ifbench carry `key` on both: a judgements-only export is a
+            # normal way to read a run, and joining back to the prompt record on
+            # `sample_id` to recover the row identity defeats the point of having
+            # a stable one.
+            extra={"uid": raw["uid"], "follow_instruction_list": detail},
         )
 
-    def _judge_scored(self, subtask: str, answer, prediction: str):
+    def _judge_scored(self, subtask: str, answer, prediction: str, *, uid: str):
         from sieval.community.iheval import (
             eval_lang_detect,
             eval_mixed,
@@ -519,6 +534,11 @@ class IHEvalZeroShotGenTask(
             [build_rollout_judgement(0, score >= 1.0, score=score, metrics=metrics)],
             score=score,
             metrics=metrics,
+            # This builder had no `extra` at all, so the row key is the whole of
+            # it. Some of these subtasks score continuously (ROUGE-L, word F1),
+            # and a fractional score is the kind a reader goes back to the source
+            # row for -- which is the case that needs the key most.
+            extra={"uid": uid},
         )
 
     @override

--- a/tests/unit/tasks/test_iheval_0shot_gen.py
+++ b/tests/unit/tasks/test_iheval_0shot_gen.py
@@ -213,6 +213,37 @@ class TestPreprocess:
         record = await task.preprocess(row, _ctx(row))
         assert "tools" not in record["extra"]
 
+    @pytest.mark.anyio
+    async def test_the_record_names_its_row_not_just_its_cell(self):
+        """Two rows of one cell must be distinguishable on the record alone.
+
+        `(subtask, setting, variant)` is a cell key and a cell holds many rows,
+        so a record carrying only those three says which *group* it came from and
+        not which row. The run's own `sample_id` is no help: it is a positional
+        index into the loaded test set, so it names a different row under a
+        different `limit` or filter without anything in the record changing.
+        """
+        rows = [
+            _row(
+                subtask="lang-detect",
+                setting="conflict",
+                sample_id=sample_id,
+                answer="fr",
+            )
+            for sample_id in ("1", "2")
+        ]
+        task = _task(rows)
+        records = [await task.preprocess(row, _ctx(row)) for row in rows]
+
+        cell = [
+            (r["extra"]["subtask"], r["extra"]["setting"], r["extra"]["variant"])
+            for r in records
+        ]
+        assert cell[0] == cell[1], "same cell -- the premise of the test"
+        uids = [r["extra"]["uid"] for r in records]
+        assert uids[0] != uids[1]
+        assert uids == [row["uid"] for row in rows]
+
 
 class TestInfer:
     @pytest.mark.anyio
@@ -296,6 +327,24 @@ class TestFeedback:
         detail = _verdict(ctx)["extra"]["follow_instruction_list"]
         assert detail["strict"] == [True, True]
         assert _verdict(ctx)["metrics"]["strict_follow_all"] is True
+
+    @pytest.mark.anyio
+    async def test_both_grading_paths_put_the_row_key_on_the_judgement(self):
+        """A judgements-only export is a normal way to read a run.
+
+        The two paths build their judgement in different places -- rule-following
+        through the IFEval checkers, everything else through the scored graders --
+        so the key has to be on both or the coverage is a coin flip on subtask.
+        """
+        rule_following = _row(
+            subtask="single-turn",
+            setting="conflict",
+            answer={"instruction_id_list": ["punctuation:no_comma"], "kwargs": [{}]},
+        )
+        scored = _row(subtask="lang-detect", setting="conflict", answer="fr")
+        for row, response in ((rule_following, "no commas"), (scored, "fr")):
+            ctx = await _judge(_task([row]), row, response)
+            assert _verdict(ctx)["extra"]["uid"] == row["uid"], row["subtask"]
 
     @pytest.mark.anyio
     async def test_unknown_subtask_is_an_error(self):

--- a/tests/unit/tasks/test_iheval_0shot_gen.py
+++ b/tests/unit/tasks/test_iheval_0shot_gen.py
@@ -217,11 +217,9 @@ class TestPreprocess:
     async def test_the_record_names_its_row_not_just_its_cell(self):
         """Two rows of one cell must be distinguishable on the record alone.
 
-        `(subtask, setting, variant)` is a cell key and a cell holds many rows,
-        so a record carrying only those three says which *group* it came from and
-        not which row. The run's own `sample_id` is no help: it is a positional
-        index into the loaded test set, so it names a different row under a
-        different `limit` or filter without anything in the record changing.
+        A cell holds many rows, so `(subtask, setting, variant)` says which
+        *group* a record came from and not which row; the run's own `sample_id`
+        is a positional index, so it renames rows under a different `limit`.
         """
         rows = [
             _row(
@@ -240,9 +238,10 @@ class TestPreprocess:
             for r in records
         ]
         assert cell[0] == cell[1], "same cell -- the premise of the test"
-        uids = [r["extra"]["uid"] for r in records]
-        assert uids[0] != uids[1]
-        assert uids == [row["uid"] for row in rows]
+        # Pins the value, not just its presence: never upstream's `sample_id`.
+        keys = [r["extra"]["key"] for r in records]
+        assert keys[0] != keys[1]
+        assert keys == [row["uid"] for row in rows]
 
 
 class TestInfer:
@@ -332,9 +331,8 @@ class TestFeedback:
     async def test_both_grading_paths_put_the_row_key_on_the_judgement(self):
         """A judgements-only export is a normal way to read a run.
 
-        The two paths build their judgement in different places -- rule-following
-        through the IFEval checkers, everything else through the scored graders --
-        so the key has to be on both or the coverage is a coin flip on subtask.
+        The two paths build their judgement in different places, so the key has
+        to be on both or coverage is a coin flip on which subtask you ran.
         """
         rule_following = _row(
             subtask="single-turn",
@@ -344,7 +342,7 @@ class TestFeedback:
         scored = _row(subtask="lang-detect", setting="conflict", answer="fr")
         for row, response in ((rule_following, "no commas"), (scored, "fr")):
             ctx = await _judge(_task([row]), row, response)
-            assert _verdict(ctx)["extra"]["uid"] == row["uid"], row["subtask"]
+            assert _verdict(ctx)["extra"]["key"] == row["uid"], row["subtask"]
 
     @pytest.mark.anyio
     async def test_unknown_subtask_is_an_error(self):


### PR DESCRIPTION
A record's `extra` carried `subtask`, `setting` and `variant` -- which
together name a *cell*, and a cell holds many rows. Two different IHEval
rows therefore produced byte-identical `extra`, and nothing in a result
directory said which of them a score belonged to.

The run's own `sample_id` does not close the gap. It is a positional index
into the loaded test set (`Runner`: `pending_ids = [i for i in
range(dataset_size) ...]`), so the same index names a different row under a
different `limit` or dataset filter, with nothing in the record marking the
change.

The dataset already builds the key this needs. `IHEvalDatasetSample`
documents `uid` as "the stable per-row key", for the stated reason that
"upstream ids are only unique within a cell" -- and the task dropped it.
`ifeval`, `ifbench` and `multi_if` all carry `key` on their records, so this
is iheval joining an existing convention rather than inventing one.

`uid` goes on the prompt record and on both judgement builders, the way
ifeval and ifbench carry `key` on both: a judgements-only export is a normal
way to read a run, and joining back to the prompt record on `sample_id` to
recover row identity defeats the point of having a stable key. The scored
path had no `extra` at all, so it gains one.

Purely additive. `report` groups cells from `ctx.raw_sample`, not from
`extra`, and reads `extra` through a single targeted lookup
(`follow_instruction_list`), so no existing metric changes value.

The three places the task already used the cell-local `sample_id` are
correctly scoped and left alone: the IFEval `InputExample.key` grades one
row at a time, and the two reference-cell helpers compare ids within a
single cell, where cell-local uniqueness is sufficient.

Tests: two, both verified to fail without the change (`KeyError: 'uid'`).
One builds two rows of one cell and asserts the cell components are equal
while the keys differ; the other asserts both grading paths carry it, since
they build their judgement in different places and coverage would otherwise
depend on which subtask you happened to run.

