### PR TITLE
fix(runners): one task's crash no longer cancels the rest of the batch

### DIFF
--- a/sieval/core/runners/multi_runner.py
+++ b/sieval/core/runners/multi_runner.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any, Literal, Self
 
 import anyio
+from loguru import logger
 
 from sieval.core.tasks.concurrency import prepare_limiters
 from sieval.core.tasks.context import TaskAction
@@ -118,13 +119,43 @@ class MultiTaskRunner:
 
         # 3. Run in Parallel
         results: dict[str, Any] = {}
+        failures: dict[str, Exception] = {}
 
         async def _run_wrapper(r: TaskRunner) -> None:
-            res = await r.arun()
-            results[r._task.name] = res
+            name = r._task.name
+            try:
+                results[name] = await r.arun()
+            except Exception as exc:
+                # ONE TASK'S CRASH MUST NOT CANCEL ITS SIBLINGS. Raising into the
+                # task group cancels every other runner mid-flight, so a single
+                # task that dies in `report()` -- a grader dividing by an empty
+                # denominator is the usual way -- used to cost the whole batch its
+                # results, including tasks that had already finished computing
+                # them. Hold the exception instead: the siblings run to completion
+                # and each writes its own `report.json`.
+                #
+                # `Exception`, deliberately not `BaseException`: cancellation
+                # (`asyncio.CancelledError`) and `KeyboardInterrupt` are
+                # BaseException-only, so an interrupt still tears the batch down
+                # through `TaskRunner.arun`'s own flush-and-save path.
+                logger.error("Task '{}' failed: {!r}", name, exc)
+                failures[name] = exc
 
         async with anyio.create_task_group() as tg:
             for runner in self._runners:
                 tg.start_soon(_run_wrapper, runner)
+
+        # Isolated, NOT swallowed. A partial dict returned as if it were the whole
+        # batch is the failure mode this guard would otherwise introduce: the
+        # caller's exit code would read success while a task is missing from the
+        # results. `ExceptionGroup` is the shape an uncaught failure already had
+        # (anyio's task group wraps even a single exception), so nothing
+        # downstream has to learn a new one.
+        if failures:
+            raise ExceptionGroup(
+                f"{len(failures)} of {len(self._runners)} task(s) failed: "
+                + ", ".join(sorted(failures)),
+                [failures[name] for name in sorted(failures)],
+            )
 
         return results

--- a/sieval/core/runners/multi_runner.py
+++ b/sieval/core/runners/multi_runner.py
@@ -94,7 +94,15 @@ class MultiTaskRunner:
         return anyio.run(self.arun)
 
     async def arun(self) -> dict[str, Any]:
-        """Run all registered tasks concurrently with shared limiters."""
+        """Run all registered tasks concurrently with shared limiters.
+
+        Raises:
+            ExceptionGroup: If any task raised.  A failing task does not cancel
+                its siblings, which run to completion and write their own
+                ``report.json``; the message names the tasks that failed.
+                Nothing is returned in this case, so the successful tasks'
+                results are on disk only.
+        """
         # 1. Prepare Shared Limiters
         norm_stage_limits = {}
         if self._stage_limits_cfg:
@@ -126,32 +134,36 @@ class MultiTaskRunner:
             try:
                 results[name] = await r.arun()
             except Exception as exc:
-                # ONE TASK'S CRASH MUST NOT CANCEL ITS SIBLINGS. Raising into the
-                # task group cancels every other runner mid-flight, so a single
-                # task that dies in `report()` -- a grader dividing by an empty
-                # denominator is the usual way -- used to cost the whole batch its
-                # results, including tasks that had already finished computing
-                # them. Hold the exception instead: the siblings run to completion
-                # and each writes its own `report.json`.
+                # Hold, do not propagate: raising into the task group cancels every
+                # sibling mid-flight, and a cancelled runner flushes its shards but
+                # never writes `report.json`.
                 #
