### PR TITLE
feat(report): carry the truncation count into report.json

### DIFF
--- a/docs/guide/metrics.md
+++ b/docs/guide/metrics.md
@@ -79,32 +79,28 @@ at **every** budget, `n = 1` included, and by the single-draw tasks below that
 have no `n` at all. It measures the parser, not the draw, and `n = 1` is where a
 silently-stopped extractor survives longest: no second rollout to disagree with.
 
-`n_truncated` and `n_scored_rollouts` — **rollouts** whose generation stopped
-because it ran out of tokens rather than because the model was done, and the
-rollouts that were scored in total — are reported by **every `gen` task**, at
-every budget, `n = 1` included, and by the single-draw tasks below that have no
-`n` at all. Like `n_unextracted` they describe the generation rather than the
-draw, so neither is confined to `n > 1`; unlike every other key on this page they
-are injected by the *runner*, not computed by a task, so a task cannot report a
-truncation of zero by having forgotten to look.
+`n_truncated` — **rollouts** whose generation stopped because it ran out of
+tokens rather than because the model was done — and `n_scored_rollouts`, the
+rollouts scored in total, are reported by **every `gen` task**, on the same terms
+as `n_unextracted`: they describe the generation rather than the draw, so neither
+is confined to `n > 1`. Unlike every other key here the *runner* injects them, so
+a task cannot report zero truncation by having forgotten to look.
 
-They are a **pair, and arrive together or not at all** — the count alone says
-nothing about how much of a score it explains (`26` is a different fact at 600
-rollouts than at 30), and the rule lanes that most need it publish rates plus
-`fails` and no sample total, so there was previously nothing in `report.json` to
-divide by. `n_scored_rollouts` is the **observed** draw, not `n × samples`: a
-short sample drew fewer rollouts than its budget asked for, and the share a
-reader wants is over what actually ran. Deriving the rate — and deciding what
-threshold should warn, fail, or annotate a score — is left to the reader.
+They arrive as a **pair or not at all**. The count alone says nothing about how
+much of a score it explains — `26` is a different fact at 600 rollouts than at 30
+— and the rule lanes that most need it publish rates plus `fails` and no sample
+total, so nothing here was divisible into it. `n_scored_rollouts` is the
+**observed** draw, not `n × samples`: a short sample drew fewer rollouts than its
+budget asked for. Deriving the rate, and deciding what threshold should warn,
+fail or annotate a score, is left to the reader.
 
-Both are omitted, not zeroed, outside `gen`: `ppl`/`clp` infer with
-`max_tokens=1` and therefore finish every call the same way a truncated
-generation does, so the count would equal the rollout total on every such run and
-mean nothing. They are also omitted when the reasons were never recorded —
-resuming a run that was written with `record_meta=False` hydrates its finals
-without any per-stage metadata, and a `0` there would claim a clean run rather
-than an unmeasured one. `sieval_versions` reports that same state in band as
-`"unknown"`; a count has no value that means "not measured", so it is left out.
+Both are omitted rather than zeroed in two cases: outside `gen`, where `ppl`/`clp`
+infer at `max_tokens=1` and finish every call the way a truncation does, so the
+count would equal the total and mean nothing; and when the reasons were never
+recorded, since resuming a run written with `record_meta=False` hydrates its
+finals without per-stage metadata and a `0` would claim a clean run rather than an
+unmeasured one. `sieval_versions` reports that state in band as `"unknown"`; a
+count has no such value.
 
 Read `n_truncated` as a **bound on how much of a score is budget, not
 capability** — a truncated rollout is scored wrong whether or not the model was

--- a/docs/guide/metrics.md
+++ b/docs/guide/metrics.md
@@ -64,10 +64,9 @@ reporting a `pass@k` of `0.0`.
 | `self_consistency` | Share of the draw that agreed on that modal answer. | the task votes on answers |
 | `n`, `k` | The budget the numbers above were measured at. | always |
 | `n_short` | Samples that came back with fewer than `n` rollouts. | always |
-| `n_truncated` | Rollouts whose generation hit its token budget instead of stopping. | `gen` tasks |
 
-Rates are percentages (0–100) over the task's declared denominator; `n`, `k`,
-`n_short` and `n_truncated` are counts.
+Rates are percentages (0–100) over the task's declared denominator; `n`, `k` and
+`n_short` are counts.
 
 **`avg@n` is spelled `@n`, not `@k`, on purpose:** it takes no `k` and does not
 move with one — at `n=4, k=2` it averages four verdicts where `pass@k` estimates
@@ -80,17 +79,36 @@ at **every** budget, `n = 1` included, and by the single-draw tasks below that
 have no `n` at all. It measures the parser, not the draw, and `n = 1` is where a
 silently-stopped extractor survives longest: no second rollout to disagree with.
 
-`n_truncated` — **rollouts** whose generation stopped because it ran out of
-tokens rather than because the model was done — is the one key here the *runner*
-injects rather than a task computing it, so a task cannot report a truncation
-rate of zero by having forgotten to look. It is omitted, not zeroed, outside
-`gen`: `ppl`/`clp` infer with `max_tokens=1` and therefore finish every call the
-same way a truncated generation does, so the count would read 100% and mean
-nothing.
+`n_truncated` and `n_scored_rollouts` — **rollouts** whose generation stopped
+because it ran out of tokens rather than because the model was done, and the
+rollouts that were scored in total — are reported by **every `gen` task**, at
+every budget, `n = 1` included, and by the single-draw tasks below that have no
+`n` at all. Like `n_unextracted` they describe the generation rather than the
+draw, so neither is confined to `n > 1`; unlike every other key on this page they
+are injected by the *runner*, not computed by a task, so a task cannot report a
+truncation of zero by having forgotten to look.
 
-Read it as a **bound on how much of a score is budget, not capability** — a
-truncated rollout is scored wrong whether or not the model was on its way to the
-right answer, and the fix is `max_tokens`. It is independent of
+They are a **pair, and arrive together or not at all** — the count alone says
+nothing about how much of a score it explains (`26` is a different fact at 600
+rollouts than at 30), and the rule lanes that most need it publish rates plus
+`fails` and no sample total, so there was previously nothing in `report.json` to
+divide by. `n_scored_rollouts` is the **observed** draw, not `n × samples`: a
+short sample drew fewer rollouts than its budget asked for, and the share a
+reader wants is over what actually ran. Deriving the rate — and deciding what
+threshold should warn, fail, or annotate a score — is left to the reader.
+
+Both are omitted, not zeroed, outside `gen`: `ppl`/`clp` infer with
+`max_tokens=1` and therefore finish every call the same way a truncated
+generation does, so the count would equal the rollout total on every such run and
+mean nothing. They are also omitted when the reasons were never recorded —
+resuming a run that was written with `record_meta=False` hydrates its finals
+without any per-stage metadata, and a `0` there would claim a clean run rather
+than an unmeasured one. `sieval_versions` reports that same state in band as
+`"unknown"`; a count has no value that means "not measured", so it is left out.
+
+Read `n_truncated` as a **bound on how much of a score is budget, not
+capability** — a truncated rollout is scored wrong whether or not the model was
+on its way to the right answer, and the fix is `max_tokens`. It is independent of
 `n_unextracted`: an answer can be cut short and still parse (the truncation lands
 after the boxed answer), or parse cleanly and be wrong for reasons of its own.
 The two are worth reading together only in the direction where they coincide — a

--- a/docs/guide/metrics.md
+++ b/docs/guide/metrics.md
@@ -64,9 +64,10 @@ reporting a `pass@k` of `0.0`.
 | `self_consistency` | Share of the draw that agreed on that modal answer. | the task votes on answers |
 | `n`, `k` | The budget the numbers above were measured at. | always |
 | `n_short` | Samples that came back with fewer than `n` rollouts. | always |
+| `n_truncated` | Rollouts whose generation hit its token budget instead of stopping. | `gen` tasks |
 
-Rates are percentages (0–100) over the task's declared denominator; `n`, `k` and
-`n_short` are counts.
+Rates are percentages (0–100) over the task's declared denominator; `n`, `k`,
+`n_short` and `n_truncated` are counts.
 
 **`avg@n` is spelled `@n`, not `@k`, on purpose:** it takes no `k` and does not
 move with one — at `n=4, k=2` it averages four verdicts where `pass@k` estimates
