### PR TITLE
fix(report): recognize Responses output-limit truncation

### DIFF
--- a/sieval/core/utils/meta.py
+++ b/sieval/core/utils/meta.py
@@ -13,12 +13,16 @@ from sieval.core.tasks.context import TaskStageMeta
 #: Finish reasons that mean the generation stopped before the model chose to.
 #:
 #: Every spelling, not one canonical name: the IR does not normalize these, so a
-#: set holding only ``length`` (OpenAI-compatible) would read zero against
-#: ``max_tokens`` (Anthropic). ``content_filter`` is in because the output is cut
-#: short the same way; separating causes is what the raw ``finish_reasons`` are
-#: for. Shared with :func:`sieval.core.tasks.anomaly.detect_truncated_output` so
-#: the rule and the report key cannot drift apart.
-TRUNCATION_FINISH_REASONS = frozenset({"length", "max_tokens", "content_filter"})
+#: set holding only ``length`` (OpenAI-compatible Chat/Completions and SGLang
+#: native) would read zero against ``max_output_tokens`` (OpenAI Responses) or
+#: ``max_tokens`` (Anthropic).
+#: ``content_filter`` is in because the output is cut short the same way;
+#: separating causes is what the raw ``finish_reasons`` are for. Shared with
+#: :func:`sieval.core.tasks.anomaly.detect_truncated_output` so the rule and the
+#: report key cannot drift apart.
+TRUNCATION_FINISH_REASONS = frozenset(
+    {"length", "max_output_tokens", "max_tokens", "content_filter"}
+)
 
 
 def build_model_call_meta(output: ModelOutput) -> ModelCallMeta:

--- a/tests/unit/core/tasks/test_anomaly.py
+++ b/tests/unit/core/tasks/test_anomaly.py
@@ -186,6 +186,7 @@ class TestDetectTruncatedOutput:
         """Single-sample (n=1) finish reason variants."""
         cases = [
             (["length"], {0}, "length"),
+            (["max_output_tokens"], {0}, "max_output_tokens"),
             (["max_tokens"], {0}, "max_tokens"),
             (["content_filter"], {0}, "content_filter"),
             (["stop"], set(), "stop"),

--- a/tests/unit/core/utils/test_meta.py
+++ b/tests/unit/core/utils/test_meta.py
@@ -305,10 +305,16 @@ class TestCountTruncatedRollouts:
         assert count_truncated_rollouts([one, four]) == 5
 
     def test_every_provider_spelling_counts(self):
-        # The IR keeps finish_reasons provider-verbatim: an OpenAI-compatible
-        # server says `length`, Anthropic says `max_tokens`. A set holding only
-        # one spelling would read zero on the other provider.
-        for reason in ("length", "max_tokens", "content_filter"):
+        # The IR keeps finish_reasons provider-verbatim: OpenAI-compatible
+        # Chat/Completions and SGLang native say `length`, Responses says
+        # `max_output_tokens`, and Anthropic says `max_tokens`. A set holding only
+        # one spelling would silently read zero on another provider.
+        for reason in (
+            "length",
+            "max_output_tokens",
+            "max_tokens",
+            "content_filter",
+        ):
             assert (
                 count_truncated_rollouts([_inferred({"finish_reasons": [reason]})]) == 1
             )


### PR DESCRIPTION
## Type

- fix — bug fix or alignment correction

## Summary

- Recognize the Responses API's provider-verbatim `max_output_tokens` incomplete reason as a truncated generation.
- Keep live anomaly detection and persisted `report.json` reduction aligned through the shared `TRUNCATION_FINISH_REASONS` set.
- Add regression coverage for both the live `ModelOutput` path and persisted model-call metadata path.
- This is a prerequisite for RFC #25's `openai_responses` adapter, which will map `incomplete_details.reason` into `finish_reasons` without normalization.
- The current tree has no Responses producer yet; the companion adapter PR will provide and test that mapping separately to preserve the adapter-only diff boundary.

## Related Issues

- Refs #25
- Follow-up to #113

## Test Plan

### Automated

- [x] Lint/format clean (`ruff check && ruff format --check`)
- [x] Type check clean (`ty check` or `mypy --strict`)
- [x] Unit tests pass (`pdm run pytest`)

Verification:

- Targeted meta/anomaly tests: 155 passed
- Core unit tests: 1988 passed
- `sieval/core/utils/meta.py`: 100% statement and branch coverage
- Quick preflight: all checks passed

## Checklist

### Required (all PRs)

- [x] PR title follows conventional format (`type(scope): description`)
- [x] No internal paths, credentials, or personal info in committed files
- [x] AI-generated code has `AI-Generated Code - <model> (<provider>)` in module docstring
- [x] No new upper-layer dependencies added to `core/`
- [x] Deleted code verified — no remaining call sites depend on it