### PR TITLE
fix(models): make deterministic request seeds dialect-aware

### DIFF
--- a/sieval/cli/leaderboard/session.py
+++ b/sieval/cli/leaderboard/session.py
@@ -161,11 +161,13 @@ class _RequestSeedDecision:
 
     dialect_id: str
     support: RequestSeedSupport
+    # Evidence-only: records where deterministic sampling is controlled
+    # (currently derivable from dialect_id). Execution consumes the frozen
+    # final seed state, not this field.
     scope: _RequestSeedScope
     seed_present: bool
     seed: int | None
     provenance: _RequestSeedProvenance
-    remove_inherited_seed: bool
 
     @property
     def explicit_seed_present(self) -> bool:
@@ -209,7 +211,6 @@ def _resolve_deterministic_request_seed(
             seed_present=True,
             seed=explicit_seed,
             provenance=explicit_provenance,
-            remove_inherited_seed=False,
         )
     if support is RequestSeedSupport.SUPPORTED:
         return _RequestSeedDecision(
@@ -219,7 +220,6 @@ def _resolve_deterministic_request_seed(
             seed_present=True,
             seed=DETERMINISTIC_DEFAULT_SEED,
             provenance=_RequestSeedProvenance.AUTOMATIC,
-            remove_inherited_seed=False,
         )
     return _RequestSeedDecision(
         dialect_id=dialect_id,
@@ -228,11 +228,15 @@ def _resolve_deterministic_request_seed(
         seed_present=False,
         seed=None,
         provenance=_RequestSeedProvenance.NONE,
-        # The legacy path is deterministic at engine scope and never inherits
-        # an orchestration-injected request default.  Ordinary unsupported
-        # dialects must remove one inherited from a supporting parent binding.
-        remove_inherited_seed=scope is _RequestSeedScope.PER_REQUEST,
     )
+
+
+def _validated_request_seed(value: object) -> int | None:
+    """Return one typed request seed or reject an invalid explicit value."""
+
+    if value is not None and (isinstance(value, bool) or not isinstance(value, int)):
+        raise TypeError("seed must be an integer")
+    return cast(int | None, value)
 
 
 def _with_task_infer_seed(
@@ -243,15 +247,12 @@ def _with_task_infer_seed(
 
     if "seed" not in infer_args:
         return decision
-    seed = infer_args["seed"]
-    if seed is not None and (isinstance(seed, bool) or not isinstance(seed, int)):
-        raise TypeError("seed must be an integer")
+    seed = _validated_request_seed(infer_args["seed"])
     return dataclasses.replace(
         decision,
         seed_present=True,
         seed=seed,
         provenance=_RequestSeedProvenance.TASK_INFER_ARGS,
-        remove_inherited_seed=False,
     )
 
 
@@ -276,8 +277,7 @@ def _apply_request_seed_decision_to_model(
             f"{decision.dialect_id!r}, but the bound model uses "
             f"{model.dialect_id!r}"
         )
-    if "seed" in model._kwargs:
-        model = model.without_args("seed")
+    model = model.without_args("seed")
     if decision.seed_present:
         model = model.with_args(seed=decision.seed)
     return model
@@ -2564,12 +2564,7 @@ class EvalSession:
     ) -> tuple[bool, int | None]:
         if "seed" not in values:
             return False, None
-        value = values["seed"]
-        if value is not None and (
-            isinstance(value, bool) or not isinstance(value, int)
-        ):
-            raise TypeError("seed must be an integer")
-        return True, value
+        return True, _validated_request_seed(values["seed"])
 
     def _freeze_deterministic_request_seed_decisions(self) -> None:
         """Freeze every model request-default seed decision after prelaunch."""
@@ -2678,7 +2673,6 @@ class EvalSession:
         binding: NormalizedModelBinding,
     ) -> dict[str, JSONValue]:
         entry: dict[str, JSONValue] = {
-            "binding_id": binding.binding_id,
             "requested_model_id": binding.requested_model_id,
             "dialect_id": decision.dialect_id,
             "request_seed_support": decision.support.value,
@@ -2687,10 +2681,9 @@ class EvalSession:
             "seed": decision.seed,
             "seed_provenance": decision.provenance.value,
             "explicit_seed_present": decision.explicit_seed_present,
-            "remove_inherited_seed": decision.remove_inherited_seed,
         }
-        if isinstance(binding, ExternalModelBinding):
-            entry["runtime_plan_fingerprint"] = binding.runtime_plan_fingerprint
+        if not isinstance(binding, ExternalModelBinding):
+            entry["binding_id"] = binding.binding_id
         return entry
 
     def _deterministic_seed_contract(self) -> dict[str, JSONValue]:
@@ -3879,31 +3872,6 @@ class EvalSession:
         raise ValueError(
             f"Task '{task_name}': 'dataset' must be a string reference or inline definition"  # noqa: E501
         )
-
-    def _resolve_task_model(self, task_cfg: TaskConfigDict, task_name: str) -> Model:
-        """Resolve model for a task."""
-        model_ref = task_cfg.get("model")
-
-        if model_ref is not None and not isinstance(model_ref, str):
-            raise ValueError(f"Task '{task_name}': 'model' must be a string reference")
-
-        # If no model specified, use default if only one exists
-        if not model_ref:
-            if len(self.models) == 1:
-                return next(iter(self.models.values()))
-            elif len(self.models) == 0:
-                raise ValueError(f"Task '{task_name}': no models defined in config")
-            else:
-                raise ValueError(
-                    f"Task '{task_name}': 'model' required when multiple models are defined"  # noqa: E501
-                )
-
-        if model_ref not in self.models:
-            raise ValueError(
-                f"Task '{task_name}' references unknown model '{model_ref}'"
-            )
-
-        return self.models[model_ref]
 
     def _build_runner_config(
         self, task_cfg: TaskConfigDict, defaults: dict[str, Any]

--- a/sieval/cli/leaderboard/session.py
+++ b/sieval/cli/leaderboard/session.py
@@ -2617,7 +2617,8 @@ class EvalSession:
                             f"Inline binding '{binding.binding_id}' args must be "
                             "a mapping"
                         )
-                    nested_present, nested_seed = self._seed_from_mapping(raw_args)
+                    nested_args = cast(Mapping[str, object], raw_args)
+                    nested_present, nested_seed = self._seed_from_mapping(nested_args)
                     if nested_present:
                         explicit_seed_present = True
                         explicit_seed = nested_seed

--- a/sieval/cli/leaderboard/session.py
+++ b/sieval/cli/leaderboard/session.py
@@ -231,23 +231,28 @@ def _resolve_deterministic_request_seed(
     )
 
 
-def _validated_request_seed(value: object) -> int | None:
-    """Return one typed request seed or reject an invalid explicit value."""
+def _validated_request_seed(value: object, subject: str) -> int | None:
+    """Return one typed request seed or reject an invalid explicit value.
+
+    ``subject`` names the config site being read so a rejected value is
+    locatable in a config that declares many models and tasks.
+    """
 
     if value is not None and (isinstance(value, bool) or not isinstance(value, int)):
-        raise TypeError("seed must be an integer")
+        raise TypeError(f"{subject} must be an integer")
     return cast(int | None, value)
 
 
 def _with_task_infer_seed(
     decision: _RequestSeedDecision,
     infer_args: Mapping[str, JSONValue],
+    subject: str,
 ) -> _RequestSeedDecision:
     """Overlay a task candidate's frozen ``infer_args.seed`` when present."""
 
     if "seed" not in infer_args:
         return decision
-    seed = _validated_request_seed(infer_args["seed"])
+    seed = _validated_request_seed(infer_args["seed"], subject)
     return dataclasses.replace(
         decision,
         seed_present=True,
@@ -2543,7 +2548,7 @@ class EvalSession:
                 )
         if not labels_by_binding:
             return
-        warned.update(labels_by_binding)
+        warned.update(labels_by_binding.keys())
         labels = sorted(
             label for values in labels_by_binding.values() for label in values
         )
@@ -2561,10 +2566,11 @@ class EvalSession:
     @staticmethod
     def _seed_from_mapping(
         values: Mapping[str, object],
+        subject: str,
     ) -> tuple[bool, int | None]:
         if "seed" not in values:
             return False, None
-        return True, _validated_request_seed(values["seed"])
+        return True, _validated_request_seed(values["seed"], subject)
 
     def _freeze_deterministic_request_seed_decisions(self) -> None:
         """Freeze every model request-default seed decision after prelaunch."""
@@ -2597,13 +2603,15 @@ class EvalSession:
                         raise ValueError(
                             f"Model '{binding.config_name}' args must be a dictionary"
                         )
-                    present, value = self._seed_from_mapping(raw_args)
+                    present, value = self._seed_from_mapping(
+                        raw_args, f"Model '{binding.config_name}' args.seed"
+                    )
                     if present:
                         explicit_seed_present = True
                         explicit_seed = value
             else:
                 explicit_seed_present, explicit_seed = self._seed_from_mapping(
-                    binding.config
+                    binding.config, f"Inline binding '{binding.binding_id}' seed"
                 )
                 raw_args = binding.config.get("args")
                 if raw_args is not None:
@@ -2613,7 +2621,10 @@ class EvalSession:
                             "a mapping"
                         )
                     nested_args = cast(Mapping[str, object], raw_args)
-                    nested_present, nested_seed = self._seed_from_mapping(nested_args)
+                    nested_present, nested_seed = self._seed_from_mapping(
+                        nested_args,
+                        f"Inline binding '{binding.binding_id}' args.seed",
+                    )
                     if nested_present:
                         explicit_seed_present = True
                         explicit_seed = nested_seed
@@ -2641,7 +2652,8 @@ class EvalSession:
                             f"External binding '{binding.binding_id}' has no dialect"
                         )
                     present, value = self._seed_from_mapping(
-                        source.meta()["default_params"]
+                        source.meta()["default_params"],
+                        f"Task '{task_name}' {role} model seed",
                     )
                     decision = _resolve_deterministic_request_seed(
                         dialect_id=dialect_id,
@@ -2659,7 +2671,9 @@ class EvalSession:
                     f"Task '{task_name}' candidate must be a named or inline binding"
                 )
             by_candidate[task_name] = _with_task_infer_seed(
-                by_binding[candidate.binding_id], context.infer_args
+                by_binding[candidate.binding_id],
+                context.infer_args,
+                f"Task '{task_name}' infer_args.seed",
             )
 
         self._request_seed_decisions_by_binding = by_binding
@@ -2672,6 +2686,27 @@ class EvalSession:
         decision: _RequestSeedDecision,
         binding: NormalizedModelBinding,
     ) -> dict[str, JSONValue]:
+        """Project one frozen decision into strict, human-auditable evidence.
+
+        This entry's key set IS the resume-invalidation surface: ``--resume``
+        compares the persisted config strictly, so adding or removing a field
+        here invalidates every in-flight deterministic result dir. Two fields
+        are deliberately kept despite being derivable from their siblings:
+
+        * ``seed_scope`` — implied by ``dialect_id`` only while
+          ``sglang_legacy`` is the one engine-scoped dialect; a registered
+          ``sglang_native`` binder decouples the two, and rotating the
+          contract then would be more expensive than carrying it now.
+        * ``explicit_seed_present`` — implied by ``seed_provenance``, and kept
+          so an audit can answer "did a human choose this seed?" without
+          knowing which provenance values count as explicit.
+
+        ``binding_id`` is omitted for external bindings: it carries a
+        per-process identity that would rotate the contract between runs that
+        differ only by endpoint. Their stable identity is the outer
+        ``task.role`` key plus ``requested_model_id`` and ``dialect_id``.
+        """
+
         entry: dict[str, JSONValue] = {
             "requested_model_id": binding.requested_model_id,
             "dialect_id": decision.dialect_id,
@@ -3185,8 +3220,6 @@ class EvalSession:
                     assert isinstance(base_name, str)
                     model = self.models[base_name]
                     args = self._normalize_dict(cfg.get("args"), f"Model '{name}' args")
-                    if self.deterministic:
-                        args.pop("seed", None)
                     concurrency_limit = args.pop("concurrency_limit", None)
                     model = model.with_args(concurrency_limit=concurrency_limit, **args)
                 else:
@@ -3234,8 +3267,6 @@ class EvalSession:
                                 )
 
                     args, extra = self._request_builder_args(cfg)
-                    if self.deterministic:
-                        args.pop("seed", None)
                     concurrency_limit = None
                     if not is_root:
                         raw_args = cfg.get("args", {})
@@ -3302,8 +3333,6 @@ class EvalSession:
             ):
                 direct_config.pop(key, None)
             extra = direct_config.pop("extra", None)
-            if self.deterministic:
-                direct_config.pop("seed", None)
             if direct_config or extra is not None:
                 model = model.with_args(
                     extra=cast(dict[str, JSONValue] | None, extra), **direct_config
@@ -3784,22 +3813,22 @@ class EvalSession:
                     f"'{candidate.config_name}' was not bound"
                 ) from exc
 
-            frozen_infer_args = dict(context.infer_args)
-            infer_args = dict(frozen_infer_args)
-            if self.deterministic:
-                infer_args.pop("seed", None)
+            infer_args = dict(context.infer_args)
             if infer_args:
                 model = model.with_args(**cast(dict[str, Any], infer_args))
             if self.deterministic:
+                # The frozen candidate decision already folded in this task's
+                # ``infer_args.seed``, so it is the single authority for the
+                # final seed and overrides whatever landed above.
                 model = _apply_request_seed_decision_to_model(
                     model,
                     self._request_seed_decisions_by_candidate[task_name],
                 )
-            if frozen_infer_args:
+            if infer_args:
                 logger.info(
                     "Task '{}': applied infer_args override {}",
                     task_name,
-                    frozen_infer_args,
+                    infer_args,
                 )
 
             # Create task instance

--- a/sieval/cli/leaderboard/session.py
+++ b/sieval/cli/leaderboard/session.py
@@ -14,6 +14,7 @@ import shlex
 import sys
 from collections.abc import Callable, Mapping
 from datetime import UTC, datetime
+from enum import StrEnum
 from pathlib import Path
 from types import MappingProxyType
 from typing import Any, Literal, TypedDict, cast
@@ -76,7 +77,11 @@ from sieval.core.models.deployment import (
     RouteIntent,
     ServingFacts,
 )