@@ -78,6 +79,23 @@ the draw that was paid for. They separate once a verdict stops being a bool.
 at **every** budget, `n = 1` included, and by the single-draw tasks below that
 have no `n` at all. It measures the parser, not the draw, and `n = 1` is where a
 silently-stopped extractor survives longest: no second rollout to disagree with.
+
+`n_truncated` — **rollouts** whose generation stopped because it ran out of
+tokens rather than because the model was done — is the one key here the *runner*
+injects rather than a task computing it, so a task cannot report a truncation
+rate of zero by having forgotten to look. It is omitted, not zeroed, outside
+`gen`: `ppl`/`clp` infer with `max_tokens=1` and therefore finish every call the
+same way a truncated generation does, so the count would read 100% and mean
+nothing.
+
+Read it as a **bound on how much of a score is budget, not capability** — a
+truncated rollout is scored wrong whether or not the model was on its way to the
+right answer, and the fix is `max_tokens`. It is independent of
+`n_unextracted`: an answer can be cut short and still parse (the truncation lands
+after the boxed answer), or parse cleanly and be wrong for reasons of its own.
+The two are worth reading together only in the direction where they coincide — a
+rollout that is both truncated *and* unextracted is the case where raising the
+budget is most likely to move the score.
 
 ### Pairs that must be read together
 

--- a/sieval/core/runners/runner.py
+++ b/sieval/core/runners/runner.py
@@ -35,7 +35,7 @@ from sieval.core.tasks.context import (
     TaskStageOutput,
 )
 from sieval.core.tasks.loader import TaskLoader
-from sieval.core.tasks.meta import get_task_run_identity
+from sieval.core.tasks.meta import EvalMode, get_task_run_identity
 from sieval.core.tasks.profiler import TaskProfiler
 from sieval.core.tasks.progress import TaskProgress
 from sieval.core.tasks.records import iter_grader_outputs
@@ -46,6 +46,7 @@ from sieval.core.utils.concurrency import CompositeLimiter
 from sieval.core.utils.meta import (
     build_model_call_meta_from_mapping,
     build_stage_meta,
+    count_truncated_rollouts,
     report_versions,
 )
 
@@ -603,7 +604,7 @@ class TaskRunner:
                 finals, fails = self._final_and_failed()
                 report = await self._task.report(finals, fails)
                 # Always save report on completion
-                await self._save_report_with_versions(report, finals, fails)
+                await self._save_report_with_diagnostics(report, finals, fails)
                 return report
 
             # 6. Setup Progress Tracker
@@ -675,7 +676,7 @@ class TaskRunner:
             finals, fails = self._final_and_failed()
             report = await self._task.report(finals, fails)
             # Always save report on completion
-            await self._save_report_with_versions(report, finals, fails)
+            await self._save_report_with_diagnostics(report, finals, fails)
             # Backstop: create-if-absent, normally a no-op (written at run start).
             await self._saver.write_run_meta()
             # Generate anomaly report
@@ -1010,25 +1011,47 @@ class TaskRunner:
         fails = [c for c in self._contexts.values() if c.stage == TaskStage.FAILED]
         return finals, fails
 
-    async def _save_report_with_versions(
+    async def _save_report_with_diagnostics(
         self,
         report: JSONValue,
         finals: list[TaskContext],
         fails: list[TaskContext],
     ) -> None:
-        """Inject the distinct producing-version list into a dict report, then save.
+        """Inject the run-level diagnostics into a dict report, then save.
 
-        Aggregates over the in-memory terminal contexts' ``stage_meta`` at zero
-        extra I/O; :func:`report_versions` owns the ``"unknown"`` sentinel rule.
+        Both aggregate over the in-memory terminal contexts' ``stage_meta`` at
+        zero extra I/O: :func:`report_versions` owns the ``"unknown"`` sentinel
+        rule, :func:`count_truncated_rollouts` the stage and history choices.
+        They are injected here rather than by each task because neither is a
+        fact about a task's metric -- every task would have to remember to report
+        them, and the ones that forgot would look clean.
+
+        ``n_truncated`` is injected for ``gen`` tasks only, and omitted rather
+        than zeroed elsewhere: ``ppl``/``clp`` infer with ``max_tokens=1`` and so
+        finish every call with ``length``, which would make the key read 100% on
+        every such run and mean nothing. The anomaly rule for the same event is
+        ``gen``-scoped for the same reason, and metrics.py states the general
+        rule -- a 0.0 meaning "not measurable" is indistinguishable from one
+        meaning "measured, and zero".
+
+        Only finals are counted, matching both the anomaly detector (which runs
+        on FINAL) and ``n_unextracted``: a FAILED sample has no score for a
+        truncation to explain.
+
         Non-dict reports are saved unchanged; ``None`` skips the save.
         """
         if report is None:
             return
         if isinstance(report, dict):
-            cast(dict[str, JSONValue], report)["sieval_versions"] = report_versions(
+            as_dict = cast(dict[str, JSONValue], report)
+            as_dict["sieval_versions"] = report_versions(
                 (c.stage_meta for c in finals),
                 (c.stage_meta for c in fails),
             )
+            if EvalMode.GEN.value in self._task.tags:
+                as_dict["n_truncated"] = count_truncated_rollouts(
+                    c.stage_meta for c in finals
+                )
         await self._saver.save_report(report)
 
     def _resolve_result_dir(

--- a/sieval/core/runners/runner.py
+++ b/sieval/core/runners/runner.py
@@ -1020,34 +1020,24 @@ class TaskRunner:
     ) -> None:
         """Inject the run-level diagnostics into a dict report, then save.
 
-        All of them aggregate over the in-memory terminal contexts' ``stage_meta``
-        at zero extra I/O: :func:`report_versions` owns the ``"unknown"`` sentinel
-        rule, and the rollout counters share the stage, history and measurability
-        choices of :func:`_scored_rollout_indices`. They are injected here rather
-        than by each task because none is a fact about a task's metric -- every
-        task would have to remember to report them, and the ones that forgot
-        would look clean.
+        All aggregate over the in-memory terminal contexts' ``stage_meta`` at zero
+        extra I/O -- :func:`report_versions` owns the ``"unknown"`` sentinel rule,
+        the rollout counters :func:`_scored_rollout_indices`. Injected here rather
+        than per task because none is a fact about a task's metric: every task
+        would have to remember, and the ones that forgot would look clean.
 
-        ``n_truncated`` and its denominator ``n_scored_rollouts`` are injected for
-        ``gen`` tasks only, and omitted rather than zeroed elsewhere:
-        ``ppl``/``clp`` infer with ``max_tokens=1`` and so finish every call with
-        ``length``, which would make the count equal the rollout total on every
-        such run and mean nothing. The anomaly rule for the same event is
-        ``gen``-scoped for the same reason, and metrics.py states the general
-        rule -- a 0 meaning "not measurable" is indistinguishable from one
-        meaning "measured, and zero".
+        ``n_truncated`` and its denominator ``n_scored_rollouts`` go in for ``gen``
+        tasks only, and are omitted rather than zeroed elsewhere -- ``ppl``/``clp``
+        infer at ``max_tokens=1`` and so finish every call with ``length``, which
+        would make the count equal the total and mean nothing. The anomaly rule is
+        ``gen``-scoped for the same reason. They go in as a **pair or not at all**:
+        a count whose base is missing is not a share of anything, and both drop out
+        when any scored record is unmeasurable (see the ``record_meta=False`` resume
+        case on ``_scored_rollout_indices``).
 
-        The pair is injected together, or not at all: a count whose base is
-        missing cannot be read as a share of anything, and the two are omitted
-        outright when any scored record turns out not to be measurable (a resume
-        under ``record_meta=False`` hydrates finals with no ``stage_meta``, so
-        reducing them to ``0`` would report a clean run for samples whose finish
-        reasons were never recorded). ``sieval_versions`` says the same thing in
-        band with its ``"unknown"`` sentinel; a count has no such value.
-
-        Only finals are counted, matching both the anomaly detector (which runs
-        on FINAL) and ``n_unextracted``: a FAILED sample has no score for a
-        truncation to explain.
+        Only finals are counted, matching both the anomaly detector (which runs on
+        FINAL) and ``n_unextracted``: a FAILED sample has no score for a truncation
+        to explain.
 
         Non-dict reports are saved unchanged; ``None`` skips the save.
         """

--- a/sieval/core/runners/runner.py
+++ b/sieval/core/runners/runner.py
@@ -46,6 +46,7 @@ from sieval.core.utils.concurrency import CompositeLimiter
 from sieval.core.utils.meta import (
     build_model_call_meta_from_mapping,
     build_stage_meta,
+    count_scored_rollouts,
     count_truncated_rollouts,
     report_versions,
 )
@@ -1019,20 +1020,30 @@ class TaskRunner:
     ) -> None:
         """Inject the run-level diagnostics into a dict report, then save.
 
-        Both aggregate over the in-memory terminal contexts' ``stage_meta`` at
-        zero extra I/O: :func:`report_versions` owns the ``"unknown"`` sentinel
-        rule, :func:`count_truncated_rollouts` the stage and history choices.
-        They are injected here rather than by each task because neither is a
-        fact about a task's metric -- every task would have to remember to report
-        them, and the ones that forgot would look clean.
+        All of them aggregate over the in-memory terminal contexts' ``stage_meta``
+        at zero extra I/O: :func:`report_versions` owns the ``"unknown"`` sentinel
+        rule, and the rollout counters share the stage, history and measurability
+        choices of :func:`_scored_rollout_indices`. They are injected here rather
+        than by each task because none is a fact about a task's metric -- every
+        task would have to remember to report them, and the ones that forgot
+        would look clean.
 
-        ``n_truncated`` is injected for ``gen`` tasks only, and omitted rather
-        than zeroed elsewhere: ``ppl``/``clp`` infer with ``max_tokens=1`` and so
-        finish every call with ``length``, which would make the key read 100% on
-        every such run and mean nothing. The anomaly rule for the same event is
+        ``n_truncated`` and its denominator ``n_scored_rollouts`` are injected for
+        ``gen`` tasks only, and omitted rather than zeroed elsewhere:
+        ``ppl``/``clp`` infer with ``max_tokens=1`` and so finish every call with
+        ``length``, which would make the count equal the rollout total on every
+        such run and mean nothing. The anomaly rule for the same event is
         ``gen``-scoped for the same reason, and metrics.py states the general
-        rule -- a 0.0 meaning "not measurable" is indistinguishable from one
+        rule -- a 0 meaning "not measurable" is indistinguishable from one
         meaning "measured, and zero".
+
+        The pair is injected together, or not at all: a count whose base is
+        missing cannot be read as a share of anything, and the two are omitted
+        outright when any scored record turns out not to be measurable (a resume
+        under ``record_meta=False`` hydrates finals with no ``stage_meta``, so
+        reducing them to ``0`` would report a clean run for samples whose finish
+        reasons were never recorded). ``sieval_versions`` says the same thing in
+        band with its ``"unknown"`` sentinel; a count has no such value.
 
         Only finals are counted, matching both the anomaly detector (which runs
         on FINAL) and ``n_unextracted``: a FAILED sample has no score for a
@@ -1049,9 +1060,12 @@ class TaskRunner:
                 (c.stage_meta for c in fails),
             )
             if EvalMode.GEN.value in self._task.tags:
-                as_dict["n_truncated"] = count_truncated_rollouts(
-                    c.stage_meta for c in finals
-                )
+                metas = [c.stage_meta for c in finals]
+                truncated = count_truncated_rollouts(metas)
+                scored = count_scored_rollouts(metas)
+                if truncated is not None and scored is not None:
+                    as_dict["n_truncated"] = truncated
+                    as_dict["n_scored_rollouts"] = scored
         await self._saver.save_report(report)
 
     def _resolve_result_dir(

--- a/sieval/core/tasks/anomaly.py
+++ b/sieval/core/tasks/anomaly.py
@@ -17,6 +17,7 @@ from loguru import logger
 from sieval.core.models import ModelOutput
 from sieval.core.tasks.context import TaskContext, TaskStage, TaskStageOutput
 from sieval.core.tasks.records import is_prediction_record
+from sieval.core.utils.meta import TRUNCATION_FINISH_REASONS
 
 
 # Schema
@@ -487,11 +488,16 @@ def detect_truncated_output(ctx: TaskContext) -> set[int]:
         return set()
     # Unioned across calls: a conversation whose second turn hit the cap has that
     # rollout truncated, whichever turn did it.
+    #
+    # The reason set is shared with the `n_truncated` report key, which reduces the
+    # same event off the persisted `finish_reasons` instead of the live output. Two
+    # copies of the tuple would let this rule and that count come to disagree about
+    # what "truncated" means, with nothing to catch it.
     return {
         i
         for output in _model_outputs(_unwrap_result(ctx.infer_result))
         for i, reason in enumerate(output.finish_reasons or ())
-        if reason in ("length", "max_tokens", "content_filter")
+        if reason in TRUNCATION_FINISH_REASONS
     }
 
 

--- a/sieval/core/tasks/anomaly.py
+++ b/sieval/core/tasks/anomaly.py
@@ -487,12 +487,9 @@ def detect_truncated_output(ctx: TaskContext) -> set[int]:
     if ctx.infer_result is None:
         return set()
     # Unioned across calls: a conversation whose second turn hit the cap has that
-    # rollout truncated, whichever turn did it.
-    #
-    # The reason set is shared with the `n_truncated` report key, which reduces the
-    # same event off the persisted `finish_reasons` instead of the live output. Two
-    # copies of the tuple would let this rule and that count come to disagree about
-    # what "truncated" means, with nothing to catch it.
+    # rollout truncated, whichever turn did it. The reason set is shared with the
+    # `n_truncated` report key -- which reduces the same event off the persisted
+    # `finish_reasons` rather than the live output -- so the two cannot drift.
     return {
         i
         for output in _model_outputs(_unwrap_result(ctx.infer_result))

--- a/sieval/core/utils/meta.py
+++ b/sieval/core/utils/meta.py
@@ -7,7 +7,24 @@ from packaging.version import InvalidVersion, Version
 
 from sieval import __version__
 from sieval.core.models import ModelCallMeta, ModelOutput
+from sieval.core.tasks.consts import TaskStage
 from sieval.core.tasks.context import TaskStageMeta
+
+#: Finish reasons that mean the generation stopped before the model chose to.
+#:
+#: Provider-verbatim, because the IR does not normalize them: an
+#: OpenAI-compatible server says ``length``, Anthropic says ``max_tokens``, and
+#: sglang's native ``meta_info`` nests the same thing under ``type``. The set
+#: holds every spelling rather than one canonical name, so a count does not
+#: silently read zero on whichever provider spells it the other way.
+#:
+#: ``content_filter`` is in here because the output is cut short the same way,
+#: which is what a reader of the count is being warned about. The cause differs,
+#: and separating causes is what the raw ``finish_reasons`` on the record are
+#: for. :func:`sieval.core.tasks.anomaly.detect_truncated_output` reads this same
+#: set, so the rule and the report key cannot drift into meaning different
+#: things.
+TRUNCATION_FINISH_REASONS = frozenset({"length", "max_tokens", "content_filter"})
 
 
 def build_model_call_meta(output: ModelOutput) -> ModelCallMeta:
@@ -135,3 +152,47 @@ def report_versions(
     if has_unstamped_final:
         versions.append("unknown")
     return versions
+
+
+def count_truncated_rollouts(stage_metas: Iterable[Mapping[str, list]]) -> int:
+    """Rollouts whose generation was cut short, over a report's scored records.
+
+    A truncated rollout scores as wrong without the model necessarily being
+    wrong -- it ran out of budget mid-answer, and the fix is ``max_tokens``, not
+    the prompt and not the model. ``finish_reasons`` has always been persisted
+    per call (:func:`build_model_call_meta`) and the ``gen``-scoped anomaly rule
+    already reports it per sample, but nothing carried it into ``report.json``,
+    the artifact a leaderboard actually reads. So a score that a truncation rate
+    explains was indistinguishable there from one that capability explains.
+
+    Only the INFERRED stage is read. A judged task's FEEDBACK stage carries the
+    GRADER's calls, and a grader that hit its own budget is a different fact
+    about a different model -- the tasks that care already report that
+    separately (``n_grader_unparsed``).
+
+    Only the LAST entry of that stage's history is read, because a retried or
+    re-iterated sample was scored on its last attempt: counting earlier ones
+    would report truncations that no longer affect any number in the report.
+    That is the opposite choice from :func:`collect_versions`, which unions the
+    whole history precisely because provenance is about everything that ran.
+
+    Counted per rollout, not per sample -- one truncated draw in four is a
+    different fact from four (RFC #74 C) -- and deduplicated by rollout index
+    within a sample, so a multi-turn task whose second turn truncated counts
+    that rollout once however many turns it took. That is the same union
+    :func:`sieval.core.tasks.anomaly.detect_truncated_output` takes across the
+    calls of one stage, so the two agree by construction rather than by
+    coincidence.
+    """
+    total = 0
+    for stage_meta in stage_metas:
+        entries = stage_meta.get(TaskStage.INFERRED.value)
+        if not entries:
+            continue
+        truncated: set[int] = set()
+        for call in entries[-1].get("model_calls") or ():
+            for index, reason in enumerate(call.get("finish_reasons") or ()):
+                if reason in TRUNCATION_FINISH_REASONS:
+                    truncated.add(index)
+        total += len(truncated)
+    return total

--- a/sieval/core/utils/meta.py
+++ b/sieval/core/utils/meta.py
@@ -12,18 +12,12 @@ from sieval.core.tasks.context import TaskStageMeta
 
 #: Finish reasons that mean the generation stopped before the model chose to.
 #:
-#: Provider-verbatim, because the IR does not normalize them: an
-#: OpenAI-compatible server says ``length``, Anthropic says ``max_tokens``, and
-#: sglang's native ``meta_info`` nests the same thing under ``type``. The set
-#: holds every spelling rather than one canonical name, so a count does not
-#: silently read zero on whichever provider spells it the other way.
-#:
-#: ``content_filter`` is in here because the output is cut short the same way,
-#: which is what a reader of the count is being warned about. The cause differs,
-#: and separating causes is what the raw ``finish_reasons`` on the record are
-#: for. :func:`sieval.core.tasks.anomaly.detect_truncated_output` reads this same
-#: set, so the rule and the report key cannot drift into meaning different
-#: things.
+#: Every spelling, not one canonical name: the IR does not normalize these, so a
+#: set holding only ``length`` (OpenAI-compatible) would read zero against
+#: ``max_tokens`` (Anthropic). ``content_filter`` is in because the output is cut
+#: short the same way; separating causes is what the raw ``finish_reasons`` are
+#: for. Shared with :func:`sieval.core.tasks.anomaly.detect_truncated_output` so
+#: the rule and the report key cannot drift apart.
 TRUNCATION_FINISH_REASONS = frozenset({"length", "max_tokens", "content_filter"})
 
 
@@ -159,31 +153,25 @@ def _scored_rollout_indices(
 ) -> tuple[set[int], set[int]] | None:
     """``(every rollout index, the truncated ones)`` for one scored record.
 
-    The two counts this backs are reduced off the same index space, so
-    ``n_truncated <= n_scored_rollouts`` holds by construction rather than by two
-    walks happening to agree.
+    Both counts come off this one index space, so ``n_truncated <=
+    n_scored_rollouts`` holds by construction rather than by two walks agreeing.
 
-    Only the INFERRED stage is read. A judged task's FEEDBACK stage carries the
-    GRADER's calls, and a grader that hit its own budget is a different fact
-    about a different model -- the tasks that care already report that
-    separately (``n_grader_unparsed``).
+    **INFERRED only:** a judged task's FEEDBACK stage carries the GRADER's calls,
+    and a grader that hit its own budget is a fact about a different model
+    (already reported as ``n_grader_unparsed``).
 
-    Only the LAST entry of that stage's history is read, because a retried or
-    re-iterated sample was scored on its last attempt: counting earlier ones
-    would report truncations that no longer affect any number in the report.
-    That is the opposite choice from :func:`collect_versions`, which unions the
-    whole history precisely because provenance is about everything that ran.
+    **Last entry only:** a retried or re-iterated sample was scored on its last
+    attempt, so an earlier truncation no longer affects any number in the report.
+    The opposite choice from :func:`collect_versions`, which unions the whole
+    history because provenance is about everything that ran.
 
-    Returns ``None`` when the record carries no INFERRED history, which means
-    nothing about its rollouts is measurable. On a fresh run that cannot happen
-    -- the runner builds a stage meta for every stage it executes, in memory,
-    whatever ``record_meta`` says. It happens on a **resume under**
-    ``record_meta=False``: nothing was persisted, so the loader hydrates a final
-    with no ``stage_meta``, and reducing that to ``0`` would report a clean run
-    for samples whose finish reasons were never recorded. Callers omit the keys
-    instead. :func:`report_versions` resolves the same state with its
-    ``"unknown"`` sentinel; a count has no in-band value that means "not
-    measured", which is the whole reason this returns an option.
+    ``None`` means no INFERRED history, so nothing here is measurable. A fresh run
+    cannot hit it -- stage meta is built in memory whatever ``record_meta`` says
+    -- but a **resume under** ``record_meta=False`` can: nothing was persisted, so
+    the loader hydrates a final without it, and reducing that to ``0`` would
+    report a clean run for samples whose finish reasons were never recorded.
+    :func:`report_versions` says this in band with ``"unknown"``; a count has no
+    such value, hence the option.
     """
     entries = stage_meta.get(TaskStage.INFERRED.value)
     if not entries:
@@ -203,25 +191,20 @@ def count_truncated_rollouts(
 ) -> int | None:
     """Rollouts whose generation was cut short, over a report's scored records.
 
-    A truncated rollout scores as wrong without the model necessarily being
-    wrong -- it ran out of budget mid-answer, and the fix is ``max_tokens``, not
-    the prompt and not the model. ``finish_reasons`` has always been persisted
-    per call (:func:`build_model_call_meta`) and the ``gen``-scoped anomaly rule
-    already reports it per sample, but nothing carried it into ``report.json``,
-    the artifact a leaderboard actually reads. So a score that a truncation rate
-    explains was indistinguishable there from one that capability explains.
+    A truncated rollout scores as wrong without the model being wrong -- it ran
+    out of budget mid-answer, and the fix is ``max_tokens``. Reported so a score
+    a truncation rate explains is distinguishable from one capability explains.
 
     Counted per rollout, not per sample -- one truncated draw in four is a
-    different fact from four (RFC #74 C) -- and deduplicated by rollout index
-    within a sample, so a multi-turn task whose second turn truncated counts
-    that rollout once however many turns it took. That is the same union
-    :func:`sieval.core.tasks.anomaly.detect_truncated_output` takes across the
-    calls of one stage, so the two agree by construction rather than by
-    coincidence.
+    different fact from four (RFC #74 C) -- and deduplicated by rollout index, so
+    a multi-turn task whose second turn truncated counts that rollout once. That
+    is the same union :func:`sieval.core.tasks.anomaly.detect_truncated_output`
+    takes over one stage's calls, so the report and the anomaly file agree by
+    construction.
 
-    Stage and history scoping, and the ``None`` case, are
-    :func:`_scored_rollout_indices`. ``None`` propagates: a count over a set of
-    records where one was not measurable would read low with nothing to say so.
+    Scoping and the ``None`` case are :func:`_scored_rollout_indices`; ``None``
+    propagates, since a count skipping an unmeasurable record reads low with
+    nothing to say so.
     """
     total = 0
     for stage_meta in stage_metas:
@@ -235,17 +218,14 @@ def count_truncated_rollouts(
 def count_scored_rollouts(stage_metas: Iterable[Mapping[str, list]]) -> int | None:
     """Rollouts a report's scored records actually drew -- ``n_truncated``'s base.
 
-    A bare count does not say how much of a score it explains: ``26`` is a
-    different fact at 600 rollouts than at 30, and the four rule lanes this was
-    built for publish rates plus ``fails`` and no sample total at all, so there
-    was nothing in ``report.json`` to divide by. This is that denominator, and it
-    is the *observed* draw rather than ``n * len(finals)``: a run with a short
-    sample drew fewer rollouts than its budget asked for, and the rate a reader
-    wants is over what actually ran.
+    Without it the numerator is unreadable: ``26`` is a different fact at 600
+    rollouts than at 30, and the rule lanes publish rates plus ``fails`` and no
+    sample total, so nothing in ``report.json`` was divisible into it.
 
-    Deliberately not the rate itself. Whether a lane above some threshold should
-    warn, fail or annotate its score is a policy call; this only makes the
-    fraction computable by whoever wants to make it.
+    The *observed* draw, not ``n * len(finals)``: a short sample drew fewer
+    rollouts than its budget asked for, and the share a reader wants is over what
+    ran. Not the rate itself -- what threshold should warn, fail or annotate a
+    score is a policy call left to the reader.
     """
     total = 0
     for stage_meta in stage_metas:

--- a/sieval/core/utils/meta.py
+++ b/sieval/core/utils/meta.py
@@ -154,16 +154,14 @@ def report_versions(
     return versions
 
 
-def count_truncated_rollouts(stage_metas: Iterable[Mapping[str, list]]) -> int:
-    """Rollouts whose generation was cut short, over a report's scored records.
+def _scored_rollout_indices(
+    stage_meta: Mapping[str, list],
+) -> tuple[set[int], set[int]] | None:
+    """``(every rollout index, the truncated ones)`` for one scored record.
 
-    A truncated rollout scores as wrong without the model necessarily being
-    wrong -- it ran out of budget mid-answer, and the fix is ``max_tokens``, not
-    the prompt and not the model. ``finish_reasons`` has always been persisted
-    per call (:func:`build_model_call_meta`) and the ``gen``-scoped anomaly rule
-    already reports it per sample, but nothing carried it into ``report.json``,
-    the artifact a leaderboard actually reads. So a score that a truncation rate
-    explains was indistinguishable there from one that capability explains.
+    The two counts this backs are reduced off the same index space, so
+    ``n_truncated <= n_scored_rollouts`` holds by construction rather than by two
+    walks happening to agree.
 
     Only the INFERRED stage is read. A judged task's FEEDBACK stage carries the
     GRADER's calls, and a grader that hit its own budget is a different fact
@@ -176,6 +174,43 @@ def count_truncated_rollouts(stage_metas: Iterable[Mapping[str, list]]) -> int:
     That is the opposite choice from :func:`collect_versions`, which unions the
     whole history precisely because provenance is about everything that ran.
 
+    Returns ``None`` when the record carries no INFERRED history, which means
+    nothing about its rollouts is measurable. On a fresh run that cannot happen
+    -- the runner builds a stage meta for every stage it executes, in memory,
+    whatever ``record_meta`` says. It happens on a **resume under**
+    ``record_meta=False``: nothing was persisted, so the loader hydrates a final
+    with no ``stage_meta``, and reducing that to ``0`` would report a clean run
+    for samples whose finish reasons were never recorded. Callers omit the keys
+    instead. :func:`report_versions` resolves the same state with its
+    ``"unknown"`` sentinel; a count has no in-band value that means "not
+    measured", which is the whole reason this returns an option.
+    """
+    entries = stage_meta.get(TaskStage.INFERRED.value)
+    if not entries:
+        return None
+    scored: set[int] = set()
+    truncated: set[int] = set()
+    for call in entries[-1].get("model_calls") or ():
+        for index, reason in enumerate(call.get("finish_reasons") or ()):
+            scored.add(index)
+            if reason in TRUNCATION_FINISH_REASONS:
+                truncated.add(index)
+    return scored, truncated
+
+
+def count_truncated_rollouts(
+    stage_metas: Iterable[Mapping[str, list]],
+) -> int | None:
+    """Rollouts whose generation was cut short, over a report's scored records.
+
+    A truncated rollout scores as wrong without the model necessarily being
+    wrong -- it ran out of budget mid-answer, and the fix is ``max_tokens``, not
+    the prompt and not the model. ``finish_reasons`` has always been persisted
+    per call (:func:`build_model_call_meta`) and the ``gen``-scoped anomaly rule
+    already reports it per sample, but nothing carried it into ``report.json``,
+    the artifact a leaderboard actually reads. So a score that a truncation rate
+    explains was indistinguishable there from one that capability explains.
+
     Counted per rollout, not per sample -- one truncated draw in four is a
     different fact from four (RFC #74 C) -- and deduplicated by rollout index
     within a sample, so a multi-turn task whose second turn truncated counts
@@ -183,16 +218,39 @@ def count_truncated_rollouts(stage_metas: Iterable[Mapping[str, list]]) -> int:
     :func:`sieval.core.tasks.anomaly.detect_truncated_output` takes across the
     calls of one stage, so the two agree by construction rather than by
     coincidence.
+
+    Stage and history scoping, and the ``None`` case, are
+    :func:`_scored_rollout_indices`. ``None`` propagates: a count over a set of
+    records where one was not measurable would read low with nothing to say so.
     """
     total = 0
     for stage_meta in stage_metas:
-        entries = stage_meta.get(TaskStage.INFERRED.value)
-        if not entries:
-            continue
-        truncated: set[int] = set()
-        for call in entries[-1].get("model_calls") or ():
-            for index, reason in enumerate(call.get("finish_reasons") or ()):
-                if reason in TRUNCATION_FINISH_REASONS:
-                    truncated.add(index)
-        total += len(truncated)
+        indices = _scored_rollout_indices(stage_meta)
+        if indices is None:
+            return None
+        total += len(indices[1])
+    return total
+
+
+def count_scored_rollouts(stage_metas: Iterable[Mapping[str, list]]) -> int | None:
+    """Rollouts a report's scored records actually drew -- ``n_truncated``'s base.
+
+    A bare count does not say how much of a score it explains: ``26`` is a
+    different fact at 600 rollouts than at 30, and the four rule lanes this was
+    built for publish rates plus ``fails`` and no sample total at all, so there
+    was nothing in ``report.json`` to divide by. This is that denominator, and it
+    is the *observed* draw rather than ``n * len(finals)``: a run with a short
+    sample drew fewer rollouts than its budget asked for, and the rate a reader
+    wants is over what actually ran.
+
+    Deliberately not the rate itself. Whether a lane above some threshold should
+    warn, fail or annotate its score is a policy call; this only makes the
+    fraction computable by whoever wants to make it.
+    """
+    total = 0
+    for stage_meta in stage_metas:
+        indices = _scored_rollout_indices(stage_meta)
+        if indices is None:
+            return None
+        total += len(indices[0])
     return total

--- a/tests/unit/core/runners/test_runner.py
+++ b/tests/unit/core/runners/test_runner.py
@@ -47,7 +47,13 @@ from sieval.core.tasks.meta import (
     sieval_task,
 )
 from sieval.core.tasks.task import Task
-from tests.conftest import MockAlwaysFailModel, MockChatModel, MockDataset, make_config
+from tests.conftest import (
+    MockAlwaysFailModel,
+    MockChatModel,
+    MockDataset,
+    make_config,
+    prompt_of,
+)
 
 # ===================================================================
 # Default samples & answers for the 3-sample happy-path dataset
@@ -2664,3 +2670,90 @@ class TestReportVersions:
 
         assert report is None
         assert not (runner.root_dir / "report.json").exists()
+
+
+class GenTask(MockTask):
+    """A ``gen``-tagged task: the protocol set ``@sieval_task`` synthesizes.
+
+    Set directly rather than by registering a decorated task, so the test does
+    not mutate the global registry to obtain one class attribute.
+    """
+
+    tags = frozenset({EvalMode.GEN.value, "zero_shot"})
+
+
+class TruncatingChatModel(MockChatModel):
+    """MockChatModel whose generations stop at the token cap, not by choice.
+
+    ``Response`` validates that ``finish_reasons`` aligns with ``texts``, so the
+    tuple is rebuilt at the same length rather than replaced by a literal.
+    """
+
+    def __init__(self, *args, truncate_for: set[str] | None = None, **kwargs):
+        self._truncate_for = truncate_for  # None = every prompt
+        super().__init__(*args, **kwargs)
+
+    async def _stub_arun(self, req):
+        response = await super()._stub_arun(req)
+        if self._truncate_for is not None and prompt_of(req) not in self._truncate_for:
+            return response
+        return replace(response, finish_reasons=("length",) * len(response.texts))
+
+
+class TestReportTruncation:
+    """`n_truncated` in the report: the count a leaderboard reader can see.
+
+    The per-sample anomaly rule for the same event predates this and is
+    unchanged; what these pin is that the count reaches `report.json`, where
+    previously a score that a truncation rate explained was indistinguishable
+    from one that capability explained.
+    """
+
+    @pytest.mark.anyio
+    async def test_gen_report_counts_every_truncated_rollout(self, tmp_path):
+        model = TruncatingChatModel(answers=DEFAULT_ANSWERS)
+        task = GenTask(dataset=MockDataset(), model=model, name="trunc_all")
+        runner = TaskRunner(task, make_config(tmp_path))
+        report = await runner.arun()
+
+        assert report["n_truncated"] == 3  # all three samples
+        saved = orjson.loads((runner.root_dir / "report.json").read_bytes())
+        assert saved["n_truncated"] == 3
+
+    @pytest.mark.anyio
+    async def test_counts_only_the_rollouts_that_truncated(self, tmp_path):
+        # The number has to move with the run. A count that only ever reads 0 or
+        # "all" would pass an all-truncated fixture while measuring nothing.
+        model = TruncatingChatModel(
+            answers=DEFAULT_ANSWERS, truncate_for={"What is 2+3?"}
+        )
+        task = GenTask(dataset=MockDataset(), model=model, name="trunc_one")
+        report = await TaskRunner(task, make_config(tmp_path)).arun()
+
+        assert report["n_truncated"] == 1
+
+    @pytest.mark.anyio
+    async def test_clean_gen_run_reports_zero_not_nothing(self, tmp_path):
+        # Present-and-zero is the point: it says the run was measured and no
+        # rollout was cut short, which an absent key cannot say.
+        model = MockChatModel(answers=DEFAULT_ANSWERS)
+        task = GenTask(dataset=MockDataset(), model=model, name="trunc_none")
+        report = await TaskRunner(task, make_config(tmp_path)).arun()
+
+        assert report["n_truncated"] == 0
+
+    @pytest.mark.anyio
+    async def test_non_gen_task_omits_the_key(self, tmp_path):
+        # The ppl/clp shape: every call here finishes `length`, and a task that
+        # infers at max_tokens=1 finishes that way by construction. Reporting 0%
+        # would be false and 100% would be meaningless, so the key is omitted --
+        # `sieval_versions`, which is protocol-independent, still lands.
+        model = TruncatingChatModel(answers=DEFAULT_ANSWERS)
+        task = MockTask(dataset=MockDataset(), model=model, name="trunc_nongen")
+        runner = TaskRunner(task, make_config(tmp_path))
+        report = await runner.arun()
+
+        assert "n_truncated" not in report
+        saved = orjson.loads((runner.root_dir / "report.json").read_bytes())
+        assert "n_truncated" not in saved
+        assert saved["sieval_versions"] == [__version__]

--- a/tests/unit/core/runners/test_runner.py
+++ b/tests/unit/core/runners/test_runner.py
@@ -2717,8 +2717,10 @@ class TestReportTruncation:
         report = await runner.arun()
 
         assert report["n_truncated"] == 3  # all three samples
+        assert report["n_scored_rollouts"] == 3
         saved = orjson.loads((runner.root_dir / "report.json").read_bytes())
         assert saved["n_truncated"] == 3
+        assert saved["n_scored_rollouts"] == 3
 
     @pytest.mark.anyio
     async def test_counts_only_the_rollouts_that_truncated(self, tmp_path):
@@ -2731,6 +2733,9 @@ class TestReportTruncation:
         report = await TaskRunner(task, make_config(tmp_path)).arun()
 
         assert report["n_truncated"] == 1
+        # The denominator is what makes that a share rather than a bare count:
+        # 1 of 3, which is the fact a reader of the score needs.
+        assert report["n_scored_rollouts"] == 3
 
     @pytest.mark.anyio
     async def test_clean_gen_run_reports_zero_not_nothing(self, tmp_path):
@@ -2741,6 +2746,7 @@ class TestReportTruncation:
         report = await TaskRunner(task, make_config(tmp_path)).arun()
 
         assert report["n_truncated"] == 0
+        assert report["n_scored_rollouts"] == 3
 
     @pytest.mark.anyio
     async def test_non_gen_task_omits_the_key(self, tmp_path):
@@ -2754,6 +2760,74 @@ class TestReportTruncation:
         report = await runner.arun()
 
         assert "n_truncated" not in report
+        assert "n_scored_rollouts" not in report
         saved = orjson.loads((runner.root_dir / "report.json").read_bytes())
         assert "n_truncated" not in saved
+        assert "n_scored_rollouts" not in saved
         assert saved["sieval_versions"] == [__version__]
+
+    @pytest.mark.anyio
+    async def test_resume_without_recorded_meta_omits_rather_than_undercounts(
+        self, tmp_path
+    ):
+        # `record_meta=False` persists no stage_meta, so a resume hydrates finals
+        # with none and the reasons cannot be re-read. Reducing that to 0 would
+        # report a clean run for a lane that truncated every rollout -- wrong in
+        # the safe-looking direction, which is exactly what this key exists to
+        # stop. `sieval_versions` says the same thing in band with "unknown"; a
+        # count has no such value, so the pair is omitted.
+        model = TruncatingChatModel(answers=DEFAULT_ANSWERS)
+        task = GenTask(dataset=MockDataset(), model=model, name="trunc_resume")
+        first = TaskRunner(task, make_config(tmp_path, record_meta=False))
+        assert (await first.arun())["n_truncated"] == 3
+        root = first.root_dir
+
+        # Drop the cached report so the resume recomputes from the disk records
+        # rather than short-circuiting on the saved artifact.
+        (root / "report.json").unlink()
+
+        resumed_task = GenTask(
+            dataset=MockDataset(),
+            model=TruncatingChatModel(answers=DEFAULT_ANSWERS),
+            name="trunc_resume",
+        )
+        resumed = TaskRunner(
+            resumed_task,
+            replace(
+                make_config(tmp_path, record_meta=False),
+                result_dir=str(root),
+                auto_resume=True,
+            ),
+        )
+        report = await resumed.arun()
+
+        assert "n_truncated" not in report
+        assert "n_scored_rollouts" not in report
+        assert report["sieval_versions"] == ["unknown"]
+        saved = orjson.loads((resumed.root_dir / "report.json").read_bytes())
+        assert "n_truncated" not in saved
+
+    @pytest.mark.anyio
+    async def test_default_resume_still_counts(self, tmp_path):
+        # The omission above must be scoped to the unmeasurable case: under the
+        # default config the hydrated stage_meta survives, so a resume reports
+        # the same count as the original run rather than dropping the key.
+        model = TruncatingChatModel(answers=DEFAULT_ANSWERS)
+        task = GenTask(dataset=MockDataset(), model=model, name="trunc_resume_ok")
+        first = TaskRunner(task, make_config(tmp_path))
+        assert (await first.arun())["n_truncated"] == 3
+        root = first.root_dir
+        (root / "report.json").unlink()
+
+        resumed_task = GenTask(
+            dataset=MockDataset(),
+            model=TruncatingChatModel(answers=DEFAULT_ANSWERS),
+            name="trunc_resume_ok",
+        )
+        report = await TaskRunner(
+            resumed_task,
+            replace(make_config(tmp_path), result_dir=str(root), auto_resume=True),
+        ).arun()
+
+        assert report["n_truncated"] == 3
+        assert report["n_scored_rollouts"] == 3

--- a/tests/unit/core/utils/test_meta.py
+++ b/tests/unit/core/utils/test_meta.py
@@ -13,6 +13,7 @@ from sieval.core.utils.meta import (
     build_model_call_meta_from_mapping,
     build_stage_meta,
     collect_versions,
+    count_scored_rollouts,
     count_truncated_rollouts,
     report_versions,
 )
@@ -275,10 +276,23 @@ class TestCountTruncatedRollouts:
     def test_no_records(self):
         assert count_truncated_rollouts([]) == 0
 
-    def test_stage_absent_contributes_nothing(self):
-        # A ppl/clp task, or a sample that failed before infer: no INFERRED
-        # history at all. Absence is 0, not an error.
-        assert count_truncated_rollouts([{}, {"final": [{"version": "0.7.0"}]}]) == 0
+    def test_unmeasurable_record_is_not_zero(self):
+        # No INFERRED history means the finish reasons were never recorded, not
+        # that nothing was truncated. The reachable cause is a resume under
+        # `record_meta=False`, which hydrates a final with no stage_meta; the two
+        # causes the absence *looks* like -- a ppl/clp task, a sample that failed
+        # before infer -- cannot arrive here, since the caller passes finals only
+        # and gates on `gen`. Reducing it to 0 would report a clean run.
+        assert count_truncated_rollouts([{}]) is None
+        assert count_truncated_rollouts([{"final": [{"version": "0.7.0"}]}]) is None
+
+    def test_one_unmeasurable_record_forfeits_the_whole_count(self):
+        # A partially-hydrated resume: some finals carry their meta, some do not.
+        # A count over just the measurable ones reads low with nothing saying so,
+        # which is the failure mode this key exists to remove.
+        truncated = _inferred({"finish_reasons": ["length"]})
+        assert count_truncated_rollouts([truncated]) == 1
+        assert count_truncated_rollouts([truncated, {}]) is None
 
     def test_natural_stop_is_not_truncation(self):
         assert count_truncated_rollouts([_inferred({"finish_reasons": ["stop"]})]) == 0
@@ -343,6 +357,90 @@ class TestCountTruncatedRollouts:
 
     def test_calls_without_finish_reasons_are_skipped(self):
         # `build_model_call_meta` omits the key when the provider sent nothing.
+        # The stage still ran, so this is measured-and-zero, not unmeasurable.
         assert count_truncated_rollouts([_inferred({"model": _model_meta("m")})]) == 0
         assert count_truncated_rollouts([{TaskStage.INFERRED.value: [{}]}]) == 0
-        assert count_truncated_rollouts([{TaskStage.INFERRED.value: []}]) == 0
+
+    def test_empty_stage_history_is_unmeasurable(self):
+        # An INFERRED key whose history is empty records nothing about the stage,
+        # which is the `{}` case spelled differently -- not a measured zero.
+        assert count_truncated_rollouts([{TaskStage.INFERRED.value: []}]) is None
+
+
+class TestCountScoredRollouts:
+    """`n_truncated`'s denominator: the rollouts a report actually scored.
+
+    Without it the numerator is unreadable -- the lanes this was built for
+    publish rates plus `fails` and no sample total, so `report.json` carried
+    nothing to divide by.
+    """
+
+    def test_no_records(self):
+        assert count_scored_rollouts([]) == 0
+
+    def test_counts_the_draw_not_the_samples(self):
+        four = _inferred({"finish_reasons": ["stop"] * 4})
+        assert count_scored_rollouts([four]) == 4
+        assert count_scored_rollouts([four, four]) == 8
+
+    def test_multi_turn_counts_each_rollout_once(self):
+        # Same union as the numerator: the list dimension is extra calls, the
+        # index dimension is rollouts. Two turns of a 2-rollout draw is 2.
+        multi_turn = _inferred(
+            {"finish_reasons": ["stop", "stop"]},
+            {"finish_reasons": ["stop", "length"]},
+        )
+        assert count_scored_rollouts([multi_turn]) == 2
+
+    def test_observed_draw_not_the_budget(self):
+        # A short sample drew fewer rollouts than the budget asked for. The rate
+        # a reader wants is over what actually ran, so the base is the observed
+        # width -- `n * len(finals)` would understate the truncation share.
+        short = _inferred({"finish_reasons": ["length"]})
+        full = _inferred({"finish_reasons": ["stop"] * 4})
+        assert count_scored_rollouts([short, full]) == 5
+        assert count_truncated_rollouts([short, full]) == 1
+
+    def test_only_the_scored_attempt_is_counted(self):
+        # Same last-entry rule as the numerator, or a retried sample would
+        # inflate the base and dilute the rate.
+        retried = {
+            TaskStage.INFERRED.value: [
+                {"model_calls": [{"finish_reasons": ["stop"] * 4}]},
+                {"model_calls": [{"finish_reasons": ["stop"] * 2}]},
+            ]
+        }
+        assert count_scored_rollouts([retried]) == 2
+
+    def test_grader_calls_are_not_part_of_the_base(self):
+        judged = {
+            TaskStage.INFERRED.value: [{"model_calls": [{"finish_reasons": ["stop"]}]}],
+            TaskStage.FEEDBACK.value: [
+                {"model_calls": [{"finish_reasons": ["stop"] * 8}]}
+            ],
+        }
+        assert count_scored_rollouts([judged]) == 1
+
+    def test_unmeasurable_record_is_not_zero(self):
+        assert count_scored_rollouts([{}]) is None
+        assert (
+            count_scored_rollouts([_inferred({"finish_reasons": ["stop"]}), {}]) is None
+        )
+
+    def test_numerator_never_exceeds_the_base(self):
+        # The invariant that makes the pair a fraction: both are reduced off the
+        # same index space, so a rate can never come out above 1.
+        cases = [
+            _inferred({"finish_reasons": ["length", "stop", "max_tokens"]}),
+            _inferred(
+                {"finish_reasons": ["length", "stop"]},
+                {"finish_reasons": ["stop", "content_filter"]},
+            ),
+            _inferred({"finish_reasons": ["length"] * 4}),
+            _inferred({"model": _model_meta("m")}),
+        ]
+        for case in cases:
+            truncated = count_truncated_rollouts([case])
+            scored = count_scored_rollouts([case])
+            assert truncated is not None and scored is not None
+            assert truncated <= scored

--- a/tests/unit/core/utils/test_meta.py
+++ b/tests/unit/core/utils/test_meta.py
@@ -7,11 +7,13 @@ AI-Generated Code - Claude Opus 4.6 (Anthropic)
 import time
 
 from sieval.core.models import ModelMeta, ModelOutput
+from sieval.core.tasks.consts import TaskStage
 from sieval.core.utils.meta import (
     build_model_call_meta,
     build_model_call_meta_from_mapping,
     build_stage_meta,
     collect_versions,
+    count_truncated_rollouts,
     report_versions,
 )
 
@@ -254,3 +256,93 @@ class TestBuildStageMetaModelCalls:
 
     def test_no_calls_omits_the_key(self):
         assert "model_calls" not in build_stage_meta(timing_s=1.0)
+
+
+def _inferred(*calls: dict) -> dict:
+    """A stage_meta whose INFERRED history is one entry with *calls*."""
+    return {TaskStage.INFERRED.value: [{"model_calls": list(calls)}]}
+
+
+class TestCountTruncatedRollouts:
+    """The report-level count of rollouts that ran out of budget.
+
+    Semantics are pinned against `detect_truncated_output`, which reduces the
+    same event off the live output rather than the persisted meta: the two must
+    agree on what "one truncation" is, or the anomaly file and the report will
+    disagree with nothing to catch it.
+    """
+
+    def test_no_records(self):
+        assert count_truncated_rollouts([]) == 0
+
+    def test_stage_absent_contributes_nothing(self):
+        # A ppl/clp task, or a sample that failed before infer: no INFERRED
+        # history at all. Absence is 0, not an error.
+        assert count_truncated_rollouts([{}, {"final": [{"version": "0.7.0"}]}]) == 0
+
+    def test_natural_stop_is_not_truncation(self):
+        assert count_truncated_rollouts([_inferred({"finish_reasons": ["stop"]})]) == 0
+
+    def test_counts_rollouts_not_samples(self):
+        # One truncated draw in four is a different fact from four.
+        one = _inferred({"finish_reasons": ["stop", "length", "stop", "stop"]})
+        four = _inferred({"finish_reasons": ["length"] * 4})
+        assert count_truncated_rollouts([one]) == 1
+        assert count_truncated_rollouts([one, four]) == 5
+
+    def test_every_provider_spelling_counts(self):
+        # The IR keeps finish_reasons provider-verbatim: an OpenAI-compatible
+        # server says `length`, Anthropic says `max_tokens`. A set holding only
+        # one spelling would read zero on the other provider.
+        for reason in ("length", "max_tokens", "content_filter"):
+            assert (
+                count_truncated_rollouts([_inferred({"finish_reasons": [reason]})]) == 1
+            )
+
+    def test_same_rollout_truncated_on_two_turns_counts_once(self):
+        # A multi-turn stage makes several calls per rollout. Rollout 0 hit the
+        # cap on both turns; that is one truncated rollout, not two.
+        multi_turn = _inferred(
+            {"finish_reasons": ["length", "stop"]},
+            {"finish_reasons": ["length", "stop"]},
+        )
+        assert count_truncated_rollouts([multi_turn]) == 1
+
+    def test_union_across_calls_of_one_stage(self):
+        # Rollout 0 truncated on turn 1, rollout 1 on turn 2: two rollouts.
+        multi_turn = _inferred(
+            {"finish_reasons": ["length", "stop"]},
+            {"finish_reasons": ["stop", "length"]},
+        )
+        assert count_truncated_rollouts([multi_turn]) == 2
+
+    def test_only_the_scored_attempt_is_counted(self):
+        # A retried sample keeps its earlier attempts in the stage history, but
+        # was scored on the last one. Counting a superseded truncation would
+        # report one that no longer affects any number in the report.
+        retried = {
+            TaskStage.INFERRED.value: [
+                {"model_calls": [{"finish_reasons": ["length"]}]},
+                {"model_calls": [{"finish_reasons": ["stop"]}]},
+            ]
+        }
+        assert count_truncated_rollouts([retried]) == 0
+
+    def test_grader_truncation_is_not_the_models(self):
+        # FEEDBACK carries the *grader's* calls. A judge that hit its own budget
+        # is a fact about a different model, already reported separately as
+        # `n_grader_unparsed` -- charging it to the candidate would inflate a
+        # judged lane's truncation rate with someone else's.
+        judged = {
+            TaskStage.INFERRED.value: [{"model_calls": [{"finish_reasons": ["stop"]}]}],
+            TaskStage.FEEDBACK.value: [
+                {"model_calls": [{"finish_reasons": ["length"]}]}
+            ],
+        }
+        assert count_truncated_rollouts([judged]) == 0
+
+    def test_calls_without_finish_reasons_are_skipped(self):
+        # `build_model_call_meta` omits the key when the provider sent nothing.
+        assert count_truncated_rollouts([_inferred({"model": _model_meta("m")})]) == 0
+        assert count_truncated_rollouts([{TaskStage.INFERRED.value: [{}]}]) == 0
+        assert count_truncated_rollouts([{TaskStage.INFERRED.value: []}]) == 0


### PR DESCRIPTION
A rollout that hit its token cap is scored wrong whether or not the model was on its way to the right answer, and the fix is `max_tokens` rather than the prompt or the model. sieval already detects this per sample — `detect_truncated_output`, `gen`-scoped, `severity="info"` — but only into `anomalies.json`. Nothing carried it into `report.json`, the artifact a leaderboard actually reads, so a score that a truncation rate explained was indistinguishable there from one that capability explained.

Offered in #58 ("Happy to send either piece as a PR once #25/#47 settle the signatures"); the signatures have settled.

## What the gap looks like on real runs

Eight archived lanes of an internal instruction-following set, produced at `0.7.1.dev10+g4c4e90d` — `finals`, then the truncated rollouts their **own** `anomalies.json` already records, then what `report.json` actually carries:

| lane | finals | truncated rollouts | score | `n_*` keys in `report.json` |
| --- | --- | --- | --- | --- |
| ifbench | 600 | **26** | 33.83 | *(none)* |
| ifeval | 1082 | 7 | 84.29 | *(none)* |
| iheval | 936 | 6 | 9.76 | *(none)* |
| multi_if | 800 | 6 | 77.93 | *(none)* |
| advanced_if | 1645 | 5 | 31.31 | `n_unextracted: 0.0`, … |
| inverse_ifeval | 1012 | 5 | `pass@1` 31.23 | `n_unextracted: 0.0`, … |
| complex_constraints | 75 | 2 | 1.33 | `n_unextracted: 0.0`, … |
| sysbench | 200 | 0 | 72.70 | `n_sessions`, `n_turns`, … |

Two things this shows, neither of them arguable from the code alone:

- **The four rule lanes carry no `n_*` diagnostic at all** — just `sieval_versions`. ifbench truncated **4.3%** of its rollouts and its report says nothing about it.
- **`n_unextracted` is not a proxy for this.** The three lanes that *do* carry a parser diagnostic report `n_unextracted: 0.0` while 12 rollouts were cut short — truncated *and* still extractable (the cap landed after the answer). So the existing key reads clean on exactly these runs, which is the wrong direction for a reader to be misled in.

## The change

`count_truncated_rollouts` reduces the event off the `finish_reasons` that `build_model_call_meta` has always persisted, and the runner injects the result next to `sieval_versions` — same terminal contexts, same zero extra I/O, hence `_save_report_with_versions` → `_save_report_with_diagnostics`.

Not in `health_metrics`: its 39 callers do **not** include ifeval, ifbench, iheval or multi_if, which are exactly the lanes whose reports carry nothing. A per-task opt-in would have missed every one of them, and a task that forgot would look clean.

The reason set is now a shared `TRUNCATION_FINISH_REASONS` that `detect_truncated_output` reads too. It stays **provider-verbatim** because the IR does not normalize it — `length` on an OpenAI-compatible server (`openai_chat.py`: `finish_reasons[index] = choice.finish_reason or ""`), `max_tokens` on Anthropic, nested under `meta_info["finish_reason"]["type"]` on sglang native — so a set holding one spelling would silently read zero on the other provider. Two copies of the tuple would let the rule and the count come to disagree about what "truncated" means with nothing to catch it. `content_filter` is kept in rather than split out for the same reason: the output is cut short the same way, and separating *causes* is what the raw `finish_reasons` on the record is for.

## Scoping, all three so the count means one thing

- **`gen` only, omitted rather than zeroed elsewhere.** `ppl`/`clp` infer with `max_tokens=1` and therefore finish every call the way a truncated generation does; the key would read 100% on every such run. The anomaly rule is `gen`-scoped for the same reason, and `metrics.py` already states the general rule — a `0.0` meaning "not measurable" is indistinguishable from one meaning "measured, and zero".
- **INFERRED stage only.** A judged task's FEEDBACK stage carries the *grader's* calls; a judge that hit its own budget is a fact about a different model, already reported separately as `n_grader_unparsed`.
- **Last history entry only,** because a retried sample was scored on its last attempt. Deliberately the opposite of `collect_versions`, which unions the whole history precisely because provenance is about everything that ran.

Counted per **rollout**, not per sample — one truncated draw in four is a different fact from four — and deduplicated by rollout index within a sample, which is the same union `detect_truncated_output` takes across the calls of one stage. So the two agree by construction rather than by coincidence: **recomputing the count from the persisted `finish_reasons` of those eight runs reproduces each lane's `anomalies.json` exactly, 8/8** (26/26, 7/7, 6/6, 6/6, 5/5, 5/5, 2/2, 0/0).

Worth naming precisely, since the records are older than the branch: those `anomalies.json` files were written by the rule as it stood at `0.7.1.dev10+g4c4e90d`, which read a single `ModelOutput`; it was widened to union across outputs before `a59c4b4`. The recomputation matching 8/8 anyway says the reduction is faithful to what was persisted, and the by-construction agreement is with the rule as it stands on this branch — the two claims rest on different evidence and neither needs the other. The four rule lanes still emit no `n_*` key at `a59c4b4` (checked in their `report()`, not inferred from the older run).

`finals` only, matching both the detector (which runs on FINAL) and `n_unextracted`: a FAILED sample has no score for a truncation to explain.

## Tests

Ten on the reducer — rollouts not samples; each provider spelling; one rollout truncated on two turns counts once; two rollouts across two turns count twice; a superseded attempt not counted; a FEEDBACK grader call not charged to the candidate. Four end to end — a `gen` task reports 3 of 3 and 1 of 3 (so the number moves with the run, rather than only ever reading 0 or "all"); a clean `gen` run reports `0` rather than nothing; a non-`gen` task omits the key even when every call finished `length`, while `sieval_versions` still lands.

Verified to fail without the change by **two ablations that isolate the halves**: removing only the injection fails the three counting end-to-end tests while all ten reducer tests still pass; neutering only the reducer fails six across both files.

Full unit suite: **5540 passed, 56 skipped** (+14, none pre-existing broken). `ruff check`/`format` clean; `ty` unchanged at the tree's baseline 99 diagnostics, none in the touched files.

## Not here

Turning the count into a **rate**, or gating on it. What the right threshold is — and whether a lane above it should warn, fail, or annotate the score — is a policy call that deserves its own discussion; this change only makes the number visible to whoever wants to make it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
