### PR TITLE
feat(models): declare the per-request timeout instead of inheriting two

### DIFF
--- a/sieval/core/models/__init__.py
+++ b/sieval/core/models/__init__.py
@@ -16,6 +16,7 @@ from .chat_model import ChatModel
 from .connection_factory import (
     ASYNC_HTTP_JSON_FACTORY,
     CONNECTION_FACTORY_REGISTRY,
+    DEFAULT_REQUEST_TIMEOUT,
     OPENAI_SDK_FACTORY,
     AsyncHTTPJSONConnection,
     ConnectionFactoryRegistry,
@@ -113,6 +114,7 @@ __all__ = [
     "ConnectionRequest",
     "ConnectionScope",
     "ContentPart",
+    "DEFAULT_REQUEST_TIMEOUT",
     "Deployment",
     "DeploymentCapabilityPlan",
     "DeploymentPlanProjection",

--- a/sieval/core/models/_legacy_binding.py
+++ b/sieval/core/models/_legacy_binding.py
@@ -20,6 +20,7 @@ from sieval.core.types import JSONValue
 
 from ._fingerprint import fingerprint_mapping
 from .capabilities import RequestDefaults, Supported
+from .connection_factory import DEFAULT_REQUEST_TIMEOUT
 from .deployment import (
     ConnectionIdentity,
     ConnectionPool,
@@ -120,6 +121,7 @@ def build_legacy_openai_binding(
         base_url=api_base,
         api_key=api_key,
         max_retries=max_retries,
+        timeout=DEFAULT_REQUEST_TIMEOUT,
     )
     endpoint = str(client.base_url).rstrip("/")
     local_limiter = (

--- a/sieval/core/models/connection_factory.py
+++ b/sieval/core/models/connection_factory.py
@@ -14,6 +14,31 @@ from types import MappingProxyType
 import httpx
 from openai import AsyncOpenAI
 
+#: The per-request timeout every sieval-owned client declares.
+#:
+#: Before this constant, no sieval client passed ``timeout`` at all, so the bound
+#: on a request was whichever default the underlying library happened to ship --
+#: and the two libraries disagreed by 120x. The OpenAI SDK defaults to
+#: ``read=600``; ``httpx`` defaults to ``5`` for every phase. Which connection
+#: family a dialect was registered under therefore decided how long a generation
+#: was allowed to take, which is not a property any dialect declares or a reader
+#: could find. Neither number was sieval's, and either library can change its
+#: default in a patch release with nothing here noticing.
+#:
+#: The value is what the ``openai_sdk`` family already had in effect, so adopting
+#: it changes no behaviour on the only family with live transports today. It is
+#: the ``async_http_json`` family that moves, off a 5s read that no generation
+#: could survive: that family has no implemented transport yet, so the 5s was
+#: never a live bug -- it was a trap set for whoever implements the first
+#: Anthropic, Google, or native-serving transport, and it would present as "the
+#: endpoint is broken" rather than "our client gave up".
+#:
+#: ``connect`` stays short because a refused or unroutable endpoint should fail
+#: fast. ``read`` is long because a reasoning model emitting thousands of tokens
+#: legitimately takes minutes, and a premature read timeout is indistinguishable
+#: -- in a result directory -- from the model having produced nothing.
+DEFAULT_REQUEST_TIMEOUT = httpx.Timeout(600.0, connect=5.0)
+
 
 class UnknownConnectionFamily(ValueError):
     """No registered factory owns the requested connection family."""
@@ -191,6 +216,7 @@ def _openai_sdk_connection(request: ConnectionRequest) -> AsyncOpenAI:
         base_url=request.endpoint,
         api_key=request.credential,
         max_retries=request.max_retries,
+        timeout=DEFAULT_REQUEST_TIMEOUT,
     )
 
 
@@ -198,7 +224,11 @@ def _async_http_json_connection(
     request: ConnectionRequest,
 ) -> AsyncHTTPJSONConnection:
     transport = httpx.AsyncHTTPTransport(retries=request.max_retries)
-    client = httpx.AsyncClient(base_url=request.endpoint, transport=transport)
+    client = httpx.AsyncClient(
+        base_url=request.endpoint,
+        transport=transport,
+        timeout=DEFAULT_REQUEST_TIMEOUT,
+    )
     return AsyncHTTPJSONConnection(client, request.credential)
 
 

--- a/sieval/core/models/connection_factory.py
+++ b/sieval/core/models/connection_factory.py
@@ -16,43 +16,26 @@ from openai import AsyncOpenAI
 
 #: The per-request timeout every sieval client that talks to a model declares.
 #:
-#: Scope is the clients whose call has no bound of its own. The code-evaluator and
-#: health-check clients are excluded on purpose: each passes a per-request
-#: ``timeout`` derived from the budget it is already enforcing server-side (a
-#: sandbox's own subprocess wall, a probe interval), so a client-level default
-#: would either duplicate that number or silently contradict it.
+#: Declared rather than inherited: the OpenAI SDK defaults ``read`` to 600 and
+#: ``httpx`` defaults every phase to 5, so a dialect's connection family silently
+#: decided how long a generation could take, and either library can change its
+#: default in a patch release. The value is what ``openai_sdk`` already had in
+#: effect, so it moves only ``async_http_json`` -- whose dialects have no
+#: implemented transport yet, making its 5s a trap rather than a live bug.
 #:
-#: Before this constant, no sieval client passed ``timeout`` at all, so the bound
-#: on a request was whichever default the underlying library happened to ship --
-#: and the two libraries disagreed by 120x. The OpenAI SDK defaults to
-#: ``read=600``; ``httpx`` defaults to ``5`` for every phase. Which connection
-#: family a dialect was registered under therefore decided how long a generation
-#: was allowed to take, which is not a property any dialect declares or a reader
-#: could find. Neither number was sieval's, and either library can change its
-#: default in a patch release with nothing here noticing.
+#: Scope is clients whose call carries no bound of its own. The code-evaluator and
+#: health-check clients each pass a per-request ``timeout`` derived from a budget
+#: they already enforce server-side, which a client-level default would duplicate
+#: or contradict.
 #:
-#: The value is what the ``openai_sdk`` family already had in effect, so adopting
-#: it changes no behaviour on the only family with live transports today. It is
-#: the ``async_http_json`` family that moves, off a 5s read that no generation
-#: could survive: that family has no implemented transport yet, so the 5s was
-#: never a live bug -- it was a trap set for whoever implements the first
-#: Anthropic, Google, or native-serving transport, and it would present as "the
-#: endpoint is broken" rather than "our client gave up".
-#:
-#: ``connect`` stays short because a refused or unroutable endpoint should fail
-#: fast. ``read`` is long because a premature read timeout is indistinguishable --
-#: in a result directory -- from the model having produced nothing, and a
-#: reasoning model emitting thousands of tokens legitimately takes minutes.
-#:
-#: What ``read`` bounds is not the same quantity on both paths, so 600s means two
-#: things. Streamed, ``read`` is the gap between chunks, which makes 600s a stall
-#: tolerance rather than a generation budget. Unstreamed, it bounds the whole
-#: response, so the one number covers every one of a request's ``n`` rollouts
-#: together: sieval asks for all of them in a single call, and the non-streaming
-#: lift only sees them once the last is done. So it is the unstreamed reading that
-#: a long high-``n`` run can actually exhaust. Which one applies is not a single
-#: default -- ``SchedulingParams.stream`` is ``False``, while the legacy
-#: ``ChatModel``/``GenModel`` wrappers send ``True`` unless a caller overrides it.
+#: ``connect`` is short so an unroutable endpoint fails fast. ``read`` is long
+#: because a premature read timeout is indistinguishable, in a result directory,
+#: from the model having produced nothing. Note it bounds two different
+#: quantities: the gap between chunks when streamed (a stall tolerance), the whole
+#: response when not -- every one of a request's ``n`` rollouts together, since
+#: sieval asks for all of them in one call. That second reading is the one a long
+#: high-``n`` run can exhaust. ``SchedulingParams.stream`` is ``False``; the legacy
+#: ``ChatModel``/``GenModel`` wrappers send ``True``.
 DEFAULT_REQUEST_TIMEOUT = httpx.Timeout(600.0, connect=5.0)
 
 

--- a/sieval/core/models/connection_factory.py
+++ b/sieval/core/models/connection_factory.py
@@ -14,7 +14,13 @@ from types import MappingProxyType
 import httpx
 from openai import AsyncOpenAI
 
-#: The per-request timeout every sieval-owned client declares.
+#: The per-request timeout every sieval client that talks to a model declares.
+#:
+#: Scope is the clients whose call has no bound of its own. The code-evaluator and
+#: health-check clients are excluded on purpose: each passes a per-request
+#: ``timeout`` derived from the budget it is already enforcing server-side (a
+#: sandbox's own subprocess wall, a probe interval), so a client-level default
+#: would either duplicate that number or silently contradict it.
 #:
 #: Before this constant, no sieval client passed ``timeout`` at all, so the bound
 #: on a request was whichever default the underlying library happened to ship --
@@ -34,9 +40,19 @@ from openai import AsyncOpenAI
 #: endpoint is broken" rather than "our client gave up".
 #:
 #: ``connect`` stays short because a refused or unroutable endpoint should fail
-#: fast. ``read`` is long because a reasoning model emitting thousands of tokens
-#: legitimately takes minutes, and a premature read timeout is indistinguishable
-#: -- in a result directory -- from the model having produced nothing.
+#: fast. ``read`` is long because a premature read timeout is indistinguishable --
+#: in a result directory -- from the model having produced nothing, and a
+#: reasoning model emitting thousands of tokens legitimately takes minutes.
+#:
+#: What ``read`` bounds is not the same quantity on both paths, so 600s means two
+#: things. Streamed, ``read`` is the gap between chunks, which makes 600s a stall
+#: tolerance rather than a generation budget. Unstreamed, it bounds the whole
+#: response, so the one number covers every one of a request's ``n`` rollouts
+#: together: sieval asks for all of them in a single call, and the non-streaming
+#: lift only sees them once the last is done. So it is the unstreamed reading that
+#: a long high-``n`` run can actually exhaust. Which one applies is not a single
+#: default -- ``SchedulingParams.stream`` is ``False``, while the legacy
+#: ``ChatModel``/``GenModel`` wrappers send ``True`` unless a caller overrides it.
 DEFAULT_REQUEST_TIMEOUT = httpx.Timeout(600.0, connect=5.0)
 
 

--- a/sieval/core/models/sglang_gen_model.py
+++ b/sieval/core/models/sglang_gen_model.py
@@ -19,6 +19,7 @@ from openai import AsyncOpenAI
 from sieval.core.types import JSONValue
 
 from .capabilities import Capability
+from .connection_factory import DEFAULT_REQUEST_TIMEOUT
 from .deployment import (
     ConnectionIdentity,
     ConnectionPool,
@@ -150,6 +151,7 @@ class SglangGenModel(Model):
             base_url=api_base,
             api_key=api_key,
             max_retries=max_retries,
+            timeout=DEFAULT_REQUEST_TIMEOUT,
         )
         self._kwargs = dict(kwargs)
         self._extra = dict(extra) if extra is not None else None

--- a/sieval/tasks/t_eval_before_calling_0shot_gen.py
+++ b/sieval/tasks/t_eval_before_calling_0shot_gen.py
@@ -7,7 +7,7 @@ import numpy as np
 from openai import AsyncOpenAI
 
 from sieval.community.t_eval import EMB_PLACEHOLDER, ResponseDataSample, format_load
-from sieval.core.models import ModelOutput
+from sieval.core.models import DEFAULT_REQUEST_TIMEOUT, ModelOutput
 from sieval.core.tasks import (
     EvalMode,
     JudgementRecord,
@@ -88,6 +88,7 @@ class TEvalBeforeCallingZeroShotGenTask(
                     "SIEVAL_EMBED_API", "https://console.siflow.cn/model-api"
                 ),
                 api_key=api_key,
+                timeout=DEFAULT_REQUEST_TIMEOUT,
             )
         else:
             self._bert_api_client = None

--- a/tests/unit/cli/leaderboard/test_session.py
+++ b/tests/unit/cli/leaderboard/test_session.py
@@ -46,6 +46,7 @@ from sieval.cli.leaderboard.session import (
 )
 from sieval.cli.resolution import derive_model_type
 from sieval.cli.validation import _VALID_OPERATIONS
+from sieval.core.models.connection_factory import DEFAULT_REQUEST_TIMEOUT
 from sieval.core.models.model import Model
 from sieval.core.models.reconcile import CheckStage, Configured, DeferredCheck
 from sieval.core.models.requirements import (
@@ -3187,6 +3188,7 @@ tasks:
             base_url="https://realized.example/v1",
             api_key=None,
             max_retries=9,
+            timeout=DEFAULT_REQUEST_TIMEOUT,
         )
         await session._close_owned_model_resources()
         close.assert_awaited_once()

--- a/tests/unit/core/models/test__legacy_binding.py
+++ b/tests/unit/core/models/test__legacy_binding.py
@@ -1,0 +1,49 @@
+"""Tests for the legacy ``ChatModel``/``GenModel`` binding construction.
+
+Scoped to what this path owes *independently* of ``connection_factory``: it
+builds its own ``AsyncOpenAI`` instead of going through a factory, so a contract
+asserted only against the factory does not reach it.
+
+AI-Generated Code - Claude Opus 5 (1M context) (Anthropic)
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from sieval.core.models._legacy_binding import build_legacy_openai_binding
+from sieval.core.models.connection_factory import DEFAULT_REQUEST_TIMEOUT
+
+
+class TestLegacyBindingClient:
+    def test_client_declares_the_shared_request_timeout(self) -> None:
+        """The wrapper path owes the same declared bound as the factory.
+
+        ``ChatModel`` and ``GenModel`` both build their client here, so this is
+        the construction that serves runs today -- and the one place a drift back
+        to whichever ``timeout`` the OpenAI SDK happens to default to would go
+        unnoticed, since the fallback is currently the same value.
+        """
+        client = SimpleNamespace(
+            base_url="https://legacy.example/v1/",
+            close=AsyncMock(),
+        )
+        with patch(
+            "sieval.core.models._legacy_binding.AsyncOpenAI",
+            return_value=client,
+        ) as client_factory:
+            build_legacy_openai_binding(
+                dialect_id="openai_chat",
+                model="m",
+                api_base="https://legacy.example/v1",
+                api_key="sk-runtime-only",
+                max_retries=4,
+                concurrency_limit=None,
+                parent_limiter=None,
+            )
+
+        client_factory.assert_called_once_with(
+            base_url="https://legacy.example/v1",
+            api_key="sk-runtime-only",
+            max_retries=4,
+            timeout=DEFAULT_REQUEST_TIMEOUT,
+        )

--- a/tests/unit/core/models/test__legacy_binding.py
+++ b/tests/unit/core/models/test__legacy_binding.py
@@ -1,8 +1,7 @@
 """Tests for the legacy ``ChatModel``/``GenModel`` binding construction.
 
-Scoped to what this path owes *independently* of ``connection_factory``: it
-builds its own ``AsyncOpenAI`` instead of going through a factory, so a contract
-asserted only against the factory does not reach it.
+Scoped to what this path owes *independently* of ``connection_factory``, which it
+bypasses.
 
 AI-Generated Code - Claude Opus 5 (1M context) (Anthropic)
 """
@@ -19,9 +18,8 @@ class TestLegacyBindingClient:
         """The wrapper path owes the same declared bound as the factory.
 
         ``ChatModel`` and ``GenModel`` both build their client here, so this is
-        the construction that serves runs today -- and the one place a drift back
-        to whichever ``timeout`` the OpenAI SDK happens to default to would go
-        unnoticed, since the fallback is currently the same value.
+        the construction serving runs today. Its fallback is the SDK's default,
+        which is the same value -- so a drift would be silent without this.
         """
         client = SimpleNamespace(
             base_url="https://legacy.example/v1/",

--- a/tests/unit/core/models/test_connection_factory.py
+++ b/tests/unit/core/models/test_connection_factory.py
@@ -256,3 +256,4 @@ class TestBuiltInConnectionFactories:
 
         openai_sdk = CONNECTION_FACTORY_REGISTRY.create("openai_sdk", request)
         assert cast(Any, openai_sdk).timeout == DEFAULT_REQUEST_TIMEOUT
+        await cast(Any, openai_sdk).close()

--- a/tests/unit/core/models/test_connection_factory.py
+++ b/tests/unit/core/models/test_connection_factory.py
@@ -11,6 +11,7 @@ import pytest
 
 from sieval.core.models.connection_factory import (
     CONNECTION_FACTORY_REGISTRY,
+    DEFAULT_REQUEST_TIMEOUT,
     AsyncHTTPJSONConnection,
     ConnectionFactoryRegistry,
     ConnectionFactorySpec,
@@ -215,4 +216,43 @@ class TestBuiltInConnectionFactories:
             base_url="https://openai-compatible.example/v1",
             api_key="sk-runtime-only",
             max_retries=7,
+            timeout=DEFAULT_REQUEST_TIMEOUT,
         )
+
+    def test_the_request_timeout_is_declared_here_not_inherited(self) -> None:
+        """The numbers, asserted literally, because their whole job is to be ours.
+
+        Reading them off ``httpx`` or the OpenAI SDK would re-derive the bound
+        from the same defaults this constant exists to stop depending on: the
+        assertion would keep passing through exactly the upstream change it is
+        supposed to catch.
+        """
+        assert DEFAULT_REQUEST_TIMEOUT.read == 600.0
+        assert DEFAULT_REQUEST_TIMEOUT.write == 600.0
+        assert DEFAULT_REQUEST_TIMEOUT.pool == 600.0
+        assert DEFAULT_REQUEST_TIMEOUT.connect == 5.0
+
+    @pytest.mark.anyio
+    async def test_both_families_bound_a_request_by_the_same_declared_timeout(
+        self,
+    ) -> None:
+        """One declared bound, not one per library.
+
+        ``httpx`` defaults every phase to 5s and the OpenAI SDK defaults ``read``
+        to 600s, so before this was declared, a dialect's connection family
+        silently decided whether a long generation was allowed to finish -- a
+        120x difference that no dialect declares and no reader could find.
+        """
+        request = ConnectionRequest(
+            endpoint="https://models.example/v1",
+            credential="runtime-only",
+            max_retries=2,
+        )
+
+        http_json = CONNECTION_FACTORY_REGISTRY.create("async_http_json", request)
+        assert isinstance(http_json, AsyncHTTPJSONConnection)
+        assert http_json.client.timeout == DEFAULT_REQUEST_TIMEOUT
+        await http_json.aclose()
+
+        openai_sdk = CONNECTION_FACTORY_REGISTRY.create("openai_sdk", request)
+        assert cast(Any, openai_sdk).timeout == DEFAULT_REQUEST_TIMEOUT

--- a/tests/unit/core/models/test_connection_factory.py
+++ b/tests/unit/core/models/test_connection_factory.py
@@ -220,12 +220,11 @@ class TestBuiltInConnectionFactories:
         )
 
     def test_the_request_timeout_is_declared_here_not_inherited(self) -> None:
-        """The numbers, asserted literally, because their whole job is to be ours.
+        """Asserted literally on purpose.
 
-        Reading them off ``httpx`` or the OpenAI SDK would re-derive the bound
-        from the same defaults this constant exists to stop depending on: the
-        assertion would keep passing through exactly the upstream change it is
-        supposed to catch.
+        Reading the numbers off ``httpx`` or the OpenAI SDK would re-derive them
+        from the very defaults this constant exists to stop depending on, so the
+        assertion would survive the upstream change it is meant to catch.
         """
         assert DEFAULT_REQUEST_TIMEOUT.read == 600.0
         assert DEFAULT_REQUEST_TIMEOUT.write == 600.0
@@ -238,10 +237,9 @@ class TestBuiltInConnectionFactories:
     ) -> None:
         """One declared bound, not one per library.
 
-        ``httpx`` defaults every phase to 5s and the OpenAI SDK defaults ``read``
-        to 600s, so before this was declared, a dialect's connection family
-        silently decided whether a long generation was allowed to finish -- a
-        120x difference that no dialect declares and no reader could find.
+        The two library defaults differ by 120x, so before this was declared a
+        dialect's connection family decided whether a long generation could
+        finish.
         """
         request = ConnectionRequest(
             endpoint="https://models.example/v1",

--- a/tests/unit/core/models/test_sglang_gen_model.py
+++ b/tests/unit/core/models/test_sglang_gen_model.py
@@ -67,10 +67,9 @@ class TestDefaultTransport:
     def test_client_declares_the_shared_request_timeout(self):
         """The other bypass owes the same declared bound as the factory.
 
-        This facade is deliberately outside canonical binding and builds its own
-        client, so a contract asserted against ``connection_factory`` does not
-        reach it. The SDK's default is the same value today, which is exactly why
-        a drift here would be silent.
+        This facade sits outside canonical binding and builds its own client, so
+        a contract asserted against ``connection_factory`` never reaches it. The
+        SDK's default is the same value, which is why a drift would be silent.
         """
         client = SimpleNamespace(
             base_url="http://host:8000/v1/",

--- a/tests/unit/core/models/test_sglang_gen_model.py
+++ b/tests/unit/core/models/test_sglang_gen_model.py
@@ -20,6 +20,7 @@ import anyio
 import pytest
 
 from sieval.core.models import (
+    DEFAULT_REQUEST_TIMEOUT,
     Capability,
     CompletionInput,
     DialectOptions,
@@ -62,6 +63,31 @@ class TestDefaultTransport:
         assert m._transport._client is m._client
         assert m._transport._model == "m"
         assert m._transport._api_base == "http://host:8000/v1"
+
+    def test_client_declares_the_shared_request_timeout(self):
+        """The other bypass owes the same declared bound as the factory.
+
+        This facade is deliberately outside canonical binding and builds its own
+        client, so a contract asserted against ``connection_factory`` does not
+        reach it. The SDK's default is the same value today, which is exactly why
+        a drift here would be silent.
+        """
+        client = SimpleNamespace(
+            base_url="http://host:8000/v1/",
+            close=AsyncMock(),
+        )
+        with patch(
+            "sieval.core.models.sglang_gen_model.AsyncOpenAI",
+            return_value=client,
+        ) as client_factory:
+            SglangGenModel(model="m", api_base="http://host:8000/v1", api_key="local")
+
+        client_factory.assert_called_once_with(
+            base_url="http://host:8000/v1",
+            api_key="local",
+            max_retries=3,
+            timeout=DEFAULT_REQUEST_TIMEOUT,
+        )
 
     def test_subclass_does_not_use_registered_compatibility_factory(self):
         class DerivedSglangGenModel(SglangGenModel):

--- a/tests/unit/tasks/test_t_eval_before_calling_0shot_gen.py
+++ b/tests/unit/tasks/test_t_eval_before_calling_0shot_gen.py
@@ -6,11 +6,11 @@ AI-Generated Code - Claude Sonnet 4.6 (Anthropic)
 import asyncio
 import json
 from types import SimpleNamespace
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 
-from sieval.core.models import ChatModel
+from sieval.core.models import DEFAULT_REQUEST_TIMEOUT, ChatModel
 from sieval.core.tasks import build_prediction_record
 from sieval.tasks.t_eval_before_calling_0shot_gen import (
     TEvalBeforeCallingZeroShotGenTask,
@@ -119,6 +119,29 @@ class TestMetricKeys:
         # the macro-average, long after the bad config was accepted.
         with pytest.raises(NotImplementedError, match="json and str"):
             _task(default_prompt_type="ReWOO")._metric_keys()
+
+
+class TestEmbeddingClient:
+    def test_client_declares_the_shared_request_timeout(self, monkeypatch):
+        """The thought axis reaches a model, so it owes the declared bound too.
+
+        This client is built here rather than through ``connection_factory``, and
+        the SDK's fallback is the same value today -- so a drift would show up as
+        an embedding call that hangs differently, with nothing pointing here.
+        """
+        monkeypatch.setenv("SIEVAL_EMBED_API_KEY", "not-a-real-key")
+        monkeypatch.setenv("SIEVAL_EMBED_API", "https://embed.example/model-api")
+
+        with patch(
+            "sieval.tasks.t_eval_before_calling_0shot_gen.AsyncOpenAI"
+        ) as client_factory:
+            _task(eval_thought=True)
+
+        client_factory.assert_called_once_with(
+            base_url="https://embed.example/model-api",
+            api_key="not-a-real-key",
+            timeout=DEFAULT_REQUEST_TIMEOUT,
+        )
 
 
 class TestCorrectDerivation:

--- a/tests/unit/tasks/test_t_eval_before_calling_0shot_gen.py
+++ b/tests/unit/tasks/test_t_eval_before_calling_0shot_gen.py
@@ -125,9 +125,8 @@ class TestEmbeddingClient:
     def test_client_declares_the_shared_request_timeout(self, monkeypatch):
         """The thought axis reaches a model, so it owes the declared bound too.
 
-        This client is built here rather than through ``connection_factory``, and
-        the SDK's fallback is the same value today -- so a drift would show up as
-        an embedding call that hangs differently, with nothing pointing here.
+        Built here rather than through ``connection_factory``, with the SDK's
+        default as its silent fallback.
         """
         monkeypatch.setenv("SIEVAL_EMBED_API_KEY", "not-a-real-key")
         monkeypatch.setenv("SIEVAL_EMBED_API", "https://embed.example/model-api")


### PR DESCRIPTION
No sieval client passed `timeout`, so the bound on a request was whichever
default the underlying library happened to ship -- and the two libraries
disagree by 120x. Measured on this tree:

    openai 2.9.0    Timeout(connect=5.0, read=600, write=600, pool=600)
    httpx  0.28.1   Timeout(timeout=5.0)

A dialect's connection family therefore decided how long a generation was
allowed to take: `openai_sdk` got a 600s read, `async_http_json` got 5s, which
no reasoning generation survives. That is not a property any dialect declares
or a reader could find, neither number was sieval's, and either library can
change its default in a patch release with nothing here noticing.

`DEFAULT_REQUEST_TIMEOUT = httpx.Timeout(600.0, connect=5.0)` is now declared
in `connection_factory`, which owns client construction, and passed at all four
places that build a client: both factory builders, plus the two that bypass the
factory (`_legacy_binding`, `sglang_gen_model`).

The value is what `openai_sdk` already had in effect, so this changes no
behaviour on the only family with a live transport today -- `openai_chat` and
`openai_completions` are the only implemented dialects, and the sglang native
transport posts through the OpenAI SDK client (`_post` reuses its low-level
`post`) rather than an httpx one. What moves is `async_http_json`, whose four
registered dialects (`anthropic_messages`, `google_genai`, `sglang_native`,
`vllm_native`) have no implemented transport yet. Its 5s was thus never a live
bug: it was a trap for whoever implements the first of them, and it would
present as "the endpoint is broken" rather than "our client gave up".

`connect` stays short because a refused or unroutable endpoint should fail
fast. `read` is long because a reasoning model emitting thousands of tokens
legitimately takes minutes, and a premature read timeout is indistinguishable,
in a result directory, from the model having produced nothing.

Deliberately not here: making the timeout configurable. That raises whether it
belongs on `ConnectionRequest` as a runtime-only input like `credential`, or in
the connection identity the way `max_retries` is encoded into `retry_policy` --
a design call that deserves its own change rather than being settled as a side
effect of this one.

Tests: one asserts both families now bound a request by the same declared
timeout, verified to fail without the change (`Timeout(timeout=5.0) !=
Timeout(connect=5.0, read=600.0, ...)`) by reverting only the two builder call
sites and keeping the constant, so the failure isolates the behaviour rather
than a missing import. One pins the four numbers literally: reading them off
httpx or the SDK would re-derive the bound from the same defaults the constant
exists to stop depending on, so such an assertion would keep passing through
exactly the upstream change it is supposed to catch. Two existing tests already
pinned the `AsyncOpenAI(...)` call and now pin the timeout along with it.

Full unit suite: 5528 passed, 56 skipped.