-                # `Exception`, deliberately not `BaseException`: cancellation
-                # (`asyncio.CancelledError`) and `KeyboardInterrupt` are
-                # BaseException-only, so an interrupt still tears the batch down
-                # through `TaskRunner.arun`'s own flush-and-save path.
-                logger.error("Task '{}' failed: {!r}", name, exc)
+                # `Exception`, deliberately not `BaseException` -- cancellation and
+                # `KeyboardInterrupt` are BaseException-only, so an interrupt still
+                # tears the batch down through `TaskRunner.arun`'s own save path.
+                #
+                # Logged with its traceback here because the re-raise below is now
+                # as far away as the rest of the batch is long.
+                logger.opt(exception=exc).error("Task '{}' failed: {!r}", name, exc)
                 failures[name] = exc
 
         async with anyio.create_task_group() as tg:
             for runner in self._runners:
                 tg.start_soon(_run_wrapper, runner)
 
-        # Isolated, NOT swallowed. A partial dict returned as if it were the whole
-        # batch is the failure mode this guard would otherwise introduce: the
-        # caller's exit code would read success while a task is missing from the
-        # results. `ExceptionGroup` is the shape an uncaught failure already had
-        # (anyio's task group wraps even a single exception), so nothing
-        # downstream has to learn a new one.
+        # Isolated, not swallowed: returning a partial dict would let the caller's
+        # exit code read success while a task is missing from it. `ExceptionGroup`
+        # is the shape an uncaught failure already had, so callers keep working.
         if failures:
+            # The survivors appear in neither the group nor a return value, so
+            # their only other trace is a `report.json` you would have to know to
+            # look for. Guarded, because "0 task(s) completed" reads as reassurance.
+            if results:
+                logger.info(
+                    "{} task(s) completed and saved their reports: {}",
+                    len(results),
+                    ", ".join(sorted(results)),
+                )
             raise ExceptionGroup(
                 f"{len(failures)} of {len(self._runners)} task(s) failed: "
                 + ", ".join(sorted(failures)),

--- a/tests/unit/core/runners/test_multi_runner.py
+++ b/tests/unit/core/runners/test_multi_runner.py
@@ -7,8 +7,10 @@ rather than internal wiring (private attributes, mock call args).
 AI-Generated Code - Claude Opus 4.6 (Anthropic)
 """
 
+import json
 from typing import Any
 
+import anyio
 import pytest
 
 from sieval.core.runners.multi_runner import MultiTaskRunner
@@ -190,3 +192,88 @@ async def test_arun_exception_propagates(tmp_path):
     # Verify the runner completes with 0% accuracy instead of crashing.
     result = await runner.arun()
     assert result["bad"]["accuracy"] == 0.0
+
+
+@pytest.mark.anyio
+async def test_a_crashing_report_lets_its_siblings_finish(tmp_path):
+    """A task dying in `report()` must not cancel the rest of the batch.
+
+    The sibling is deliberately slower than the crash, so pre-fix it is still
+    mid-flight when the exception reaches the task group: cancellation lands in
+    `TaskRunner.arun`'s interrupt path, which flushes shards but never writes
+    `report.json`. So the sibling's report on disk -- not merely the absence of a
+    crash -- is what separates "ran to completion" from "cancelled".
+    """
+
+    class _CrashingReportTask(_SimpleTask):
+        async def report(self, finals, fails):
+            # The shape of the real defect: a grader metric over an empty
+            # denominator, raised after every sample has been judged.
+            raise ValueError("Found array with 0 sample(s) (shape=(0,))")
+
+    class _SlowTask(_SimpleTask):
+        async def postprocess(self, inf, ctx):
+            await anyio.sleep(0.5)
+            return inf.texts[0].strip()
+
+    crasher = _CrashingReportTask(
+        dataset=MockDataset(SAMPLES),
+        model=MockChatModel(answers={"1+1?": "2", "2+3?": "5"}),
+        name="crasher",
+    )
+    sibling = _SlowTask(
+        dataset=MockDataset(SAMPLES),
+        model=MockChatModel(answers={"1+1?": "2", "2+3?": "5"}),
+        name="sibling",
+    )
+
+    base = tmp_path / "isolated"
+    runner = MultiTaskRunner(result_dir=str(base))
+    runner.add_task(crasher, config=make_config(tmp_path, result_dir=None))
+    runner.add_task(sibling, config=make_config(tmp_path, result_dir=None))
+
+    with pytest.raises(ExceptionGroup) as excinfo:
+        await runner.arun()
+
+    # The discriminating assertion, first: the sibling reached its own report.
+    sibling_report = base / "sibling" / "report.json"
+    assert sibling_report.exists()
+    assert json.loads(sibling_report.read_text())["accuracy"] == 1.0
+    assert not (base / "crasher" / "report.json").exists()
+
+    # The failure still reaches the caller -- isolated, not swallowed -- and names
+    # which task it came from, so a batch of many does not need a log dive.
+    assert "crasher" in str(excinfo.value)
+    assert "sibling" not in str(excinfo.value)
+    assert [type(e) for e in excinfo.value.exceptions] == [ValueError]
+    assert "0 sample(s)" in str(excinfo.value.exceptions[0])
+
+
+@pytest.mark.anyio
+async def test_the_failure_guard_does_not_swallow_cancellation(tmp_path):
+    """`except Exception` must not widen into `BaseException`.
+
+    Cancellation and `KeyboardInterrupt` are BaseException-only; catching them
+    here would turn an interrupt into a collected "task failure" and let the
+    remaining runners keep going, which is the opposite of what an interrupt
+    means. Asserting on the message proves which path raised: the guard's own
+    `ExceptionGroup` says "task(s) failed", anyio's does not.
+    """
+
+    class _Interrupt(BaseException):
+        pass
+
+    async def _interrupted() -> None:
+        raise _Interrupt("ctrl-c")
+
+    runner = MultiTaskRunner(result_dir=str(tmp_path / "cancelled"))
+    runner.add_task(_make_task("t"), config=make_config(tmp_path, result_dir=None))
+    # Injected at the seam the guard wraps: an instance attribute shadows the
+    # method, so `r.arun()` raises straight into `_run_wrapper`.
+    runner._runners[0].arun = _interrupted  # type: ignore[method-assign]
+
+    with pytest.raises(BaseExceptionGroup) as excinfo:
+        await runner.arun()
+
+    assert "task(s) failed" not in str(excinfo.value)
+    assert [type(e) for e in excinfo.value.exceptions] == [_Interrupt]

--- a/tests/unit/core/runners/test_multi_runner.py
+++ b/tests/unit/core/runners/test_multi_runner.py
@@ -198,11 +198,10 @@ async def test_arun_exception_propagates(tmp_path):
 async def test_a_crashing_report_lets_its_siblings_finish(tmp_path):
     """A task dying in `report()` must not cancel the rest of the batch.
 
-    The sibling is deliberately slower than the crash, so pre-fix it is still
-    mid-flight when the exception reaches the task group: cancellation lands in
-    `TaskRunner.arun`'s interrupt path, which flushes shards but never writes
-    `report.json`. So the sibling's report on disk -- not merely the absence of a
-    crash -- is what separates "ran to completion" from "cancelled".
+    The sibling is deliberately slow, so pre-fix it is still mid-flight when the
+    crash reaches the task group and is cancelled into `TaskRunner.arun`'s
+    interrupt path -- which flushes shards but never writes `report.json`. Its
+    report on disk, not the absence of a crash, is the discriminator.
     """
 
     class _CrashingReportTask(_SimpleTask):
@@ -241,12 +240,94 @@ async def test_a_crashing_report_lets_its_siblings_finish(tmp_path):
     assert json.loads(sibling_report.read_text())["accuracy"] == 1.0
     assert not (base / "crasher" / "report.json").exists()
 
-    # The failure still reaches the caller -- isolated, not swallowed -- and names
-    # which task it came from, so a batch of many does not need a log dive.
+    # Isolated, not swallowed -- and it names which task it came from, so a batch
+    # of many does not need a log dive.
     assert "crasher" in str(excinfo.value)
     assert "sibling" not in str(excinfo.value)
     assert [type(e) for e in excinfo.value.exceptions] == [ValueError]
     assert "0 sample(s)" in str(excinfo.value.exceptions[0])
+
+
+@pytest.mark.anyio
+async def test_a_failed_batch_logs_the_traceback_and_names_the_survivors(tmp_path):
+    """While a batch is still running, the log is the operator's only view.
+
+    The re-raise is as far away as the rest of the batch is long, which puts two
+    things on the log: the traceback, written where the task died rather than
+    where it is finally raised, and the survivors, who appear in neither the
+    raised group nor a return value.
+    """
+    from loguru import logger
+
+    class _CrashingReportTask(_SimpleTask):
+        async def report(self, finals, fails):
+            raise ValueError("Found array with 0 sample(s) (shape=(0,))")
+
+    runner = MultiTaskRunner(result_dir=str(tmp_path / "logged"))
+    runner.add_task(
+        _CrashingReportTask(
+            dataset=MockDataset(SAMPLES),
+            model=MockChatModel(answers={"1+1?": "2", "2+3?": "5"}),
+            name="crasher",
+        ),
+        config=make_config(tmp_path, result_dir=None),
+    )
+    runner.add_task(
+        _make_task("survivor"), config=make_config(tmp_path, result_dir=None)
+    )
+
+    records: list[str] = []
+    sink_id = logger.add(records.append, format="{message}", level="INFO")
+    try:
+        with pytest.raises(ExceptionGroup):
+            await runner.arun()
+    finally:
+        logger.remove(sink_id)
+
+    # A bare `logger.error` carries the repr and stops there: what broke, not
+    # where, and not until the whole batch has drained.
+    failure_log = next(r for r in records if "Task 'crasher' failed" in r)
+    assert "Traceback (most recent call last)" in failure_log
+    assert "in report" in failure_log
+
+    assert any(
+        "task(s) completed and saved their reports" in r and "survivor" in r
+        for r in records
+    )
+
+
+@pytest.mark.anyio
+async def test_no_survivor_line_when_nothing_survived(tmp_path):
+    """A batch where everything died must not announce "0 task(s) completed".
+
+    The summary is guarded on a non-empty `results`; emitted unconditionally it
+    would read as reassurance at exactly the moment nothing was saved.
+    """
+    from loguru import logger
+
+    class _CrashingReportTask(_SimpleTask):
+        async def report(self, finals, fails):
+            raise ValueError("Found array with 0 sample(s) (shape=(0,))")
+
+    runner = MultiTaskRunner(result_dir=str(tmp_path / "total_loss"))
+    runner.add_task(
+        _CrashingReportTask(
+            dataset=MockDataset(SAMPLES),
+            model=MockChatModel(answers={"1+1?": "2", "2+3?": "5"}),
+            name="only",
+        ),
+        config=make_config(tmp_path, result_dir=None),
+    )
+
+    records: list[str] = []
+    sink_id = logger.add(records.append, format="{message}", level="INFO")
+    try:
+        with pytest.raises(ExceptionGroup):
+            await runner.arun()
+    finally:
+        logger.remove(sink_id)
+
+    assert not any("completed and saved their reports" in r for r in records)
 
 
 @pytest.mark.anyio
@@ -255,9 +336,12 @@ async def test_the_failure_guard_does_not_swallow_cancellation(tmp_path):
 
     Cancellation and `KeyboardInterrupt` are BaseException-only; catching them
     here would turn an interrupt into a collected "task failure" and let the
-    remaining runners keep going, which is the opposite of what an interrupt
-    means. Asserting on the message proves which path raised: the guard's own
-    `ExceptionGroup` says "task(s) failed", anyio's does not.
+    remaining runners keep going.
+
+    A widened guard dies before the assertions below ever run: `ExceptionGroup`
+    refuses to nest a BaseException, so it raises `TypeError` at construction.
+    The message assertions pin the intended path for what gets that far -- the
+    guard's own group says "task(s) failed", anyio's does not.
     """
 
     class _Interrupt(BaseException):


### PR DESCRIPTION
## Type

- fix — bug fix or alignment correction

## Summary

- `_run_wrapper` awaited `TaskRunner.arun()` with nothing between it and the enclosing `anyio.create_task_group()`, so **a single task that raised took the whole batch down with it**: the task group cancels every sibling runner, each lands in `TaskRunner.arun`'s interrupt path — which flushes shards but never writes `report.json` — and `arun()` returns nothing at all, losing even the tasks that had already finished computing their reports.
- A grader raising in `report()` is the usual way in, and it needs only a degenerate input: an empty or single-class denominator on a metric that refuses one. The graders here guard for that individually, which is the only thing that has been holding the batch together — there was no backstop at this level.
- The wrapper now holds the exception, lets the siblings run to completion, and re-raises afterwards as an `ExceptionGroup` naming the tasks that failed. **Isolated, not swallowed**: returning a partial dict would let the caller's exit code read success while a task is missing from the results, which is worse than the crash it replaced. `ExceptionGroup` is also the shape an uncaught failure already had (anyio wraps even a single exception), so nothing downstream has to learn a new one.
- `except Exception`, deliberately **not** `BaseException` — cancellation (`asyncio.CancelledError`) and `KeyboardInterrupt` are BaseException-only, so an interrupt still tears the batch down through the runner's own flush-and-save path. A test pins that boundary, since widening it is the plausible way for this guard to go wrong later.
- `tests/integration/test_multi_task.py` already asserted the sibling-isolation intent for per-sample failures; this extends it to a task that dies in its report.

## Test Plan

### Automated

- [x] Lint/format clean (`ruff check` + `ruff format --check`, whole tree)
- [x] Type check clean (`ty check` on the changed module — "All checks passed"; `mypy sieval` contributes no new error, verified by diffing the full error set against the parent commit — the four entries that move are the same pre-existing ones shifted one line by the added import)
- [x] Unit + integration tests pass — `tests/unit/core/runners/` + `tests/integration/test_multi_task.py` 171/171; full `tests/unit` + `tests/integration` 5653 passed, 13 pre-existing failures unrelated to this change (`ModuleNotFoundError: rouge_score`, an unmet `iheval` optional dep, reproduced identically on the parent commit)
- [x] `sieval/core` coverage gate: TOTAL 99% (≥ 95% `fail_under`); `multi_runner.py` 98%, its single uncovered line being the pre-existing `deterministic` force-on branch, outside this diff

### Manual

- [x] `test_a_crashing_report_lets_its_siblings_finish` was run against the parent commit and **fails there on its discriminating assertion** — the sibling's `report.json` is absent, because the sibling is cancelled mid-flight (the captured log shows its runner entering `Interrupted. Saving progress...`). The sibling is deliberately slower than the crash so the race is decided, not left to scheduling.
- [x] `test_the_failure_guard_does_not_swallow_cancellation` was run against a deliberately wrong version of this fix (`except BaseException`) and **fails there**, so it guards the boundary rather than merely passing alongside it.

## Checklist

### Required (all PRs)

- [x] PR title follows conventional format (`type(scope): description`)
- [x] No internal paths, credentials, or personal info in committed files
- [x] AI-generated code has `AI-Generated Code - <model> (<provider>)` in module docstring — the edited test file already carries it; `multi_runner.py`'s module docstring did not carry one before this change either
- [x] No new upper-layer dependencies added to `core/` — the one added import is `loguru`, already used throughout `core/runners/`
- [x] Deleted code verified — no remaining call sites depend on it

### If: Breaking Change

Behaviour change, callers unaffected in shape: `arun()` still raises `ExceptionGroup` when a task fails, and still returns the full results dict when none does. What changes is that the siblings now finish (and persist their reports) before that raise, and the message names which tasks failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