-from sieval.core.models.dialect_registry import dialect_is_bindable, get_dialect_spec
+from sieval.core.models.dialect_registry import (
+    RequestSeedSupport,
+    dialect_is_bindable,
+    get_dialect_spec,
+)
 from sieval.core.models.reconcile import (
     BindingReconcileInput,
     CannotVerify,
@@ -129,6 +134,153 @@ _PR1_REQUEST_VERIFIERS = {
     "sampled_logprobs": "validate_response_channel",
     "top_logprobs": "validate_response_channel",
 }
+
+_DETERMINISTIC_SEED_CONTRACT_KEY = "_sieval_deterministic_seed_contract"
+
+
+class _RequestSeedScope(StrEnum):
+    """Where deterministic sampling is controlled for one binding."""
+
+    PER_REQUEST = "per_request"
+    ENGINE_LEVEL_ONLY = "engine_level_only"
+
+
+class _RequestSeedProvenance(StrEnum):
+    """Frozen source of one model default for ``sampling.seed``."""
+
+    NONE = "none"
+    AUTOMATIC = "automatic"
+    BINDING_CONFIG = "binding_config"
+    EXTERNAL_MODEL = "external_model"
+    TASK_INFER_ARGS = "task_infer_args"
+
+
+@dataclasses.dataclass(frozen=True)
+class _RequestSeedDecision:
+    """One frozen deterministic request-seed policy decision."""
+
+    dialect_id: str
+    support: RequestSeedSupport
+    scope: _RequestSeedScope
+    seed_present: bool
+    seed: int | None
+    provenance: _RequestSeedProvenance
+    remove_inherited_seed: bool
+
+    @property
+    def explicit_seed_present(self) -> bool:
+        return self.provenance in {
+            _RequestSeedProvenance.BINDING_CONFIG,
+            _RequestSeedProvenance.EXTERNAL_MODEL,
+            _RequestSeedProvenance.TASK_INFER_ARGS,
+        }
+
+
+def _resolve_deterministic_request_seed(
+    *,
+    dialect_id: str,
+    explicit_seed_present: bool,
+    explicit_seed: int | None = None,
+    explicit_provenance: _RequestSeedProvenance = (
+        _RequestSeedProvenance.BINDING_CONFIG
+    ),
+) -> _RequestSeedDecision:
+    """Resolve one immutable decision for execution and persistence."""
+
+    if dialect_id == "sglang_legacy":
+        # TODO(PR-5): delete this compatibility policy when the legacy SGLang
+        # path becomes a registered ``sglang_native`` DialectSpec/binder.
+        support = RequestSeedSupport.UNSUPPORTED
+        scope = _RequestSeedScope.ENGINE_LEVEL_ONLY
+    else:
+        support = get_dialect_spec(dialect_id).request_seed_support
+        scope = _RequestSeedScope.PER_REQUEST
+
+    if support is RequestSeedSupport.RESERVED:
+        raise ValueError(
+            f"dialect {dialect_id!r} has not declared whether it supports "
+            "per-request deterministic seeds"
+        )
+    if explicit_seed_present:
+        return _RequestSeedDecision(
+            dialect_id=dialect_id,
+            support=support,
+            scope=scope,
+            seed_present=True,
+            seed=explicit_seed,
+            provenance=explicit_provenance,
+            remove_inherited_seed=False,
+        )
+    if support is RequestSeedSupport.SUPPORTED:
+        return _RequestSeedDecision(
+            dialect_id=dialect_id,
+            support=support,
+            scope=scope,
+            seed_present=True,
+            seed=DETERMINISTIC_DEFAULT_SEED,
+            provenance=_RequestSeedProvenance.AUTOMATIC,
+            remove_inherited_seed=False,
+        )
+    return _RequestSeedDecision(
+        dialect_id=dialect_id,
+        support=support,
+        scope=scope,
+        seed_present=False,
+        seed=None,
+        provenance=_RequestSeedProvenance.NONE,
+        # The legacy path is deterministic at engine scope and never inherits
+        # an orchestration-injected request default.  Ordinary unsupported
+        # dialects must remove one inherited from a supporting parent binding.
+        remove_inherited_seed=scope is _RequestSeedScope.PER_REQUEST,
+    )
+
+
+def _with_task_infer_seed(
+    decision: _RequestSeedDecision,
+    infer_args: Mapping[str, JSONValue],
+) -> _RequestSeedDecision:
+    """Overlay a task candidate's frozen ``infer_args.seed`` when present."""
+
+    if "seed" not in infer_args:
+        return decision
+    seed = infer_args["seed"]
+    if seed is not None and (isinstance(seed, bool) or not isinstance(seed, int)):
+        raise TypeError("seed must be an integer")
+    return dataclasses.replace(
+        decision,
+        seed_present=True,
+        seed=seed,
+        provenance=_RequestSeedProvenance.TASK_INFER_ARGS,
+        remove_inherited_seed=False,
+    )
+
+
+def _apply_request_seed_decision_to_args(
+    args: dict[str, Any], decision: _RequestSeedDecision
+) -> None:
+    """Make an argument mapping match a previously frozen seed decision."""
+
+    args.pop("seed", None)
+    if decision.seed_present:
+        args["seed"] = decision.seed
+
+
+def _apply_request_seed_decision_to_model(
+    model: Model, decision: _RequestSeedDecision
+) -> Model:
+    """Make a bound model's defaults match a previously frozen decision."""
+
+    if model.dialect_id != decision.dialect_id:
+        raise RuntimeError(
+            "frozen request-seed decision targets dialect "
+            f"{decision.dialect_id!r}, but the bound model uses "
+            f"{model.dialect_id!r}"
+        )
+    if "seed" in model._kwargs:
+        model = model.without_args("seed")
+    if decision.seed_present:
+        model = model.with_args(seed=decision.seed)
+    return model
 
 
 def _model_value_paths(value: object) -> tuple[str, ...]:
@@ -403,6 +555,7 @@ class AlignmentBlockDict(TypedDict):
 
 
 class RootConfigDict(TypedDict, total=False):
+    _sieval_deterministic_seed_contract: dict[str, JSONValue]
     deterministic: bool
     result_dir: str
     concurrency_limit: int
@@ -794,8 +947,8 @@ def _reify_cli_overrides(
 
     Mirrors EvalSession's runtime override behavior so that `sieval eval
     <persisted_effective_config>` with NO CLI args reproduces the session:
-        --deterministic → root `deterministic: true` + setdefault(seed=0) on
-                          each base model's `args`
+        --deterministic → root `deterministic: true`; automatic request seeds
+                          are resolved per binding after dialect reconciliation
         --model X       → overwrite `name: X` on every base model
         --result-dir D  → root `result_dir: D`
     Per-op seeds (dataset `shuffle.seed`, task `args.seed`) are not
@@ -803,14 +956,6 @@ def _reify_cli_overrides(
     """
     if deterministic:
         cfg["deterministic"] = True
-        models = cfg.get("models") or {}
-        if isinstance(models, dict):
-            for mcfg in models.values():
-                if not isinstance(mcfg, dict) or "base" in mcfg:
-                    continue
-                args = mcfg.setdefault("args", {})
-                if isinstance(args, dict):
-                    args.setdefault("seed", DETERMINISTIC_DEFAULT_SEED)
 
     if model is not None:
         models = cfg.get("models") or {}
@@ -957,14 +1102,20 @@ def _warn_best_effort_deterministic(
         and name not in self_managed_endpoints
     )
     if external:
-        logger.warning(
-            "Deterministic mode is best-effort for model(s) {} — "
-            "sieval applies request-level seeds where the protocol supports "
-            "them, but cannot verify the remote process seed or batch-invariant "
-            "kernels. For guaranteed reproducibility, self-host via `sieval run` / "
-            "`sieval infer start` with a local checkpoint.",
-            external,
-        )
+        _emit_best_effort_deterministic_warning(external)
+
+
+def _emit_best_effort_deterministic_warning(labels: list[str]) -> None:
+    """Emit the shared warning for externally managed model bindings."""
+
+    logger.warning(
+        "Deterministic mode is best-effort for model binding(s) {} — "
+        "sieval applies request-level seeds where the protocol supports them, "
+        "but cannot verify the remote process seed or batch-invariant kernels. "
+        "For guaranteed reproducibility, self-host via `sieval run` / "
+        "`sieval infer start` with a local checkpoint.",
+        labels,
+    )
 
 
 class EvalSession:
@@ -1173,10 +1324,21 @@ class EvalSession:
         self._owned_pools: dict[str, ConnectionPool[Any]] = {}
         self._root_shared_limiters: dict[str, anyio.CapacityLimiter | None] = {}
         self._owned_legacy_models: dict[str, SglangGenModel] = {}
+        self._warned_best_effort_role_bindings: set[str] = set()
         # Runtime-only sources for the post-launch ``models_by_role`` binding
         # seam.  They are never serialized or fingerprinted by reconciliation.
         self._task_role_model_sources: dict[str, dict[str, object]] = {}
         self._bound_task_role_models: dict[str, dict[str, Model]] = {}
+        # Runtime-only deterministic request-default decisions.  Prelaunch
+        # freezes these from normalized bindings, exact external role sources,
+        # and RequirementContext.infer_args.  Only their JSON projection enters
+        # effective_config; the caches themselves are never fingerprinted.
+        self._request_seed_decisions_by_binding: dict[str, _RequestSeedDecision] = {}
+        self._request_seed_decisions_by_external_role: dict[
+            str, _RequestSeedDecision
+        ] = {}
+        self._request_seed_decisions_by_candidate: dict[str, _RequestSeedDecision] = {}
+        self._request_seed_decisions_frozen = False
 
         # Resolved lazily in `_init_runner` at the start of `_prepare_execution`.
         self.result_dir: str | None = None
@@ -2171,6 +2333,12 @@ class EvalSession:
     def _setup_prelaunch_reconciliation(self) -> None:
         """Resolve and reconcile every task/model binding before client creation."""
 
+        self._request_seed_decisions_frozen = False
+        self._request_seed_decisions_by_binding = {}
+        self._request_seed_decisions_by_external_role = {}
+        self._request_seed_decisions_by_candidate = {}
+        self.prelaunch_reconcile_result = None
+        self.postlaunch_reconcile_result = None
         models_cfg = self._get_named_config_map("models")
         tasks_cfg = self._get_named_config_map("tasks")
 
@@ -2353,7 +2521,33 @@ class EvalSession:
         self._legacy_bypass_bindings = frozenset(legacy_bypass)
         self._prelaunch_binding_inputs = tuple(binding_inputs)
         self._prelaunch_deployment_inputs = dict(deployment_inputs)
+        self._freeze_deterministic_request_seed_decisions()
         self.prelaunch_reconcile_result = result
+        self._warn_best_effort_deterministic_roles()
+
+    def _warn_best_effort_deterministic_roles(self) -> None:
+        """Warn for inline or borrowed role models outside managed topology."""
+
+        if not self.deterministic:
+            return
+        warned = self._warned_best_effort_role_bindings
+        labels_by_binding: dict[str, list[str]] = {}
+        for task_name, context in self._task_requirement_contexts.items():
+            for role, binding in context.model_bindings.items():
+                if not isinstance(binding, InlineModelBinding | ExternalModelBinding):
+                    continue
+                if binding.binding_id in warned:
+                    continue
+                labels_by_binding.setdefault(binding.binding_id, []).append(
+                    f"{task_name}.{role}"
+                )
+        if not labels_by_binding:
+            return
+        warned.update(labels_by_binding)
+        labels = sorted(
+            label for values in labels_by_binding.values() for label in values
+        )
+        _emit_best_effort_deterministic_warning(labels)
 
     def prepare_prelaunch(self) -> ReconcileResult:
         """Public pure setup seam for launch-before-I/O capability validation."""
@@ -2363,6 +2557,204 @@ class EvalSession:
         if result is None:  # defensive: the setup method assigns on success
             raise RuntimeError("pre-launch reconciliation produced no result")
         return result
+
+    @staticmethod
+    def _seed_from_mapping(
+        values: Mapping[str, object],
+    ) -> tuple[bool, int | None]:
+        if "seed" not in values:
+            return False, None
+        value = values["seed"]
+        if value is not None and (
+            isinstance(value, bool) or not isinstance(value, int)
+        ):
+            raise TypeError("seed must be an integer")
+        return True, value
+
+    def _freeze_deterministic_request_seed_decisions(self) -> None:
+        """Freeze every model request-default seed decision after prelaunch."""
+
+        if not self.deterministic:
+            self._request_seed_decisions_by_binding = {}
+            self._request_seed_decisions_by_external_role = {}
+            self._request_seed_decisions_by_candidate = {}
+            self._request_seed_decisions_frozen = True
+            return
+
+        models_cfg = self._get_named_config_map("models")
+        by_binding: dict[str, _RequestSeedDecision] = {}
+        for binding in self._normalized_model_bindings.values():
+            if isinstance(binding, ExternalModelBinding):
+                continue
+            dialect_id = binding.dialect_id
+            if dialect_id is None:
+                raise ValueError(f"Model binding '{binding.binding_id}' has no dialect")
+            if isinstance(binding, NamedModelBinding):
+                explicit_seed_present = False
+                explicit_seed: int | None = None
+                for _, config in self._model_config_chain(
+                    binding.config_name, models_cfg
+                ):
+                    raw_args = config.get("args")
+                    if raw_args is None:
+                        continue
+                    if not isinstance(raw_args, Mapping):
+                        raise ValueError(
+                            f"Model '{binding.config_name}' args must be a dictionary"
+                        )
+                    present, value = self._seed_from_mapping(raw_args)
+                    if present:
+                        explicit_seed_present = True
+                        explicit_seed = value
+            else:
+                explicit_seed_present, explicit_seed = self._seed_from_mapping(
+                    binding.config
+                )
+                raw_args = binding.config.get("args")
+                if raw_args is not None:
+                    if not isinstance(raw_args, Mapping):
+                        raise ValueError(
+                            f"Inline binding '{binding.binding_id}' args must be "
+                            "a mapping"
+                        )
+                    nested_present, nested_seed = self._seed_from_mapping(raw_args)
+                    if nested_present:
+                        explicit_seed_present = True
+                        explicit_seed = nested_seed
+            by_binding[binding.binding_id] = _resolve_deterministic_request_seed(
+                dialect_id=dialect_id,
+                explicit_seed_present=explicit_seed_present,
+                explicit_seed=explicit_seed,
+            )
+
+        by_external_role: dict[str, _RequestSeedDecision] = {}
+        by_candidate: dict[str, _RequestSeedDecision] = {}
+        for task_name, context in sorted(self._task_requirement_contexts.items()):
+            sources = self._task_role_model_sources.get(task_name, {})
+            for role, binding in sorted(context.model_bindings.items()):
+                if isinstance(binding, ExternalModelBinding):
+                    source = sources.get(role)
+                    if not isinstance(source, Model):
+                        raise ValueError(
+                            f"External binding '{binding.binding_id}' lost its "
+                            "Model source"
+                        )
+                    dialect_id = binding.dialect_id
+                    if dialect_id is None:
+                        raise ValueError(
+                            f"External binding '{binding.binding_id}' has no dialect"
+                        )
+                    present, value = self._seed_from_mapping(
+                        source.meta()["default_params"]
+                    )
+                    decision = _resolve_deterministic_request_seed(
+                        dialect_id=dialect_id,
+                        explicit_seed_present=present,
+                        explicit_seed=value,
+                        explicit_provenance=_RequestSeedProvenance.EXTERNAL_MODEL,
+                    )
+                    by_external_role[f"{task_name}.{role}"] = decision
+
+            candidate = context.model_bindings.get("candidate")
+            if candidate is None:
+                raise ValueError(f"Task '{task_name}' has no candidate binding")
+            if isinstance(candidate, ExternalModelBinding):
+                raise ValueError(
+                    f"Task '{task_name}' candidate must be a named or inline binding"
+                )
+            by_candidate[task_name] = _with_task_infer_seed(
+                by_binding[candidate.binding_id], context.infer_args
+            )
+
+        self._request_seed_decisions_by_binding = by_binding
+        self._request_seed_decisions_by_external_role = by_external_role
+        self._request_seed_decisions_by_candidate = by_candidate
+        self._request_seed_decisions_frozen = True
+
+    @staticmethod
+    def _request_seed_contract_entry(
+        decision: _RequestSeedDecision,
+        binding: NormalizedModelBinding,
+    ) -> dict[str, JSONValue]:
+        entry: dict[str, JSONValue] = {
+            "binding_id": binding.binding_id,
+            "requested_model_id": binding.requested_model_id,
+            "dialect_id": decision.dialect_id,
+            "request_seed_support": decision.support.value,
+            "seed_scope": decision.scope.value,
+            "seed_present": decision.seed_present,
+            "seed": decision.seed,
+            "seed_provenance": decision.provenance.value,
+            "explicit_seed_present": decision.explicit_seed_present,
+            "remove_inherited_seed": decision.remove_inherited_seed,
+        }
+        if isinstance(binding, ExternalModelBinding):
+            entry["runtime_plan_fingerprint"] = binding.runtime_plan_fingerprint
+        return entry
+
+    def _deterministic_seed_contract(self) -> dict[str, JSONValue]:
+        """Return strict evidence for frozen model request-default seeds."""
+
+        if not self._request_seed_decisions_frozen:
+            raise RuntimeError(
+                "deterministic request-seed decisions must be frozen by "
+                "pre-launch reconciliation before stamping the contract"
+            )
+        bindings = self._normalized_model_bindings
+        return {
+            "bindings": {
+                key: self._request_seed_contract_entry(decision, bindings[key])
+                for key, decision in sorted(
+                    self._request_seed_decisions_by_binding.items()
+                )
+            },
+            "external_roles": {
+                key: self._request_seed_contract_entry(
+                    decision,
+                    self._task_requirement_contexts[
+                        key.rsplit(".", 1)[0]
+                    ].model_bindings[key.rsplit(".", 1)[1]],
+                )
+                for key, decision in sorted(
+                    self._request_seed_decisions_by_external_role.items()
+                )
+            },
+            "candidates": {
+                task_name: self._request_seed_contract_entry(
+                    decision,
+                    self._task_requirement_contexts[task_name].model_bindings[
+                        "candidate"
+                    ],
+                )
+                for task_name, decision in sorted(
+                    self._request_seed_decisions_by_candidate.items()
+                )
+            },
+        }
+
+    def _stamp_deterministic_seed_contract(self) -> None:
+        """Put the current resolved seed contract in the strict persisted config."""
+
+        if not self.deterministic:
+            if _DETERMINISTIC_SEED_CONTRACT_KEY in self._raw_config:
+                raise RuntimeError(
+                    "persisted deterministic-seed contract cannot be replayed "
+                    "with deterministic mode disabled"
+                )
+            self._reified_config.pop(_DETERMINISTIC_SEED_CONTRACT_KEY, None)
+            return
+        resolved = self._deterministic_seed_contract()
+        raw_config = cast(Mapping[str, object], self._raw_config)
+        if (
+            _DETERMINISTIC_SEED_CONTRACT_KEY in raw_config
+            and raw_config[_DETERMINISTIC_SEED_CONTRACT_KEY] != resolved
+        ):
+            raise RuntimeError(
+                "persisted deterministic-seed contract no longer matches the "
+                "resolved dialect seed policy; use the same sieval version and "
+                "dialect declarations, or start from the original source config"
+            )
+        self._reified_config[_DETERMINISTIC_SEED_CONTRACT_KEY] = resolved
 
     def _source_for_binding(self, binding_id: str) -> object | None:
         """Return the runtime-only config/model source for a role binding."""
@@ -2730,6 +3122,11 @@ class EvalSession:
         result = self.postlaunch_reconcile_result
         if result is None:
             raise RuntimeError("bound model setup requires post-launch reconciliation")
+        if self.deterministic and not self._request_seed_decisions_frozen:
+            raise RuntimeError(
+                "deterministic request-seed decisions were not frozen before "
+                "model binding"
+            )
         models_cfg = self._get_named_config_map("models")
 
         by_root: dict[str, list[NormalizedModelBinding]] = {}
@@ -2767,15 +3164,18 @@ class EvalSession:
             cfg = chain[0][1]
             args = self._normalize_dict(cfg.get("args"), f"Model '{name}' args")
             if self.deterministic:
-                args.setdefault("seed", DETERMINISTIC_DEFAULT_SEED)
+                _apply_request_seed_decision_to_args(
+                    args,
+                    self._request_seed_decisions_by_binding[binding.binding_id],
+                )
             if "api_key" in cfg:
                 args["api_key"] = cfg["api_key"]
             if "api_base" in cfg:
                 args["api_base"] = cfg["api_base"]
-            model = SglangGenModel(model=binding.requested_model_id, **args)
-            self.models[name] = model
-            bound_by_binding[binding.binding_id] = model
-            self._owned_legacy_models[binding.root_deployment_key] = model
+            legacy_model = SglangGenModel(model=binding.requested_model_id, **args)
+            self.models[name] = legacy_model
+            bound_by_binding[binding.binding_id] = legacy_model
+            self._owned_legacy_models[binding.root_deployment_key] = legacy_model
             del pending_named[name]
 
         while pending_named:
@@ -2791,6 +3191,8 @@ class EvalSession:
                     assert isinstance(base_name, str)
                     model = self.models[base_name]
                     args = self._normalize_dict(cfg.get("args"), f"Model '{name}' args")
+                    if self.deterministic:
+                        args.pop("seed", None)
                     concurrency_limit = args.pop("concurrency_limit", None)
                     model = model.with_args(concurrency_limit=concurrency_limit, **args)
                 else:
@@ -2798,7 +3200,8 @@ class EvalSession:
                     deployment = self._realized_deployments_by_root[
                         binding.root_deployment_key
                     ]
-                    root_config = self._model_config_chain(name, models_cfg)[0][1]
+                    chain = self._model_config_chain(name, models_cfg)
+                    root_config = chain[0][1]
                     pool = self._create_owned_pool(
                         binding.root_deployment_key,
                         deployment,
@@ -2837,8 +3240,8 @@ class EvalSession:
                                 )
 
                     args, extra = self._request_builder_args(cfg)
-                    if is_root and self.deterministic:
-                        args.setdefault("seed", DETERMINISTIC_DEFAULT_SEED)
+                    if self.deterministic:
+                        args.pop("seed", None)
                     concurrency_limit = None
                     if not is_root:
                         raw_args = cfg.get("args", {})
@@ -2852,6 +3255,12 @@ class EvalSession:
                         )
                     model = self._as_legacy_wrapper(
                         model, self._aggregated_requirements[binding.binding_id]
+                    )
+
+                if self.deterministic:
+                    model = _apply_request_seed_decision_to_model(
+                        model,
+                        self._request_seed_decisions_by_binding[binding.binding_id],
                     )
 
                 self.models[name] = model
@@ -2899,9 +3308,16 @@ class EvalSession:
             ):
                 direct_config.pop(key, None)
             extra = direct_config.pop("extra", None)
+            if self.deterministic:
+                direct_config.pop("seed", None)
             if direct_config or extra is not None:
                 model = model.with_args(
                     extra=cast(dict[str, JSONValue] | None, extra), **direct_config
+                )
+            if self.deterministic:
+                model = _apply_request_seed_decision_to_model(
+                    model,
+                    self._request_seed_decisions_by_binding[binding.binding_id],
                 )
             bound_by_binding[binding.binding_id] = self._as_legacy_wrapper(
                 model, self._aggregated_requirements[binding.binding_id]
@@ -2922,6 +3338,13 @@ class EvalSession:
                     rebound = live_model.with_dialect(
                         runtime_plan.dialect_id, runtime_plan
                     )
+                    if self.deterministic:
+                        rebound = _apply_request_seed_decision_to_model(
+                            rebound,
+                            self._request_seed_decisions_by_external_role[
+                                f"{task_name}.{role}"
+                            ],
+                        )
                     role_model = self._as_legacy_wrapper(
                         rebound, self._aggregated_requirements[binding.binding_id]
                     )
@@ -3311,6 +3734,10 @@ class EvalSession:
 
     def _setup_tasks(self) -> None:
         """Initialize all tasks from config."""
+        if self.deterministic and not self._request_seed_decisions_frozen:
+            raise RuntimeError(
+                "deterministic request-seed decisions were not frozen before task setup"
+            )
         tasks_cfg = self._get_named_config_map("tasks")
         runner_defaults_raw = self.config.get("runner_config", {})
         if not isinstance(runner_defaults_raw, dict):
@@ -3339,20 +3766,46 @@ class EvalSession:
             # Resolve dataset
             dataset = self._resolve_task_dataset(task_cfg, task_name)
 
-            # Resolve model
-            model = self._resolve_task_model(task_cfg, task_name)
+            # RequirementContext is the prelaunch-frozen source for both the
+            # candidate identity and every task-local inference default. Never
+            # resolve ``task_cfg["model"]`` from mutable config a second time:
+            # capability reconciliation and the deterministic seed contract
+            # were both derived from this exact binding.
+            try:
+                context = self._task_requirement_contexts[task_name]
+            except KeyError as exc:
+                raise RuntimeError(
+                    f"Task '{task_name}' has no frozen requirement context"
+                ) from exc
+            candidate = context.model_bindings.get("candidate")
+            if not isinstance(candidate, NamedModelBinding):
+                raise RuntimeError(
+                    f"Task '{task_name}' has no frozen named candidate binding"
+                )
+            try:
+                model = self.models[candidate.config_name]
+            except KeyError as exc:
+                raise RuntimeError(
+                    f"Task '{task_name}' frozen candidate model "
+                    f"'{candidate.config_name}' was not bound"
+                ) from exc
 
-            # Apply infer_args override (per-task inference parameter override)
-            infer_args = self._normalize_dict(
-                task_cfg.get("infer_args"),
-                f"Task '{task_name}' infer_args",
-            )
+            frozen_infer_args = dict(context.infer_args)
+            infer_args = dict(frozen_infer_args)
+            if self.deterministic:
+                infer_args.pop("seed", None)
             if infer_args:
-                model = model.with_args(**infer_args)
+                model = model.with_args(**cast(dict[str, Any], infer_args))
+            if self.deterministic:
+                model = _apply_request_seed_decision_to_model(
+                    model,
+                    self._request_seed_decisions_by_candidate[task_name],
+                )
+            if frozen_infer_args:
                 logger.info(
                     "Task '{}': applied infer_args override {}",
                     task_name,
-                    infer_args,
+                    frozen_infer_args,
                 )
 
             # Create task instance
@@ -3483,7 +3936,8 @@ class EvalSession:
         # Resolve task-side requirements and fail before any model/client is
         # constructed.  This is pure setup work; managed runs re-run the same
         # reconciliation after launch with realized Deployment/ServingFacts.
-        await run_sync(self.prepare_prelaunch)
+        if self.prelaunch_reconcile_result is None:
+            await run_sync(self.prepare_prelaunch)
         await run_sync(self._setup_postlaunch_reconciliation)
 
         # Wrap in to_thread: dataset download / heavy model init can block the
@@ -3643,11 +4097,12 @@ class EvalSession:
     async def _persist_effective_config(self) -> None:
         """Write effective_config.yaml to result_dir at session start.
 
-        Dumps ``self._reified_config`` (raw YAML + CLI reification, minus
-        legacy endpoint-adapter injection). User-supplied ``api_base`` /
-        ``api_key`` in the source YAML ARE preserved. Runtime endpoints are
-        excluded, so ``sieval run <this file>`` can re-launch services from
-        the preserved ``path`` / ``infer`` fields.
+        Dumps ``self._reified_config`` (raw YAML + CLI reification + the
+        resolved deterministic-seed contract, minus legacy endpoint-adapter
+        injection). User-supplied ``api_base`` / ``api_key`` in the source
+        YAML ARE preserved. Runtime endpoints are excluded, so ``sieval run
+        <this file>`` can re-launch services from the preserved ``path`` /
+        ``infer`` fields.
         """
         body = yaml.safe_dump(
             self._reified_config,
@@ -3724,9 +4179,12 @@ class EvalSession:
     async def arun(self) -> dict[str, Any]:
         """Run all configured tasks asynchronously."""
         try:
-            # Persist BEFORE _prepare_execution so a resume-mismatch abort
-            # fails fast — avoid paying the model/dataset load cost just to
-            # discover the config doesn't match the persisted one.
+            # Pure prelaunch resolution stamps the binding-local seed contract
+            # into effective_config before the strict resume comparison. No
+            # model client, dataset, or serving I/O has happened at this point;
+            # pure config/requirement errors may therefore surface first.
+            await run_sync(self.prepare_prelaunch)
+            self._stamp_deterministic_seed_contract()
             await self._persist_effective_config()
             await self._persist_infer_plans()
             await self._prepare_execution()

--- a/sieval/core/models/__init__.py
+++ b/sieval/core/models/__init__.py
@@ -37,7 +37,12 @@ from .deployment import (
     ServingFacts,
 )
 from .dialect import Dialect, DialectError
-from .dialect_registry import DialectSpec, bind_dialect, get_dialect_spec
+from .dialect_registry import (
+    DialectSpec,
+    RequestSeedSupport,
+    bind_dialect,
+    get_dialect_spec,
+)
 from .exceptions import CapabilityError
 from .gen_model import GenModel
 from .ir import (
@@ -152,6 +157,7 @@ __all__ = [
     "ReconcileResult",
     "Request",
     "RequestDefaults",
+    "RequestSeedSupport",
     "ResolvedRoute",
     "Response",
     "RouteIntent",

--- a/sieval/core/models/dialect_registry.py
+++ b/sieval/core/models/dialect_registry.py
@@ -88,6 +88,14 @@ class DialectImplementationStatus(StrEnum):
     RESERVED = "reserved"
 
 
+class RequestSeedSupport(StrEnum):
+    """Whether one dialect can transmit a per-request sampling seed."""
+
+    SUPPORTED = "supported"
+    UNSUPPORTED = "unsupported"
+    RESERVED = "reserved"
+
+
 @dataclass(frozen=True)
 class DialectSpec:
     """Serializable descriptor for one stable provider wire dialect."""
@@ -96,6 +104,7 @@ class DialectSpec:
     connection_family: str
     implementation_status: DialectImplementationStatus
     capability_outcomes: Mapping[CapabilityKey, DialectCapabilityStatus]
+    request_seed_support: RequestSeedSupport
     input_kinds: tuple[str, ...]
     input_modalities: tuple[str, ...]
 
@@ -108,6 +117,8 @@ class DialectSpec:
             raise TypeError(
                 "implementation_status must be a DialectImplementationStatus"
             )
+        if not isinstance(self.request_seed_support, RequestSeedSupport):
+            raise TypeError("request_seed_support must be a RequestSeedSupport")
         outcomes = normalize_dialect_capability_outcomes(
             cast(
                 Mapping[str, DialectCapabilityStatus | str],
@@ -119,6 +130,11 @@ class DialectSpec:
             and DialectCapabilityStatus.RESERVED in outcomes.values()
         ):
             raise ValueError("an active dialect cannot reserve a capability outcome")
+        if (
+            self.implementation_status is DialectImplementationStatus.ACTIVE
+            and self.request_seed_support is RequestSeedSupport.RESERVED
+        ):
+            raise ValueError("an active dialect cannot reserve request-seed support")
         object.__setattr__(
             self,
             "capability_outcomes",
@@ -142,6 +158,7 @@ class DialectSpec:
             "dialect_id": self.dialect_id,
             "connection_family": self.connection_family,
             "implementation_status": self.implementation_status.value,
+            "request_seed_support": self.request_seed_support.value,
             "capability_outcomes": {
                 key: self.capability_outcomes[key].value for key in CAPABILITY_KEYS
             },
@@ -261,6 +278,7 @@ def _spec(
     connection_family: str,
     *,
     decisions: Mapping[str, DialectCapabilityDecision] | None = None,
+    request_seed_support: RequestSeedSupport,
     input_kinds: tuple[str, ...],
     input_modalities: tuple[str, ...],
 ) -> DialectSpec:
@@ -279,6 +297,7 @@ def _spec(
         connection_family=connection_family,
         implementation_status=status,
         capability_outcomes=outcomes,
+        request_seed_support=request_seed_support,
         input_kinds=input_kinds,
         input_modalities=input_modalities,
     )
@@ -336,6 +355,7 @@ DIALECT_SPECS: Mapping[str, DialectSpec] = MappingProxyType(
             "openai_chat",
             "openai_sdk",
             decisions=_registered_decisions("openai_chat"),
+            request_seed_support=RequestSeedSupport.SUPPORTED,
             input_kinds=("chat",),
             input_modalities=("text", "image", "tool_call", "tool_result"),
         ),
@@ -343,36 +363,42 @@ DIALECT_SPECS: Mapping[str, DialectSpec] = MappingProxyType(
             "openai_completions",
             "openai_sdk",
             decisions=_registered_decisions("openai_completions"),
+            request_seed_support=RequestSeedSupport.SUPPORTED,
             input_kinds=("completion",),
             input_modalities=("text",),
         ),
         "openai_responses": _spec(
             "openai_responses",
             "openai_sdk",
+            request_seed_support=RequestSeedSupport.RESERVED,
             input_kinds=("chat",),
             input_modalities=("text", "image", "tool_call", "tool_result"),
         ),
         "anthropic_messages": _spec(
             "anthropic_messages",
             "async_http_json",
+            request_seed_support=RequestSeedSupport.RESERVED,
             input_kinds=("chat",),
             input_modalities=("text", "image", "tool_call", "tool_result"),
         ),
         "google_genai": _spec(
             "google_genai",
             "async_http_json",
+            request_seed_support=RequestSeedSupport.RESERVED,
             input_kinds=("chat",),
             input_modalities=("text", "image", "tool_call", "tool_result"),
         ),
         "sglang_native": _spec(
             "sglang_native",
             "async_http_json",
+            request_seed_support=RequestSeedSupport.RESERVED,
             input_kinds=("completion",),
             input_modalities=("text",),
         ),
         "vllm_native": _spec(
             "vllm_native",
             "async_http_json",
+            request_seed_support=RequestSeedSupport.RESERVED,
             input_kinds=("completion",),
             input_modalities=("text",),
         ),

--- a/sieval/core/models/model.py
+++ b/sieval/core/models/model.py
@@ -313,6 +313,28 @@ class Model:
             )
         return new_model
 
+    def without_args(self, *names: str) -> Self:
+        """Derive a model with selected builder defaults removed.
+
+        This is intentionally distinct from ``with_args(name=None)``: ``None``
+        is a user-visible explicit default that belongs in model metadata,
+        whereas removing an inherited orchestration default must leave no
+        request leaf and no persisted ``default_params`` entry.
+        """
+
+        if not names or any(not isinstance(name, str) or not name for name in names):
+            raise ValueError("without_args requires non-empty argument names")
+        reserved = sorted(BINDING_RESOURCE_KEYS & set(names))
+        if reserved:
+            raise ValueError(
+                "without_args cannot change binding resources: " + ", ".join(reserved)
+            )
+        new_model = copy.copy(self)
+        new_model._kwargs = {
+            key: value for key, value in self._kwargs.items() if key not in names
+        }
+        return new_model
+
     def with_dialect(
         self,
         dialect_id: str,

--- a/tests/unit/cli/leaderboard/test_session.py
+++ b/tests/unit/cli/leaderboard/test_session.py
@@ -20,6 +20,7 @@ import yaml
 
 from sieval.cli._filter_spec import VALUES_DIGEST_KEY, compute_values_digest
 from sieval.cli.leaderboard.session import (
+    _DETERMINISTIC_SEED_CONTRACT_KEY,
     _NONMATCH_RUNNER_KEYS,
     _STRICT_RUNNER_KEYS,
     _THROUGHPUT_RUNNER_KEYS,
@@ -35,6 +36,7 @@ from sieval.cli.leaderboard.session import (
     _diff_lines,
     _format_comment_header,
     _reify_cli_overrides,
+    _resolve_deterministic_request_seed,
     _sort_versions,
     _split_header,
     _strip_header,
@@ -47,6 +49,7 @@ from sieval.cli.leaderboard.session import (
 from sieval.cli.resolution import derive_model_type
 from sieval.cli.validation import _VALID_OPERATIONS
 from sieval.core.models.connection_factory import DEFAULT_REQUEST_TIMEOUT
+from sieval.core.models.dialect_registry import RequestSeedSupport
 from sieval.core.models.model import Model
 from sieval.core.models.reconcile import CheckStage, Configured, DeferredCheck
 from sieval.core.models.requirements import (
@@ -54,6 +57,7 @@ from sieval.core.models.requirements import (
     InlineModelBinding,
     InputKind,
     NamedModelBinding,
+    RequirementContext,
     TaskModelRequirement,
     TaskRequirements,
 )
@@ -76,6 +80,31 @@ def _write_yaml_config(tmp_path: Path, filename: str, content: str) -> Path:
     return path
 
 
+def _task_requirement_context_for_setup_test(
+    task_cfg: object,
+    models: dict[str, Model],
+) -> RequirementContext:
+    """Build the frozen candidate seam expected by direct ``_setup_tasks`` tests."""
+
+    if not isinstance(task_cfg, dict):
+        return RequirementContext()
+    infer_args = task_cfg.get("infer_args", {})
+    if not isinstance(infer_args, dict):
+        infer_args = {}
+    model_name = task_cfg.get("model")
+    if not model_name and len(models) == 1:
+        model_name = next(iter(models))
+    bindings = {}
+    if isinstance(model_name, str) and model_name:
+        bindings["candidate"] = NamedModelBinding(
+            binding_id=f"model:{model_name}",
+            root_deployment_key=f"model:{model_name}",
+            requested_model_id=model_name,
+            config_name=model_name,
+        )
+    return RequirementContext(model_bindings=bindings, infer_args=infer_args)
+
+
 def _prepare_eval_session(
     config_path: Path,
     *,
@@ -85,6 +114,14 @@ def _prepare_eval_session(
     runner = EvalSession(config_path=str(config_path), resume=resume)
     if models is not None:
         runner.models = models
+    tasks_cfg = runner._get_named_config_map("tasks")
+    runner._task_requirement_contexts = {
+        task_name: _task_requirement_context_for_setup_test(
+            task_cfg,
+            runner.models,
+        )
+        for task_name, task_cfg in tasks_cfg.items()
+    }
     runner._init_runner()
     runner._setup_datasets()
     runner._setup_tasks()
@@ -1084,6 +1121,7 @@ class TestEvalSessionArun:
     async def test_arun_full_chain(self, tmp_path):
         """EvalSession.arun() should load config, set up all components, and run."""
         yaml_content = """\
+deterministic: true
 result_dir: "{result_dir}"
 
 models:
@@ -1122,6 +1160,16 @@ tasks:
 
         assert "chain_eval" in results
         assert results["chain_eval"]["total"] == 3
+        persisted = yaml.safe_load(
+            (tmp_path / "arun_results" / "effective_config.yaml").read_text()
+        )
+        contract = persisted[_DETERMINISTIC_SEED_CONTRACT_KEY]
+        assert set(contract) == {"bindings", "external_roles", "candidates"}
+        binding = contract["bindings"]["model:mock_model"]
+        assert binding["dialect_id"] == "openai_chat"
+        assert binding["request_seed_support"] == "supported"
+        assert binding["seed"] == DETERMINISTIC_DEFAULT_SEED
+        assert binding["seed_provenance"] == "automatic"
 
 
 class TestEvalSessionConfigLoading:
@@ -1461,6 +1509,17 @@ class TestSetupTasksErrors:
         runner.models = models or {}
         runner.datasets = datasets or {}
         runner.runner = MultiTaskRunner()
+        runner._task_requirement_contexts = (
+            {
+                task_name: _task_requirement_context_for_setup_test(
+                    task_cfg,
+                    runner.models,
+                )
+                for task_name, task_cfg in tasks_cfg.items()
+            }
+            if isinstance(tasks_cfg, dict)
+            else {}
+        )
         return runner
 
     def test_tasks_not_dict_raises(self):
@@ -3502,6 +3561,7 @@ tasks:
         config_path = self._config(
             tmp_path,
             """
+deterministic: true
 models:
   candidate:
     name: org/candidate
@@ -3519,6 +3579,7 @@ tasks:
         api_base: https://extractor.example/v1
         api_key: extractor-key
         temperature: 0
+        seed: 17
 """,
         )
         session = EvalSession(config_path)
@@ -3536,12 +3597,28 @@ tasks:
             ) as client_factory,
         ):
             session._setup_prelaunch_reconciliation()
+            tasks = cast(dict, session.config["tasks"])
+            extracted = cast(dict, tasks["extracted"])
+            task_args = cast(dict, extracted["args"])
+            cast(dict, task_args["extractor"])["seed"] = 71
             session._setup_postlaunch_reconciliation()
             session._setup_models()
+            session._stamp_deterministic_seed_contract()
 
         extractor = session._bound_task_role_models["extracted"]["extractor"]
         assert isinstance(session.models["candidate"], ChatModel)
         assert isinstance(extractor, ChatModel)
+        assert session.models["candidate"]._kwargs["seed"] == 0
+        assert extractor._kwargs["seed"] == 17
+        binding_id = (
+            session._task_requirement_contexts["extracted"]
+            .model_bindings["extractor"]
+            .binding_id
+        )
+        contract = session._reified_config[_DETERMINISTIC_SEED_CONTRACT_KEY]
+        inline_contract = contract["bindings"][binding_id]
+        assert inline_contract["seed"] == 17
+        assert inline_contract["seed_provenance"] == "binding_config"
         assert extractor is not session.models["candidate"]
         assert extractor.pool is not session.models["candidate"].pool
         assert len(session._owned_pools) == 2
@@ -3556,13 +3633,14 @@ tasks:
 
     @pytest.mark.anyio
     async def test_postlaunch_inline_grader_gets_own_pool_and_role_binding(
-        self, tmp_path: Path
+        self, tmp_path: Path, loguru_caplog
     ) -> None:
         from sieval.core.models import ChatModel
 
         config_path = self._config(
             tmp_path,
             """
+deterministic: true
 models:
   candidate:
     name: org/candidate
@@ -3603,6 +3681,8 @@ tasks:
         grader = session._bound_task_role_models["judged"]["grader"]
         assert isinstance(session.models["candidate"], ChatModel)
         assert isinstance(grader, ChatModel)
+        assert session.models["candidate"]._kwargs["seed"] == 0
+        assert grader._kwargs["seed"] == 0
         assert grader is not session.models["candidate"]
         assert grader.pool is not session.models["candidate"].pool
         assert len(session._owned_pools) == 2
@@ -3610,6 +3690,11 @@ tasks:
             "https://candidate.example/v1",
             "https://grader.example/v1",
         }
+        assert any(
+            "judged.grader" in record.message
+            for record in loguru_caplog.records
+            if "best-effort" in record.message
+        )
 
         await session._close_owned_model_resources()
         for close in closes:
@@ -3617,13 +3702,14 @@ tasks:
 
     @pytest.mark.anyio
     async def test_external_grader_pool_is_borrowed_not_closed(
-        self, tmp_path: Path
+        self, tmp_path: Path, loguru_caplog
     ) -> None:
         from sieval.core.models import ChatModel
 
         config_path = self._config(
             tmp_path,
             """
+deterministic: true
 models:
   candidate:
     name: org/candidate
@@ -3671,6 +3757,8 @@ tasks:
             rebound = session._bound_task_role_models["judged"]["grader"]
             assert rebound is not external
             assert rebound.pool is external.pool
+            assert "seed" not in external._kwargs
+            assert rebound._kwargs["seed"] == 0
             assert rebound.runtime_plan is not None
             postlaunch = session.postlaunch_reconcile_result
             assert postlaunch is not None
@@ -3680,6 +3768,17 @@ tasks:
                 is postlaunch.runtime_plans[external.runtime_plan.binding_id]
             )
             assert external.pool not in session._owned_pools.values()
+            session._stamp_deterministic_seed_contract()
+            contract = session._reified_config[_DETERMINISTIC_SEED_CONTRACT_KEY]
+            external_contract = contract["external_roles"]["judged.grader"]
+            assert external_contract["explicit_seed_present"] is False
+            assert external_contract["seed"] == DETERMINISTIC_DEFAULT_SEED
+            assert external_contract["seed_provenance"] == "automatic"
+            assert any(
+                "judged.grader" in record.message
+                for record in loguru_caplog.records
+                if "best-effort" in record.message
+            )
             await session._close_owned_model_resources()
 
         candidate_close.assert_awaited_once()
@@ -3705,6 +3804,7 @@ tasks:
         config_path = self._config(
             tmp_path,
             f"""
+deterministic: true
 models:
   candidate:
     name: org/candidate
@@ -3723,6 +3823,7 @@ tasks:
         derived = {
             "a": base.with_args(
                 temperature=0,
+                seed=7,
                 extra={"source": "a"},
                 concurrency_limit=2,
             ),
@@ -3756,8 +3857,13 @@ tasks:
                 patch.object(base.pool, "aclose", external_close),
             ):
                 session._setup_prelaunch_reconciliation()
+                # The exact external role defaults are frozen before rebind.
+                # Later source mutation must not change contract or execution.
+                derived["a"]._kwargs["seed"] = 70
+                derived["b"]._kwargs["seed"] = 90
                 session._setup_postlaunch_reconciliation()
                 session._setup_models()
+                session._stamp_deterministic_seed_contract()
 
                 postlaunch = session.postlaunch_reconcile_result
                 assert postlaunch is not None
@@ -3765,11 +3871,22 @@ tasks:
                 rebound_plan = postlaunch.runtime_plans[base.runtime_plan.binding_id]
                 for name in ("a", "b"):
                     rebound = session._bound_task_role_models[name]["grader"]
-                    assert rebound._kwargs == {"temperature": 0 if name == "a" else 1}
+                    assert rebound._kwargs == {
+                        "temperature": 0 if name == "a" else 1,
+                        "seed": 7 if name == "a" else DETERMINISTIC_DEFAULT_SEED,
+                    }
                     assert rebound.extra == {"source": name}
                     assert rebound._limiter is derived[name]._limiter
                     assert rebound.pool is base.pool
                     assert rebound.runtime_plan is rebound_plan
+
+                contract = session._reified_config[_DETERMINISTIC_SEED_CONTRACT_KEY]
+                explicit = contract["external_roles"]["a.grader"]
+                automatic = contract["external_roles"]["b.grader"]
+                assert explicit["seed"] == 7
+                assert explicit["seed_provenance"] == "external_model"
+                assert automatic["seed"] == DETERMINISTIC_DEFAULT_SEED
+                assert automatic["seed_provenance"] == "automatic"
 
                 assert base.pool not in session._owned_pools.values()
                 await session._close_owned_model_resources()
@@ -4112,7 +4229,7 @@ tasks:
         close.assert_awaited_once()
 
     @pytest.mark.anyio
-    async def test_deterministic_sglang_legacy_seed_is_engine_level_noop(
+    async def test_deterministic_sglang_legacy_does_not_auto_inject_request_seed(
         self, tmp_path: Path
     ) -> None:
         from sieval.core.models import (
@@ -4168,9 +4285,18 @@ tasks:
                 session._setup_prelaunch_reconciliation()
                 session._setup_postlaunch_reconciliation()
                 session._setup_models()
+                session._stamp_deterministic_seed_contract()
 
             model = session.models["m"]
             assert isinstance(model, SglangGenModel)
+            assert "seed" not in model._kwargs
+            contract = session._reified_config[_DETERMINISTIC_SEED_CONTRACT_KEY]
+            binding = contract["bindings"]["model:m"]
+            assert binding["request_seed_support"] == "unsupported"
+            assert binding["seed_scope"] == "engine_level_only"
+            assert binding["seed_present"] is False
+            assert binding["seed"] is None
+            assert binding["seed_provenance"] == "none"
             with patch.object(model._legacy_transport, "arun", transport_arun):
                 generated = await model.agenerate("prompt")
                 scored = await model.alogprobs("prompt", echo=False)
@@ -4181,10 +4307,73 @@ tasks:
                 cast(Request, call.args[0]) for call in transport_arun.await_args_list
             ]
             assert len(requests) == 2
-            assert all(
-                request.sampling.seed == DETERMINISTIC_DEFAULT_SEED
-                for request in requests
-            )
+            assert all(request.sampling.seed is None for request in requests)
+        finally:
+            await session._close_owned_model_resources()
+
+        close.assert_awaited_once()
+
+    @pytest.mark.anyio
+    async def test_explicit_sglang_legacy_seed_remains_engine_level_noop(
+        self, tmp_path: Path
+    ) -> None:
+        from sieval.core.models import Request, Response, SglangGenModel
+
+        config_path = self._config(
+            tmp_path,
+            """
+deterministic: true
+models:
+  m:
+    name: org/model
+    type: gen
+    engine: sglang
+    api_base: https://sglang.example/v1
+    api_key: local
+    args:
+      seed: 7
+tasks:
+  completion:
+    class: fake.CompletionTask
+    dataset:
+      class: fake.Dataset
+    model: m
+""",
+        )
+        session = EvalSession(config_path)
+        close = AsyncMock()
+        connection = types.SimpleNamespace(
+            close=close,
+            base_url="https://sglang.example/v1",
+        )
+        transport_arun = AsyncMock(return_value=Response(texts=("ok",)))
+
+        try:
+            with (
+                patch(
+                    "sieval.cli.leaderboard.session.resolve_task_class",
+                    return_value=self.CompletionTask,
+                ),
+                patch(
+                    "sieval.core.models.sglang_gen_model.AsyncOpenAI",
+                    return_value=connection,
+                ),
+            ):
+                session._setup_prelaunch_reconciliation()
+                session._setup_postlaunch_reconciliation()
+                session._setup_models()
+
+            model = session.models["m"]
+            assert isinstance(model, SglangGenModel)
+            assert model._kwargs["seed"] == 7
+            with patch.object(model._legacy_transport, "arun", transport_arun):
+                output = await model.agenerate("prompt")
+
+            assert output.texts == ["ok"]
+            call = transport_arun.await_args
+            assert call is not None
+            request = cast(Request, call.args[0])
+            assert request.sampling.seed == 7
         finally:
             await session._close_owned_model_resources()
 
@@ -4356,6 +4545,8 @@ class TestEvalSessionWrappers:
         runner = object.__new__(EvalSession)
         runner.runner = None
         with (
+            patch.object(runner, "prepare_prelaunch", MagicMock(return_value=None)),
+            patch.object(runner, "_stamp_deterministic_seed_contract"),
             patch.object(runner, "_prepare_execution", AsyncMock(return_value=None)),
             patch.object(
                 runner, "_persist_effective_config", AsyncMock(return_value=None)
@@ -4376,6 +4567,8 @@ class TestEvalSessionWrappers:
         runner._owned_legacy_models = {}
 
         with (
+            patch.object(runner, "prepare_prelaunch", MagicMock(return_value=None)),
+            patch.object(runner, "_stamp_deterministic_seed_contract"),
             patch.object(runner, "_prepare_execution", AsyncMock(return_value=None)),
             patch.object(
                 runner, "_persist_effective_config", AsyncMock(return_value=None)
@@ -4450,6 +4643,13 @@ class TestInferArgs:
         runner.models = models or {}
         runner.datasets = datasets or {}
         runner.runner = MultiTaskRunner()
+        runner._task_requirement_contexts = {
+            task_name: _task_requirement_context_for_setup_test(
+                task_cfg,
+                runner.models,
+            )
+            for task_name, task_cfg in tasks_cfg.items()
+        }
         return runner
 
     @pytest.mark.parametrize("key", ["name", "dataset", "model", "models_by_role"])
@@ -4785,15 +4985,70 @@ tasks:
 
 
 # ===================================================================
-# Deterministic mode: required-seed injection + transparent sampling
+# Deterministic mode: dialect-declared seed injection + transparent sampling
 # ===================================================================
+class TestDeterministicRequestSeedPolicy:
+    @pytest.mark.parametrize("dialect_id", ["openai_chat", "openai_completions"])
+    def test_supported_dialects_receive_the_automatic_seed(self, dialect_id):
+        decision = _resolve_deterministic_request_seed(
+            dialect_id=dialect_id,
+            explicit_seed_present=False,
+        )
+
+        assert decision.seed_present is True
+        assert decision.seed == DETERMINISTIC_DEFAULT_SEED
+        assert decision.provenance.value == "automatic"
+
+    def test_unsupported_dialect_requests_automatic_default_removal(self):
+        with patch(
+            "sieval.cli.leaderboard.session.get_dialect_spec",
+            return_value=types.SimpleNamespace(
+                request_seed_support=RequestSeedSupport.UNSUPPORTED
+            ),
+        ):
+            decision = _resolve_deterministic_request_seed(
+                dialect_id="future_seedless",
+                explicit_seed_present=False,
+            )
+
+        assert decision.seed_present is False
+        assert decision.seed is None
+        assert decision.provenance.value == "none"
+        assert decision.remove_inherited_seed is True
+
+    def test_reserved_seed_policy_fails_loudly(self):
+        with pytest.raises(ValueError, match="openai_responses.*has not declared"):
+            _resolve_deterministic_request_seed(
+                dialect_id="openai_responses",
+                explicit_seed_present=False,
+            )
+
+    @pytest.mark.parametrize("seed", [None, 0, 42])
+    def test_explicit_seed_is_never_rewritten(self, seed):
+        with patch(
+            "sieval.cli.leaderboard.session.get_dialect_spec",
+            return_value=types.SimpleNamespace(
+                request_seed_support=RequestSeedSupport.UNSUPPORTED
+            ),
+        ):
+            decision = _resolve_deterministic_request_seed(
+                dialect_id="future_seedless",
+                explicit_seed_present=True,
+                explicit_seed=seed,
+            )
+
+        assert decision.seed_present is True
+        assert decision.seed == seed
+        assert decision.provenance.value == "binding_config"
+        assert decision.remove_inherited_seed is False
+
+
 class TestDeterministicMode:
     """Deterministic mode flag resolution, seed injection, sampling pass-through.
 
-    Deterministic mode injects only `seed` as required. All sampling
-    parameters (temperature, top_p, top_k, ...) are transparent — users
-    configure them freely and pass@k configurations with temperature > 0
-    are first-class.
+    Deterministic mode injects only ``seed``, and only when the selected
+    dialect declares that it can transmit one. All other sampling parameters
+    (temperature, top_p, top_k, ...) remain transparent.
     """
 
     class ChatTask:
@@ -4810,11 +5065,33 @@ class TestDeterministicMode:
                 ),
             )
 
-    def _bind_models(self, tmp_path: Path, config: dict) -> EvalSession:
+    class GenTask:
+        model_type = "gen"
+
+        @classmethod
+        def model_requirements_for(cls, context):
+            return (
+                TaskModelRequirement(
+                    role="candidate",
+                    binding=context.model_bindings["candidate"],
+                    requires=TaskRequirements(input=InputKind.COMPLETION),
+                    source_task="deterministic_test",
+                ),
+            )
+
+    def _bind_models(
+        self,
+        tmp_path: Path,
+        config: dict,
+        *,
+        task_class: type | None = None,
+        connection: object | None = None,
+    ) -> EvalSession:
         """Exercise the same prelaunch -> postlaunch -> bind path as a run."""
 
+        task_class = task_class or self.ChatTask
         config.setdefault("tasks", {})["eval"] = {
-            "class": "fake.ChatTask",
+            "class": f"fake.{task_class.__name__}",
             "dataset": {"class": "fake.Dataset"},
             "model": next(reversed(config["models"])),
         }
@@ -4824,11 +5101,11 @@ class TestDeterministicMode:
             yaml.safe_dump(config, sort_keys=False),
         )
         session = EvalSession(config_path)
-        connection = types.SimpleNamespace(close=AsyncMock())
+        connection = connection or types.SimpleNamespace(close=AsyncMock())
         with (
             patch(
                 "sieval.cli.leaderboard.session.resolve_task_class",
-                return_value=self.ChatTask,
+                return_value=task_class,
             ),
             patch(
                 "sieval.core.models.connection_factory.AsyncOpenAI",
@@ -4885,7 +5162,7 @@ class TestDeterministicMode:
     # ------------------------------------------------------------------
 
     def test_seed_auto_injected_when_absent(self, tmp_path):
-        """Deterministic mode injects seed=0 when user doesn't specify."""
+        """A supporting dialect receives seed=0 when the user omits it."""
         session = self._bind_models(
             tmp_path,
             {
@@ -4894,6 +5171,345 @@ class TestDeterministicMode:
             },
         )
         assert session.models["m1"]._kwargs.get("seed") == 0
+
+    def test_completions_seed_auto_injected_when_absent(self, tmp_path):
+        session = self._bind_models(
+            tmp_path,
+            {
+                "deterministic": True,
+                "models": {"m1": {"name": "mock-gen", "type": "gen", "args": {}}},
+            },
+            task_class=self.GenTask,
+        )
+
+        assert session.models["m1"].dialect_id == "openai_completions"
+        assert session.models["m1"]._kwargs.get("seed") == 0
+
+    @pytest.mark.anyio
+    async def test_chat_automatic_seed_reaches_wire_and_model_output(self, tmp_path):
+        create = AsyncMock(
+            return_value=types.SimpleNamespace(
+                choices=[
+                    types.SimpleNamespace(
+                        index=0,
+                        message=types.SimpleNamespace(
+                            content="ok",
+                            reasoning=None,
+                            reasoning_content=None,
+                            tool_calls=None,
+                        ),
+                        finish_reason="stop",
+                        logprobs=None,
+                    )
+                ],
+                usage=None,
+                model="served-chat",
+                system_fingerprint=None,
+            )
+        )
+        connection = types.SimpleNamespace(
+            close=AsyncMock(),
+            chat=types.SimpleNamespace(
+                completions=types.SimpleNamespace(create=create)
+            ),
+        )
+        session = self._bind_models(
+            tmp_path,
+            {
+                "deterministic": True,
+                "models": {"m1": {"name": "mock-chat", "type": "chat"}},
+            },
+            connection=connection,
+        )
+
+        try:
+            output = await session.models["m1"].agenerate("hello", stream=False)
+            masked = await session.models["m1"].agenerate(
+                "hello", stream=False, seed=None
+            )
+        finally:
+            await session._close_owned_model_resources()
+
+        seeded_call, masked_call = create.await_args_list
+        assert seeded_call.kwargs["seed"] == DETERMINISTIC_DEFAULT_SEED
+        assert "seed" not in masked_call.kwargs
+        assert output.request_params is not None
+        assert output.request_params["seed"] == DETERMINISTIC_DEFAULT_SEED
+        assert masked.request_params is not None
+        assert "seed" not in masked.request_params
+
+    @pytest.mark.anyio
+    async def test_completions_automatic_seed_reaches_wire_and_model_output(
+        self, tmp_path
+    ):
+        create = AsyncMock(
+            return_value=types.SimpleNamespace(
+                choices=[
+                    types.SimpleNamespace(
+                        index=0,
+                        text="ok",
+                        finish_reason="stop",
+                        logprobs=None,
+                    )
+                ],
+                usage=None,
+                model="served-completion",
+                system_fingerprint=None,
+            )
+        )
+        connection = types.SimpleNamespace(
+            close=AsyncMock(),
+            completions=types.SimpleNamespace(create=create),
+        )
+        session = self._bind_models(
+            tmp_path,
+            {
+                "deterministic": True,
+                "models": {"m1": {"name": "mock-gen", "type": "gen"}},
+            },
+            task_class=self.GenTask,
+            connection=connection,
+        )
+
+        try:
+            output = await session.models["m1"].agenerate("hello", stream=False)
+        finally:
+            await session._close_owned_model_resources()
+
+        call = create.await_args
+        assert call is not None
+        assert call.kwargs["seed"] == DETERMINISTIC_DEFAULT_SEED
+        assert output.request_params is not None
+        assert output.request_params["seed"] == DETERMINISTIC_DEFAULT_SEED
+
+    @pytest.mark.anyio
+    async def test_task_infer_seed_contract_matches_each_candidate_wire(self, tmp_path):
+        from tests.unit.core.runners.test_runner import MockTask
+
+        create = AsyncMock(
+            return_value=types.SimpleNamespace(
+                choices=[
+                    types.SimpleNamespace(
+                        index=0,
+                        message=types.SimpleNamespace(
+                            content="ok",
+                            reasoning=None,
+                            reasoning_content=None,
+                            tool_calls=None,
+                        ),
+                        finish_reason="stop",
+                        logprobs=None,
+                    )
+                ],
+                usage=None,
+                model="served-chat",
+                system_fingerprint=None,
+            )
+        )
+        connection = types.SimpleNamespace(
+            close=AsyncMock(),
+            chat=types.SimpleNamespace(
+                completions=types.SimpleNamespace(create=create)
+            ),
+        )
+        config_path = _write_yaml_config(
+            tmp_path,
+            "candidate-seeds.yaml",
+            yaml.safe_dump(
+                {
+                    "deterministic": True,
+                    "models": {"m": {"name": "mock-chat", "type": "chat"}},
+                    "datasets": {"ds": {"class": "fake.Dataset"}},
+                    "tasks": {
+                        "first": {
+                            "class": "fake.MockTask",
+                            "dataset": "ds",
+                            "model": "m",
+                            "infer_args": {"seed": 11},
+                        },
+                        "second": {
+                            "class": "fake.MockTask",
+                            "dataset": "ds",
+                            "model": "m",
+                            "infer_args": {"seed": 22},
+                        },
+                    },
+                },
+                sort_keys=False,
+            ),
+        )
+        session = EvalSession(config_path)
+
+        try:
+            with (
+                patch(
+                    "sieval.cli.leaderboard.session.resolve_task_class",
+                    return_value=MockTask,
+                ),
+                patch(
+                    "sieval.core.models.connection_factory.AsyncOpenAI",
+                    return_value=connection,
+                ),
+            ):
+                session._setup_prelaunch_reconciliation()
+                session._stamp_deterministic_seed_contract()
+
+                # Execution must consume RequirementContext.infer_args, not a
+                # second read of the now-mutated session config.
+                tasks = cast(dict, session.config["tasks"])
+                cast(dict, tasks["first"])["infer_args"] = {"seed": 91}
+                cast(dict, tasks["second"])["infer_args"] = {"seed": 92}
+
+                session._setup_postlaunch_reconciliation()
+                session._setup_models()
+                session._init_runner()
+                session.datasets["ds"] = MagicMock()
+                session._setup_tasks()
+
+            contract = session._reified_config[_DETERMINISTIC_SEED_CONTRACT_KEY]
+            assert contract["bindings"]["model:m"]["seed"] == 0
+            assert contract["candidates"]["first"]["seed"] == 11
+            assert (
+                contract["candidates"]["first"]["seed_provenance"] == "task_infer_args"
+            )
+            assert contract["candidates"]["second"]["seed"] == 22
+            assert (
+                contract["candidates"]["second"]["seed_provenance"] == "task_infer_args"
+            )
+            yaml.safe_dump(contract)
+            assert "_request_seed_decisions" not in session._reified_config
+
+            assert session.runner is not None
+            task_models = {
+                entry._task.name: entry._task.model for entry in session.runner._runners
+            }
+            await task_models["first"].agenerate("hello", stream=False)
+            await task_models["second"].agenerate("hello", stream=False)
+
+            first_call, second_call = create.await_args_list
+            assert first_call.kwargs["seed"] == 11
+            assert second_call.kwargs["seed"] == 22
+        finally:
+            await session._close_owned_model_resources()
+
+    @pytest.mark.anyio
+    async def test_task_candidate_binding_is_frozen_before_setup(self, tmp_path):
+        from tests.unit.core.runners.test_runner import MockTask
+
+        def response() -> object:
+            return types.SimpleNamespace(
+                choices=[
+                    types.SimpleNamespace(
+                        index=0,
+                        message=types.SimpleNamespace(
+                            content="ok",
+                            reasoning=None,
+                            reasoning_content=None,
+                            tool_calls=None,
+                        ),
+                        finish_reason="stop",
+                        logprobs=None,
+                    )
+                ],
+                usage=None,
+                model="served-chat",
+                system_fingerprint=None,
+            )
+
+        frozen_create = AsyncMock(return_value=response())
+        mutated_create = AsyncMock(return_value=response())
+        frozen_connection = types.SimpleNamespace(
+            close=AsyncMock(),
+            chat=types.SimpleNamespace(
+                completions=types.SimpleNamespace(create=frozen_create)
+            ),
+        )
+        mutated_connection = types.SimpleNamespace(
+            close=AsyncMock(),
+            chat=types.SimpleNamespace(
+                completions=types.SimpleNamespace(create=mutated_create)
+            ),
+        )
+        config_path = _write_yaml_config(
+            tmp_path,
+            "frozen-candidate.yaml",
+            yaml.safe_dump(
+                {
+                    "deterministic": True,
+                    "models": {
+                        "frozen": {
+                            "name": "frozen-model",
+                            "type": "chat",
+                            "api_base": "https://frozen.example/v1",
+                            "api_key": "frozen-key",
+                            "args": {"seed": 11},
+                        },
+                        "mutated": {
+                            "name": "mutated-model",
+                            "type": "chat",
+                            "api_base": "https://mutated.example/v1",
+                            "api_key": "mutated-key",
+                            "args": {"seed": 22},
+                        },
+                    },
+                    "datasets": {"ds": {"class": "fake.Dataset"}},
+                    "tasks": {
+                        "eval": {
+                            "class": "fake.MockTask",
+                            "dataset": "ds",
+                            "model": "frozen",
+                        }
+                    },
+                },
+                sort_keys=False,
+            ),
+        )
+        session = EvalSession(config_path)
+
+        try:
+            with (
+                patch(
+                    "sieval.cli.leaderboard.session.resolve_task_class",
+                    return_value=MockTask,
+                ),
+                patch(
+                    "sieval.core.models.connection_factory.AsyncOpenAI",
+                    side_effect=[frozen_connection, mutated_connection],
+                ),
+            ):
+                session._setup_prelaunch_reconciliation()
+                session._stamp_deterministic_seed_contract()
+
+                tasks = cast(dict, session.config["tasks"])
+                cast(dict, tasks["eval"])["model"] = "mutated"
+
+                session._setup_postlaunch_reconciliation()
+                session._setup_models()
+                session._init_runner()
+                session.datasets["ds"] = MagicMock()
+                session._setup_tasks()
+
+            contract = session._reified_config[_DETERMINISTIC_SEED_CONTRACT_KEY]
+            candidate_contract = contract["candidates"]["eval"]
+            assert candidate_contract["binding_id"] == "model:frozen"
+            assert candidate_contract["requested_model_id"] == "frozen-model"
+            assert candidate_contract["seed"] == 11
+
+            assert session.runner is not None
+            task_model = session.runner._runners[0]._task.model
+            assert task_model.runtime_plan is not None
+            assert task_model.runtime_plan.binding_id == "model:frozen"
+            assert task_model._kwargs["seed"] == 11
+
+            await task_model.agenerate("hello", stream=False)
+            frozen_create.assert_awaited_once()
+            mutated_create.assert_not_awaited()
+            call = frozen_create.await_args
+            assert call is not None
+            assert call.kwargs["model"] == "frozen-model"
+            assert call.kwargs["seed"] == 11
+        finally:
+            await session._close_owned_model_resources()
 
     def test_seed_user_override_preserved(self, tmp_path):
         """User's explicit seed=42 is preserved; no injection override."""
@@ -4912,6 +5528,114 @@ class TestDeterministicMode:
         )
         assert session.models["m1"]._kwargs.get("seed") == 42
 
+    @pytest.mark.anyio
+    async def test_named_seed_value_and_provenance_are_frozen_before_binding(
+        self, tmp_path
+    ):
+        create = AsyncMock(
+            return_value=types.SimpleNamespace(
+                choices=[
+                    types.SimpleNamespace(
+                        index=0,
+                        message=types.SimpleNamespace(
+                            content="ok",
+                            reasoning=None,
+                            reasoning_content=None,
+                            tool_calls=None,
+                        ),
+                        finish_reason="stop",
+                        logprobs=None,
+                    )
+                ],
+                usage=None,
+                model="served-chat",
+                system_fingerprint=None,
+            )
+        )
+        connection = types.SimpleNamespace(
+            close=AsyncMock(),
+            chat=types.SimpleNamespace(
+                completions=types.SimpleNamespace(create=create)
+            ),
+        )
+        config_path = _write_yaml_config(
+            tmp_path,
+            "frozen-named-seed.yaml",
+            yaml.safe_dump(
+                {
+                    "deterministic": True,
+                    "models": {
+                        "m": {
+                            "name": "mock-chat",
+                            "type": "chat",
+                            "args": {"seed": 41},
+                        }
+                    },
+                    "tasks": {
+                        "eval": {
+                            "class": "fake.ChatTask",
+                            "dataset": {"class": "fake.Dataset"},
+                            "model": "m",
+                        }
+                    },
+                },
+                sort_keys=False,
+            ),
+        )
+        session = EvalSession(config_path)
+
+        try:
+            with (
+                patch(
+                    "sieval.cli.leaderboard.session.resolve_task_class",
+                    return_value=self.ChatTask,
+                ),
+                patch(
+                    "sieval.core.models.connection_factory.AsyncOpenAI",
+                    return_value=connection,
+                ),
+            ):
+                session._setup_prelaunch_reconciliation()
+                models = cast(dict, session.config["models"])
+                args = cast(dict, cast(dict, models["m"])["args"])
+                args["seed"] = 99
+                session._setup_postlaunch_reconciliation()
+                session._setup_models()
+                session._stamp_deterministic_seed_contract()
+
+            contract = session._reified_config[_DETERMINISTIC_SEED_CONTRACT_KEY]
+            assert contract["bindings"]["model:m"]["seed"] == 41
+            assert (
+                contract["bindings"]["model:m"]["seed_provenance"] == "binding_config"
+            )
+            assert contract["candidates"]["eval"]["seed"] == 41
+
+            await session.models["m"].agenerate("hello", stream=False)
+            call = create.await_args
+            assert call is not None
+            assert call.kwargs["seed"] == 41
+        finally:
+            await session._close_owned_model_resources()
+
+    def test_explicit_none_seed_is_preserved_through_derived_chain(self, tmp_path):
+        session = self._bind_models(
+            tmp_path,
+            {
+                "deterministic": True,
+                "models": {
+                    "base": {
+                        "name": "mock-chat",
+                        "type": "chat",
+                        "args": {"seed": None},
+                    },
+                    "child": {"base": "base", "args": {"temperature": 0.7}},
+                },
+            },
+        )
+
+        assert session.models["base"]._kwargs["seed"] is None
+        assert session.models["child"]._kwargs["seed"] is None
+
     def test_no_seed_injection_when_not_deterministic(self, tmp_path):
         """seed is NOT auto-injected when deterministic=False."""
         session = self._bind_models(
@@ -4923,14 +5647,8 @@ class TestDeterministicMode:
         )
         assert "seed" not in session.models["m1"]._kwargs
 
-    def test_derived_model_inherits_injected_seed(self, tmp_path):
-        """Derived models inherit seed=0 from base via with_args kwarg merge.
-
-        seed is injected only on the first (base) pass; derived models pick it
-        up through ``base_model.with_args(**args)`` which merges
-        ``{**base._kwargs, **args}``. Uses a real ``MockChatModel`` so the
-        merge is exercised rather than mocked.
-        """
+    def test_derived_model_keeps_binding_local_automatic_seed(self, tmp_path):
+        """Every compatible binding receives the deterministic request seed."""
         session = self._bind_models(
             tmp_path,
             {
@@ -5016,8 +5734,7 @@ class TestDeterministicMode:
 
     def test_per_task_infer_args_temperature_allowed(self):
         """Per-task infer_args with temperature > 0 is accepted (no lock)."""
-        mock_model = MagicMock()
-        mock_model.with_args.return_value = mock_model
+        mock_model = MockChatModel()
         mock_ds = MagicMock()
         mock_task_cls = MagicMock(return_value=MagicMock())
 
@@ -5047,13 +5764,37 @@ class TestDeterministicMode:
         runner.datasets = {"ds": mock_ds}
         runner.runner = MultiTaskRunner()
         runner.deterministic = True
+        runner._task_requirement_contexts = {
+            "eval_task": RequirementContext(
+                model_bindings={
+                    "candidate": NamedModelBinding(
+                        binding_id="model:m",
+                        root_deployment_key="model:m",
+                        requested_model_id="m",
+                        config_name="m",
+                        dialect_id="openai_chat",
+                    )
+                },
+                infer_args={"temperature": 0.6, "top_k": 20},
+            )
+        }
+        runner._request_seed_decisions_by_candidate = {
+            "eval_task": _resolve_deterministic_request_seed(
+                dialect_id="openai_chat",
+                explicit_seed_present=False,
+            )
+        }
+        runner._request_seed_decisions_frozen = True
 
         with patch(
             "sieval.cli.leaderboard.session.resolve_task_class",
             return_value=mock_task_cls,
         ):
             runner._setup_tasks()  # must not raise
-        mock_model.with_args.assert_called_once_with(temperature=0.6, top_k=20)
+        task_model = mock_task_cls.call_args.kwargs["model"]
+        assert task_model._kwargs["temperature"] == 0.6
+        assert task_model._kwargs["top_k"] == 20
+        assert task_model._kwargs["seed"] == DETERMINISTIC_DEFAULT_SEED
 
 
 # ===================================================================
@@ -5371,7 +6112,7 @@ class TestUnwrapProxies:
 
 
 class TestReifyCliOverrides:
-    def test_deterministic_sets_root_and_base_model_seed(self):
+    def test_deterministic_sets_root_without_persisting_automatic_seed(self):
         cfg = {
             "models": {
                 "base": {"name": "qwen3-4b", "args": {"max_tokens": 8192}},
@@ -5380,8 +6121,8 @@ class TestReifyCliOverrides:
         }
         out = _reify_cli_overrides(cfg, deterministic=True)
         assert out["deterministic"] is True
-        assert out["models"]["base"]["args"]["seed"] == DETERMINISTIC_DEFAULT_SEED
         assert out["models"]["base"]["args"]["max_tokens"] == 8192
+        assert "seed" not in out["models"]["base"]["args"]
         assert "seed" not in out["models"]["derived"]["args"]
 
     def test_deterministic_preserves_user_seed(self):
@@ -5389,10 +6130,10 @@ class TestReifyCliOverrides:
         out = _reify_cli_overrides(cfg, deterministic=True)
         assert out["models"]["base"]["args"]["seed"] == 42
 
-    def test_deterministic_adds_args_dict_when_missing(self):
+    def test_deterministic_does_not_add_args_dict_when_missing(self):
         cfg = {"models": {"base": {"name": "m"}}}
         out = _reify_cli_overrides(cfg, deterministic=True)
-        assert out["models"]["base"]["args"] == {"seed": DETERMINISTIC_DEFAULT_SEED}
+        assert "args" not in out["models"]["base"]
 
     def test_deterministic_idempotent_when_already_true(self):
         cfg = {
@@ -5402,6 +6143,11 @@ class TestReifyCliOverrides:
         out = _reify_cli_overrides(cfg, deterministic=True)
         assert out["deterministic"] is True
         assert out["models"]["base"]["args"]["seed"] == 0
+
+    def test_deterministic_preserves_explicit_none_seed(self):
+        cfg = {"models": {"base": {"name": "m", "args": {"seed": None}}}}
+        out = _reify_cli_overrides(cfg, deterministic=True)
+        assert out["models"]["base"]["args"]["seed"] is None
 
     def test_model_override_rewrites_base_names_only(self):
         cfg = {
@@ -5437,7 +6183,7 @@ class TestReifyCliOverrides:
         assert out["deterministic"] is True
         assert out["result_dir"] == "./new"
         assert out["models"]["base"]["name"] == "new"
-        assert out["models"]["base"]["args"]["seed"] == DETERMINISTIC_DEFAULT_SEED
+        assert "args" not in out["models"]["base"]
 
 
 class TestApplyEndpointInjection:
@@ -5683,7 +6429,7 @@ class TestEvalSessionRawConfig:
         assert session._raw_config["models"]["base"].get("args", {}).get("seed") is None
         # self.config has reification applied
         assert session.config["deterministic"] is True
-        assert session.config["models"]["base"]["args"]["seed"] == 0
+        assert "args" not in session.config["models"]["base"]
 
     def test_raw_config_unaffected_by_legacy_external_endpoint_adapter(self, tmp_path):
         config_path = _write_yaml_config(
@@ -5769,7 +6515,7 @@ class TestEvalSessionRawConfig:
 
         # Reification must survive runner initialization.
         assert session.config["deterministic"] is True
-        assert session.config["models"]["base"]["args"]["seed"] == 0
+        assert "args" not in session.config["models"]["base"]
 
 
 class TestDiffDicts:

--- a/tests/unit/cli/leaderboard/test_session.py
+++ b/tests/unit/cli/leaderboard/test_session.py
@@ -752,6 +752,62 @@ class TestDeriveModelType:
             derive_model_type("m", None, cast(Any, object()))
 
 
+class TestTaskModelConfigName:
+    """Task -> candidate model-name resolution.
+
+    This is the single surviving resolver: `_setup_tasks` reads the candidate
+    from the prelaunch-frozen `RequirementContext`, so these errors are the
+    only thing standing between a typo'd `model:` and a confusing failure
+    much deeper in binding.
+    """
+
+    def _session(self):
+        return object.__new__(EvalSession)
+
+    def test_explicit_model_ref_is_returned(self):
+        session = self._session()
+        models_cfg = {"my_model": {"name": "org/m"}, "other": {"name": "org/o"}}
+
+        assert (
+            session._task_model_config_name("t1", {"model": "my_model"}, models_cfg)
+            == "my_model"
+        )
+
+    def test_single_model_is_the_default_candidate(self):
+        session = self._session()
+
+        assert (
+            session._task_model_config_name("t1", {}, {"only": {"name": "org/m"}})
+            == "only"
+        )
+
+    def test_unknown_model_ref_is_rejected(self):
+        session = self._session()
+        with pytest.raises(ValueError, match="references unknown model 'bad_ref'"):
+            session._task_model_config_name(
+                "t1", {"model": "bad_ref"}, {"my_model": {"name": "org/m"}}
+            )
+
+    def test_no_models_defined_is_rejected(self):
+        session = self._session()
+        with pytest.raises(ValueError, match="no models defined in config"):
+            session._task_model_config_name("t1", {}, {})
+
+    def test_ambiguous_candidate_is_rejected(self):
+        session = self._session()
+        with pytest.raises(ValueError, match="'model' required when multiple models"):
+            session._task_model_config_name(
+                "t1", {}, {"a": {"name": "org/a"}, "b": {"name": "org/b"}}
+            )
+
+    def test_non_string_model_ref_is_rejected(self):
+        session = self._session()
+        with pytest.raises(ValueError, match="'model' must be a string reference"):
+            session._task_model_config_name(
+                "t1", {"model": 123}, {"my_model": {"name": "org/m"}}
+            )
+
+
 class TestResolveTaskDataset:
     def _make_runner(self, datasets=None):
         runner = object.__new__(EvalSession)
@@ -4441,6 +4497,81 @@ tasks:
             await session._close_owned_model_resources()
 
         close.assert_awaited_once()
+
+    @pytest.mark.anyio
+    async def test_deterministic_legacy_candidate_survives_task_setup(
+        self, tmp_path: Path
+    ) -> None:
+        """`_setup_tasks` applies the frozen decision to a `SglangGenModel`.
+
+        The legacy facade is the one candidate that reaches
+        `_apply_request_seed_decision_to_model` as a `Model` *subclass* whose
+        `with_dialect` raises, so the helper's dialect guard has to be
+        satisfied by `SglangGenModel.dialect_id` rather than a runtime plan.
+        """
+        from sieval.core.models import SglangGenModel
+        from tests.unit.core.runners.test_runner import MockTask
+
+        class LegacyGenTask(MockTask):
+            model_type = "gen"
+
+        config_path = self._config(
+            tmp_path,
+            """
+deterministic: true
+models:
+  m:
+    name: org/model
+    type: gen
+    engine: sglang
+    api_base: https://sglang.example/v1
+    api_key: local
+datasets:
+  ds:
+    class: fake.Dataset
+tasks:
+  completion:
+    class: fake.LegacyGenTask
+    dataset: ds
+    model: m
+""",
+        )
+        session = EvalSession(config_path)
+        close = AsyncMock()
+        connection = types.SimpleNamespace(
+            close=close,
+            base_url="https://sglang.example/v1",
+        )
+
+        try:
+            with (
+                patch(
+                    "sieval.cli.leaderboard.session.resolve_task_class",
+                    return_value=LegacyGenTask,
+                ),
+                patch(
+                    "sieval.core.models.sglang_gen_model.AsyncOpenAI",
+                    return_value=connection,
+                ),
+            ):
+                session._setup_prelaunch_reconciliation()
+                session._setup_postlaunch_reconciliation()
+                session._setup_models()
+                session._init_runner()
+                session.datasets["ds"] = MagicMock()
+                session._setup_tasks()
+
+            assert session.runner is not None
+            task_model = session.runner._runners[0]._task.model
+            assert isinstance(task_model, SglangGenModel)
+            assert task_model.dialect_id == "sglang_legacy"
+            assert "seed" not in task_model._kwargs
+            # The helper derives rather than mutates, so a distinct object is
+            # the evidence that it ran against the legacy facade at all.
+            assert task_model is not session.models["m"]
+            assert "seed" not in session.models["m"]._kwargs
+        finally:
+            await session._close_owned_model_resources()
 
 
 class TestEvalSessionWrappers:

--- a/tests/unit/cli/leaderboard/test_session.py
+++ b/tests/unit/cli/leaderboard/test_session.py
@@ -28,6 +28,8 @@ from sieval.cli.leaderboard.session import (
     EvalSession,
     _append_resume_note,
     _apply_endpoint_injection,
+    _apply_request_seed_decision_to_args,
+    _apply_request_seed_decision_to_model,
     _brief_diff,
     _cross_version_resume_hint,
     _describe_order_change,
@@ -748,60 +750,6 @@ class TestDeriveModelType:
             derive_model_type("m", "other", empty)
         with pytest.raises(TypeError, match="AggregatedTaskRequirements"):
             derive_model_type("m", None, cast(Any, object()))
-
-
-# ===================================================================
-# Resolve task model / dataset helpers
-# ===================================================================
-class TestResolveTaskModel:
-    def _make_runner(self, models=None):
-        runner = object.__new__(EvalSession)
-        runner.models = models or {}
-        return runner
-
-    def test_explicit_model_ref(self):
-        m = MagicMock()
-        runner = self._make_runner({"my_model": m})
-        result = runner._resolve_task_model({"model": "my_model"}, "t1")
-        assert result is m
-
-    def test_single_model_default(self):
-        m = MagicMock()
-        runner = self._make_runner({"only": m})
-        result = runner._resolve_task_model({}, "t1")
-        assert result is m
-
-    def test_error_cases(self):
-        # (models_map, task_cfg, expected_error_pattern)
-        cases = [
-            # Explicit model reference does not exist.
-            (
-                {"my_model": MagicMock()},
-                {"model": "bad_ref"},
-                "unknown model",
-            ),
-            # No model available and no reference provided.
-            (
-                {},
-                {},
-                "no models defined",
-            ),
-            # Multiple models available but task doesn't choose one.
-            (
-                {"a": MagicMock(), "b": MagicMock()},
-                {},
-                "'model' required",
-            ),
-        ]
-        for models, task_cfg, error_match in cases:
-            runner = self._make_runner(models)
-            with pytest.raises(ValueError, match=error_match):
-                runner._resolve_task_model(task_cfg, "t1")
-
-    def test_model_ref_must_be_string(self):
-        runner = self._make_runner({"my_model": MagicMock()})
-        with pytest.raises(ValueError, match="'model' must be a string reference"):
-            runner._resolve_task_model({"model": 123}, "t1")
 
 
 class TestResolveTaskDataset:
@@ -1750,6 +1698,120 @@ class TestPrelaunchReconciliation:
     @staticmethod
     def _config(tmp_path: Path, body: str) -> Path:
         return _write_yaml_config(tmp_path, "prelaunch.yaml", body)
+
+    async def _external_seed_contract_entry(
+        self,
+        tmp_path: Path,
+        *,
+        requested_model_id: str = "org/external-grader",
+        api_base: str = "https://external.example:8000/v1",
+        completion: bool = False,
+        explicit_seed: int | None = None,
+    ) -> dict[str, Any]:
+        from sieval.core.models import ChatModel, GenModel
+
+        config_path = self._config(
+            tmp_path,
+            """
+deterministic: true
+models:
+  candidate:
+    name: org/candidate
+tasks:
+  judged:
+    class: fake.JudgeTask
+    dataset:
+      class: fake.Dataset
+    model: candidate
+    args: {}
+""",
+        )
+        if completion:
+            if explicit_seed is None:
+                external: Model = GenModel(
+                    model=requested_model_id,
+                    api_base=api_base,
+                    api_key="external-key",
+                )
+            else:
+                external = GenModel(
+                    model=requested_model_id,
+                    api_base=api_base,
+                    api_key="external-key",
+                    seed=explicit_seed,
+                )
+        else:
+            if explicit_seed is None:
+                external = ChatModel(
+                    model=requested_model_id,
+                    api_base=api_base,
+                    api_key="external-key",
+                )
+            else:
+                external = ChatModel(
+                    model=requested_model_id,
+                    api_base=api_base,
+                    api_key="external-key",
+                    seed=explicit_seed,
+                )
+        session = EvalSession(config_path)
+        tasks = cast(dict[str, Any], session.config["tasks"])
+        task = cast(dict[str, Any], tasks["judged"])
+        cast(dict[str, Any], task["args"])["grader"] = external
+        task_class = self.ScoringJudgeTask if completion else self.JudgeTask
+
+        try:
+            with patch(
+                "sieval.cli.leaderboard.session.resolve_task_class",
+                return_value=task_class,
+            ):
+                session.prepare_prelaunch()
+                session._stamp_deterministic_seed_contract()
+            contract = cast(
+                dict[str, Any],
+                session._reified_config[_DETERMINISTIC_SEED_CONTRACT_KEY],
+            )
+            entry = cast(dict[str, Any], contract["external_roles"]["judged.grader"])
+            return dict(entry)
+        finally:
+            await external.aclose()
+
+    @pytest.mark.anyio
+    async def test_external_seed_contract_uses_stable_semantic_identity(
+        self, tmp_path: Path
+    ) -> None:
+        first = await self._external_seed_contract_entry(tmp_path)
+        reconstructed = await self._external_seed_contract_entry(tmp_path)
+        moved_endpoint = await self._external_seed_contract_entry(
+            tmp_path,
+            api_base="https://external.example:9000/v1",
+        )
+
+        assert first == reconstructed == moved_endpoint
+        assert "binding_id" not in first
+        assert "runtime_plan_fingerprint" not in first
+
+    @pytest.mark.anyio
+    async def test_external_seed_contract_retains_semantic_sensitivity(
+        self, tmp_path: Path
+    ) -> None:
+        baseline = await self._external_seed_contract_entry(tmp_path)
+        changed_model = await self._external_seed_contract_entry(
+            tmp_path,
+            requested_model_id="org/other-grader",
+        )
+        changed_dialect = await self._external_seed_contract_entry(
+            tmp_path,
+            completion=True,
+        )
+        changed_seed = await self._external_seed_contract_entry(
+            tmp_path,
+            explicit_seed=7,
+        )
+
+        assert changed_model != baseline
+        assert changed_dialect != baseline
+        assert changed_seed != baseline
 
     def test_implicit_single_model_completion_uses_normalized_hook_evidence(
         self, tmp_path: Path
@@ -5015,7 +5077,55 @@ class TestDeterministicRequestSeedPolicy:
         assert decision.seed_present is False
         assert decision.seed is None
         assert decision.provenance.value == "none"
-        assert decision.remove_inherited_seed is True
+
+    @pytest.mark.anyio
+    async def test_absent_decision_removes_existing_model_seed(self):
+        with patch(
+            "sieval.cli.leaderboard.session.get_dialect_spec",
+            return_value=types.SimpleNamespace(
+                request_seed_support=RequestSeedSupport.UNSUPPORTED
+            ),
+        ):
+            decision = _resolve_deterministic_request_seed(
+                dialect_id="openai_chat",
+                explicit_seed_present=False,
+            )
+
+        source = MockChatModel(seed=7)
+        try:
+            model = _apply_request_seed_decision_to_model(source, decision)
+            assert "seed" not in model.meta()["default_params"]
+        finally:
+            await source.aclose()
+
+    def test_absent_decision_removes_existing_argument_seed(self):
+        with patch(
+            "sieval.cli.leaderboard.session.get_dialect_spec",
+            return_value=types.SimpleNamespace(
+                request_seed_support=RequestSeedSupport.UNSUPPORTED
+            ),
+        ):
+            decision = _resolve_deterministic_request_seed(
+                dialect_id="future_seedless",
+                explicit_seed_present=False,
+            )
+
+        args = {"seed": 7, "temperature": 0.5}
+        _apply_request_seed_decision_to_args(args, decision)
+
+        assert args == {"temperature": 0.5}
+
+    def test_present_decision_replaces_existing_argument_seed(self):
+        decision = _resolve_deterministic_request_seed(
+            dialect_id="openai_chat",
+            explicit_seed_present=True,
+            explicit_seed=0,
+        )
+        args = {"seed": 9, "temperature": 0.5}
+
+        _apply_request_seed_decision_to_args(args, decision)
+
+        assert args == {"seed": 0, "temperature": 0.5}
 
     def test_reserved_seed_policy_fails_loudly(self):
         with pytest.raises(ValueError, match="openai_responses.*has not declared"):
@@ -5041,7 +5151,6 @@ class TestDeterministicRequestSeedPolicy:
         assert decision.seed_present is True
         assert decision.seed == seed
         assert decision.provenance.value == "binding_config"
-        assert decision.remove_inherited_seed is False
 
 
 class TestDeterministicMode:

--- a/tests/unit/cli/leaderboard/test_session.py
+++ b/tests/unit/cli/leaderboard/test_session.py
@@ -88,10 +88,11 @@ def _task_requirement_context_for_setup_test(
 
     if not isinstance(task_cfg, dict):
         return RequirementContext()
-    infer_args = task_cfg.get("infer_args", {})
+    typed_task_cfg = cast(dict[str, Any], task_cfg)
+    infer_args = typed_task_cfg.get("infer_args", {})
     if not isinstance(infer_args, dict):
         infer_args = {}
-    model_name = task_cfg.get("model")
+    model_name = typed_task_cfg.get("model")
     if not model_name and len(models) == 1:
         model_name = next(iter(models))
     bindings = {}

--- a/tests/unit/cli/leaderboard/test_session_persistence.py
+++ b/tests/unit/cli/leaderboard/test_session_persistence.py
@@ -12,6 +12,7 @@ import pytest
 import yaml
 
 from sieval.cli.leaderboard.session import (
+    _DETERMINISTIC_SEED_CONTRACT_KEY,
     EvalSession,
     _format_comment_header,
     _split_header,
@@ -64,7 +65,7 @@ class TestPersistEffectiveConfig:
         # CLI reification baked in
         assert loaded["deterministic"] is True
         assert loaded["models"]["base"]["name"] == "new-name"
-        assert loaded["models"]["base"]["args"]["seed"] == 0
+        assert "args" not in loaded["models"]["base"]
         # Endpoint injection NOT persisted
         assert "api_base" not in loaded["models"]["base"]
         assert "api_key" not in loaded["models"]["base"]
@@ -445,6 +446,180 @@ class TestStrictResumeMatch:
 
         # Header timestamp may differ; body should still match the original file
         assert (result_dir / "effective_config.yaml").read_text() == original
+
+    @pytest.mark.anyio
+    async def test_deterministic_resume_matches_without_persisted_automatic_seed(
+        self, tmp_path: Path
+    ):
+        cfg_path = _write_yaml(
+            tmp_path,
+            "cfg.yaml",
+            "deterministic: true\n"
+            "models:\n"
+            "  base:\n"
+            "    name: mock-chat\n"
+            "    type: chat\n"
+            "    args:\n"
+            "      max_tokens: 32\n"
+            "tasks:\n"
+            "  eval:\n"
+            "    class: tests.unit.core.runners.test_runner.MockTask\n"
+            "    dataset:\n"
+            "      class: tests.conftest.MockDataset\n"
+            "    model: base\n",
+        )
+        result_dir = tmp_path / "out"
+
+        first = EvalSession(
+            config_path=str(cfg_path),
+            result_dir_override=str(result_dir),
+        )
+        first.prepare_prelaunch()
+        first._stamp_deterministic_seed_contract()
+        await first._persist_effective_config()
+        target = result_dir / "effective_config.yaml"
+        original = target.read_text()
+        persisted = yaml.safe_load(original)
+        assert persisted["deterministic"] is True
+        assert persisted["models"]["base"]["args"] == {"max_tokens": 32}
+        original_contract = persisted[_DETERMINISTIC_SEED_CONTRACT_KEY]
+
+        replayed = EvalSession(
+            config_path=str(target),
+            result_dir_override=str(tmp_path / "replayed"),
+        )
+        replayed.prepare_prelaunch()
+        replayed._stamp_deterministic_seed_contract()
+        assert (
+            replayed._reified_config[_DETERMINISTIC_SEED_CONTRACT_KEY]
+            == original_contract
+        )
+
+        resumed = EvalSession(
+            config_path=str(cfg_path),
+            resume=True,
+            result_dir_override=str(result_dir),
+        )
+        resumed.prepare_prelaunch()
+        resumed._stamp_deterministic_seed_contract()
+        await resumed._persist_effective_config()
+
+        assert target.read_text() == original
+
+    @pytest.mark.anyio
+    async def test_deterministic_seed_contract_drift_aborts_resume(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        cfg_path = _write_yaml(
+            tmp_path,
+            "cfg.yaml",
+            "deterministic: true\n"
+            "models:\n"
+            "  m:\n"
+            "    name: mock-chat\n"
+            "    type: chat\n"
+            "tasks:\n"
+            "  eval:\n"
+            "    class: tests.unit.core.runners.test_runner.MockTask\n"
+            "    dataset:\n"
+            "      class: tests.conftest.MockDataset\n"
+            "    model: m\n",
+        )
+        result_dir = tmp_path / "out"
+        first = EvalSession(
+            config_path=str(cfg_path),
+            result_dir_override=str(result_dir),
+        )
+        first.prepare_prelaunch()
+        first._stamp_deterministic_seed_contract()
+        await first._persist_effective_config()
+
+        monkeypatch.setattr(
+            "sieval.cli.leaderboard.session.DETERMINISTIC_DEFAULT_SEED", 1
+        )
+        replayed = EvalSession(
+            config_path=str(result_dir / "effective_config.yaml"),
+            result_dir_override=str(tmp_path / "replayed"),
+        )
+        replayed.prepare_prelaunch()
+        with pytest.raises(RuntimeError, match="persisted deterministic-seed contract"):
+            replayed._stamp_deterministic_seed_contract()
+
+        resumed = EvalSession(
+            config_path=str(cfg_path),
+            resume=True,
+            result_dir_override=str(result_dir),
+        )
+        resumed.prepare_prelaunch()
+        resumed._stamp_deterministic_seed_contract()
+
+        with pytest.raises(RuntimeError, match="_sieval_deterministic_seed_contract"):
+            await resumed._persist_effective_config()
+
+    def test_explicit_seed_contract_ignores_unused_default_changes(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cfg_path = _write_yaml(
+            tmp_path,
+            "cfg.yaml",
+            "deterministic: true\n"
+            "models:\n"
+            "  m:\n"
+            "    name: mock-chat\n"
+            "    type: chat\n"
+            "    args:\n"
+            "      seed: 42\n"
+            "tasks:\n"
+            "  eval:\n"
+            "    class: tests.unit.core.runners.test_runner.MockTask\n"
+            "    dataset:\n"
+            "      class: tests.conftest.MockDataset\n"
+            "    model: m\n",
+        )
+        first = EvalSession(config_path=str(cfg_path))
+        first.prepare_prelaunch()
+        first._stamp_deterministic_seed_contract()
+        original = first._reified_config[_DETERMINISTIC_SEED_CONTRACT_KEY]
+
+        monkeypatch.setattr(
+            "sieval.cli.leaderboard.session.DETERMINISTIC_DEFAULT_SEED", 1
+        )
+        replayed = EvalSession(config_path=str(cfg_path))
+        replayed.prepare_prelaunch()
+        replayed._stamp_deterministic_seed_contract()
+
+        assert replayed._reified_config[_DETERMINISTIC_SEED_CONTRACT_KEY] == original
+
+    @pytest.mark.anyio
+    async def test_legacy_baked_automatic_seed_aborts_resume(self, tmp_path: Path):
+        cfg_path = _write_yaml(
+            tmp_path,
+            "cfg.yaml",
+            "models:\n  base:\n    name: m\n    args:\n      max_tokens: 32\n",
+        )
+        result_dir = tmp_path / "out"
+        result_dir.mkdir()
+        _write_yaml(
+            result_dir,
+            "effective_config.yaml",
+            "deterministic: true\n"
+            "models:\n"
+            "  base:\n"
+            "    name: m\n"
+            "    args:\n"
+            "      max_tokens: 32\n"
+            "      seed: 0\n"
+            f"result_dir: {result_dir}\n",
+        )
+
+        resumed = EvalSession(
+            config_path=str(cfg_path),
+            resume=True,
+            deterministic_override=True,
+            result_dir_override=str(result_dir),
+        )
+        with pytest.raises(RuntimeError, match=r"models\.base\.args\.seed"):
+            await resumed._persist_effective_config()
 
     @pytest.mark.anyio
     async def test_mismatched_deterministic_raises(self, tmp_path: Path):

--- a/tests/unit/core/models/test_dialect_registry.py
+++ b/tests/unit/core/models/test_dialect_registry.py
@@ -33,6 +33,8 @@ from sieval.core.models.dialect_registry import (
     DialectImplementationStatus,
     DialectNotImplemented,
     DialectRegistryError,
+    DialectSpec,
+    RequestSeedSupport,
     UnknownDialect,
     _normalized_symbols,
     _outcomes_from_decisions,
@@ -105,6 +107,26 @@ class TestDialectDescriptors:
         )
         assert "vllm_native" in encoded
         assert "openai_chat" in encoded
+        for value in dialect_registry_to_json().values():
+            assert isinstance(value, dict)
+            assert "request_seed_support" in value
+
+    def test_request_seed_support_is_required_and_explicit(self) -> None:
+        field = DialectSpec.__dataclass_fields__["request_seed_support"]
+        assert field.default is dataclasses.MISSING
+        assert field.default_factory is dataclasses.MISSING
+        assert {
+            dialect_id: spec.request_seed_support
+            for dialect_id, spec in DIALECT_SPECS.items()
+        } == {
+            "openai_chat": RequestSeedSupport.SUPPORTED,
+            "openai_completions": RequestSeedSupport.SUPPORTED,
+            "openai_responses": RequestSeedSupport.RESERVED,
+            "anthropic_messages": RequestSeedSupport.RESERVED,
+            "google_genai": RequestSeedSupport.RESERVED,
+            "sglang_native": RequestSeedSupport.RESERVED,
+            "vllm_native": RequestSeedSupport.RESERVED,
+        }
 
     def test_only_pr1_dialects_are_active_and_bindable(self) -> None:
         active = {
@@ -126,6 +148,11 @@ class TestDialectDescriptors:
             ({"dialect_id": ""}, "dialect_id"),
             ({"connection_family": ""}, "connection_family"),
             ({"implementation_status": "active"}, "implementation_status"),
+            ({"request_seed_support": "supported"}, "request_seed_support"),
+            (
+                {"request_seed_support": RequestSeedSupport.RESERVED},
+                "cannot reserve request-seed support",
+            ),
             (
                 {
                     "capability_outcomes": dict.fromkeys(

--- a/tests/unit/core/models/test_model_derivation.py
+++ b/tests/unit/core/models/test_model_derivation.py
@@ -87,6 +87,24 @@ class TestModelDerivation:
         assert child._limiter is None
         assert child._parent_limiter is None
 
+    def test_without_args_removes_default_without_mutating_parent(self, base_gen):
+        seeded = base_gen.with_args(seed=0, temperature=0.5)
+
+        child = seeded.without_args("seed")
+
+        assert seeded._kwargs["seed"] == 0
+        assert child._kwargs == {"temperature": 0.5}
+        assert "seed" not in child.meta()["default_params"]
+
+    @pytest.mark.parametrize("names", [(), ("",)])
+    def test_without_args_requires_non_empty_names(self, base_gen, names):
+        with pytest.raises(ValueError, match="non-empty"):
+            base_gen.without_args(*names)
+
+    def test_without_args_cannot_remove_binding_resources(self, base_gen):
+        with pytest.raises(ValueError, match="binding resources"):
+            base_gen.without_args("api_key")
+
     def test_with_args_new_limiter_total_tokens(self, base_gen):
         """Child limiter capacity equals the requested concurrency_limit."""
         child = base_gen.with_args(concurrency_limit=16)

--- a/tests/unit/core/models/transports/test_sglang.py
+++ b/tests/unit/core/models/transports/test_sglang.py
@@ -316,6 +316,23 @@ class TestWirePlumbing:
         assert resp.request_params["sampling_params"] == {"temperature": 0.0}
 
     @pytest.mark.anyio
+    async def test_explicit_seed_is_not_persisted_when_wire_cannot_transmit_it(self):
+        t, post = _make_transport(
+            {"text": "x", "meta_info": _meta(prompt_tokens=1, completion_tokens=1)}
+        )
+
+        resp = await t.arun(_request("prompt", sampling=SamplingParams(seed=7)))
+
+        body = post.call_args.kwargs["body"]
+        assert "seed" not in body
+        assert "seed" not in _sampling(body)
+        assert resp.request_params is not None
+        assert "seed" not in resp.request_params
+        sampling_params = resp.request_params["sampling_params"]
+        assert isinstance(sampling_params, dict)
+        assert "seed" not in sampling_params
+
+    @pytest.mark.anyio
     async def test_absent_provider_model_id_stays_none(self):
         t, _ = _make_transport({"text": "x", "meta_info": _meta(prompt_tokens=1)})
         resp = await t.arun(_request("hi"))


### PR DESCRIPTION
## Type

- fix — bug fix or alignment correction

## Summary

- Add typed per-request seed-support declarations to `DialectSpec`.
- Deterministic mode previously treated per-request `seed` as universal and baked `seed: 0` into every base model configuration.
- Work on #25 exposed the problem through OpenAI Responses, but the issue is protocol-general: request-seed support differs across current and future APIs.
- Model this capability explicitly in `DialectSpec` instead of special-casing OpenAI Responses; reserved dialects must declare a supported or unsupported outcome before their binders become active.
- Freeze seed value, provenance, scope, and inheritance policy during prelaunch reconciliation.
- Reuse the same frozen decisions for model bindings, external roles, task candidates, and the persisted deterministic contract.
- Inject the automatic seed only for supporting dialects. Unsupported dialects omit automatic seeds and strip inherited automatic request seeds, while preserving explicit user values for pre-I/O dialect audit.
- Keep legacy SGLang deterministic control engine-scoped rather than injecting a request seed.
- Resolve task execution from each task’s frozen prelaunch candidate binding so reconciliation, contract evidence, and wire execution cannot drift.
- Existing deterministic runs with a baked `models.<name>.args.seed: 0` cannot resume across this change; restart them from the source configuration.
- This is a prerequisite for #25; it does not activate the reserved `openai_responses` dialect.

## Related Issues

Refs #25

## Test Plan

### Automated

- [x] Modified files pass Ruff lint and format checks
- [x] Modified production files pass `ty check`
- [x] Relevant regression suite passes (`528 passed`)
- [x] Full non-benchmark test coverage passes (`5764 passed`, `56 skipped`)
- [x] `git diff --check` passes

## Checklist

### Required (all PRs)

- [x] PR title follows conventional format (`type(scope): description`)
- [x] No internal paths, credentials, or personal info in committed files
- [x] AI-generated code has `AI-Generated Code - <model> (<provider>)` in module docstring
- [x] No new upper-layer dependencies added to `core/`
- [x] Deleted code verified — no remaining call sites depend on it

### If: Breaking Change

- [x] Described what breaks and migration path in Summary
- [x] Existing tests updated to reflect new behavior