### PR TITLE
fix(models): make request audits source-bound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Request audits now verify consumed Chat aggregates independently of their
+  lowering helpers, recursively freeze prepared wire bodies, and derive stored
+  request parameters from the exact body handed to the provider SDK.
+- Empty structured-output names and empty dialect-option keys are rejected with
+  `RequestAuditError`. Use `name=None` to request the dialect's default schema
+  name; empty option keys must be removed or renamed.
+
+### Changed
+
+- **BREAKING — custom dialect preparation evidence.** `PreparedRequest` now
+  accepts only `operation`, the complete provider `body`, and optional response
+  `context`; call `prepared.thaw_body()` once when invoking an SDK.
+  `RequestAudit.consumed()` now requires `WireObservation` or `WireVerifier`
+  evidence, and `PassthroughObservation` is removed. Identity-preserving fields
+  should use `WireObservation(destination)` so the expected value comes from
+  the audited request leaf; aggregate or transformed fields should use an
+  independent `WireVerifier`.
+
 ## [0.8.0] - 2026-08-14
 
 A minor bump, and a wide one: the on-disk record shape, several `report.json`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,28 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
-
-### Fixed
-
-- Request audits now verify consumed Chat aggregates independently of their
-  lowering helpers, recursively freeze prepared wire bodies, and derive stored
-  request parameters from the exact body handed to the provider SDK.
-- Empty structured-output names and empty dialect-option keys are rejected with
-  `RequestAuditError`. Use `name=None` to request the dialect's default schema
-  name; empty option keys must be removed or renamed.
-
-### Changed
-
-- **BREAKING — custom dialect preparation evidence.** `PreparedRequest` now
-  accepts only `operation`, the complete provider `body`, and optional response
-  `context`; call `prepared.thaw_body()` once when invoking an SDK.
-  `RequestAudit.consumed()` now requires `WireObservation` or `WireVerifier`
-  evidence, and `PassthroughObservation` is removed. Identity-preserving fields
-  should use `WireObservation(destination)` so the expected value comes from
-  the audited request leaf; aggregate or transformed fields should use an
-  independent `WireVerifier`.
-
 ## [0.8.0] - 2026-08-14
 
 A minor bump, and a wide one: the on-disk record shape, several `report.json`

--- a/sieval/core/models/_shared.py
+++ b/sieval/core/models/_shared.py
@@ -12,8 +12,43 @@ AI-Generated Code - Claude Opus 5 (1M context) (Anthropic)
 
 import math
 from collections.abc import Mapping
+from types import MappingProxyType
+from typing import Never, Self, cast
 
 from sieval.core.types import JSONValue
+
+
+class _FrozenJSONList(list[JSONValue]):
+    """List-shaped JSON value that rejects mutation while preserving equality."""
+
+    def _immutable(self, *args: object, **kwargs: object) -> Never:
+        del self, args, kwargs
+        raise TypeError("frozen JSON sequences do not support mutation")
+
+    def __copy__(self) -> Self:
+        return self
+
+    def __deepcopy__(self, memo: dict[int, object]) -> Self:
+        del memo
+        return self
+
+
+for _method_name in (
+    "append",
+    "clear",
+    "extend",
+    "insert",
+    "pop",
+    "remove",
+    "reverse",
+    "sort",
+    "__delitem__",
+    "__iadd__",
+    "__imul__",
+    "__setitem__",
+):
+    setattr(_FrozenJSONList, _method_name, _FrozenJSONList._immutable)
+del _method_name
 
 
 def copy_json_value(value: object, path: str) -> JSONValue:
@@ -42,6 +77,55 @@ def copy_json_value(value: object, path: str) -> JSONValue:
             for index, item in enumerate(value)
         ]
     raise TypeError(f"{path} contains non-JSON value {type(value).__name__}")
+
+
+def freeze_json_value(value: object, path: str) -> JSONValue:
+    """Detach and recursively freeze one JSON-compatible value."""
+
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError(f"{path} must not contain non-finite floats")
+        return value
+    if isinstance(value, Mapping):
+        return freeze_json_mapping(cast(Mapping[str, JSONValue], value), path)
+    if isinstance(value, (list, tuple)):
+        return _FrozenJSONList(
+            freeze_json_value(item, f"{path}[{index}]")
+            for index, item in enumerate(value)
+        )
+    raise TypeError(f"{path} contains non-JSON value {type(value).__name__}")
+
+
+def freeze_json_mapping(
+    value: Mapping[str, JSONValue], path: str
+) -> Mapping[str, JSONValue]:
+    """Detach and recursively freeze a JSON mapping."""
+
+    copied: dict[str, JSONValue] = {}
+    for key, item in value.items():
+        if not isinstance(key, str):
+            raise TypeError(f"{path} keys must be strings")
+        copied[key] = freeze_json_value(item, f"{path}.{key}")
+    return MappingProxyType(copied)
+
+
+def thaw_json_mapping(
+    value: Mapping[str, JSONValue], path: str
+) -> dict[str, JSONValue]:
+    """Return a detached, mutable plain-JSON copy of a frozen mapping."""
+
+    thawed = copy_json_value(value, path)
+    if not isinstance(thawed, dict):
+        raise TypeError(f"{path} must be a mapping")
+    return cast(dict[str, JSONValue], thawed)
+
+
+def thaw_json_value(value: object, path: str) -> JSONValue:
+    """Return a detached, mutable plain-JSON copy of any frozen JSON value."""
+
+    return copy_json_value(value, path)
 
 
 def named_json_value(value: object, name: str) -> JSONValue:

--- a/sieval/core/models/_shared.py
+++ b/sieval/core/models/_shared.py
@@ -33,6 +33,9 @@ class _FrozenJSONList(list[JSONValue]):
         return self
 
 
+# ``list`` exposes several mutation spellings, including in-place operators.
+# Install the same guard for all of them so nested JSON sequences remain
+# list-compatible without leaving a normal mutation path open.
 for _method_name in (
     "append",
     "clear",
@@ -120,12 +123,6 @@ def thaw_json_mapping(
     if not isinstance(thawed, dict):
         raise TypeError(f"{path} must be a mapping")
     return cast(dict[str, JSONValue], thawed)
-
-
-def thaw_json_value(value: object, path: str) -> JSONValue:
-    """Return a detached, mutable plain-JSON copy of any frozen JSON value."""
-
-    return copy_json_value(value, path)
 
 
 def named_json_value(value: object, name: str) -> JSONValue:

--- a/sieval/core/models/dialect.py
+++ b/sieval/core/models/dialect.py
@@ -8,13 +8,16 @@ channels without a condition language or solver.
 AI-Generated Code - GPT-5.6 (OpenAI)
 """
 
+import json
 from collections.abc import Callable, Mapping
+from copy import deepcopy
 from dataclasses import dataclass, fields
 from enum import StrEnum
-from typing import Protocol, runtime_checkable
+from typing import Protocol, cast, runtime_checkable
 
 from sieval.core.types import JSONValue
 
+from ._shared import copy_json_value, freeze_json_mapping, thaw_json_mapping
 from .ir import (
     ChatInput,
     CompletionInput,
@@ -52,8 +55,32 @@ class Guarantee(StrEnum):
 
 
 @dataclass(frozen=True)
+class WireObservation:
+    """A wire destination whose expected value is the audited request leaf."""
+
+    destination: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if not self.destination or any(
+            not isinstance(item, str) or not item for item in self.destination
+        ):
+            raise ValueError("wire observation destination must be non-empty keys")
+
+
+@runtime_checkable
+class WireVerifier(Protocol):
+    """Independently compare an audited source value with the final wire body."""
+
+    def verify(self, body: Mapping[str, JSONValue]) -> str | None: ...
+
+
+type WireEvidence = WireObservation | WireVerifier
+
+
+@dataclass(frozen=True)
 class Consumed:
     path: str
+    wire_evidence: tuple[WireEvidence, ...]
 
 
 @dataclass(frozen=True)
@@ -78,20 +105,70 @@ type AuditDecision = Consumed | Rejected | NoOp | Passthrough
 
 
 @dataclass(frozen=True)
-class PassthroughObservation:
-    destination: str
-    value: object
-
-
-@dataclass(frozen=True)
 class PreparedRequest:
-    """Dialect-local wire preparation plus explicit audit evidence."""
+    """Dialect-local complete wire request awaiting audit verification.
+
+    ``body`` is the sole authority for provider request fields.  ``execute``
+    may use ``context`` for response lifting, but must not reconstruct or add
+    request fields outside this body.
+    """
 
     operation: str
     body: Mapping[str, JSONValue]
-    consumed_paths: frozenset[str]
-    passthrough: Mapping[str, PassthroughObservation]
     context: object | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "body",
+            freeze_json_mapping(self.body, "prepared wire body"),
+        )
+
+    def thaw_body(self) -> dict[str, JSONValue]:
+        """Return one mutable, detached copy for a provider SDK call."""
+
+        return thaw_json_mapping(self.body, "prepared wire body")
+
+
+_MISSING_WIRE_VALUE = object()
+
+
+def _canonical_json(value: object) -> str:
+    copied = copy_json_value(value, "prepared wire value")
+    return json.dumps(
+        copied,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    )
+
+
+def _wire_value(body: Mapping[str, JSONValue], destination: tuple[str, ...]) -> object:
+    current: object = body
+    for key in destination:
+        if not isinstance(current, Mapping):
+            return _MISSING_WIRE_VALUE
+        mapping = cast(Mapping[str, object], current)
+        if key not in mapping:
+            return _MISSING_WIRE_VALUE
+        current = mapping[key]
+    return current
+
+
+def _wire_destination(destination: tuple[str, ...]) -> str:
+    return "body." + ".".join(destination)
+
+
+def _snapshot_audit_value(value: object) -> object:
+    return deepcopy(value)
+
+
+def _same_audit_value(left: object, right: object) -> bool:
+    try:
+        return _canonical_json(left) == _canonical_json(right)
+    except (TypeError, ValueError):
+        return left == right
 
 
 def _input_leaves(req: Request) -> dict[str, object]:
@@ -171,12 +248,22 @@ class RequestAudit:
     """Require exactly one observable decision for each active request leaf."""
 
     def __init__(self, active: Mapping[str, object]):
-        self._active = dict(active)
+        self._active = {
+            path: _snapshot_audit_value(value) for path, value in active.items()
+        }
         self._decisions: dict[str, AuditDecision] = {}
 
     @property
     def active(self) -> Mapping[str, object]:
-        return dict(self._active)
+        return {
+            path: _snapshot_audit_value(value) for path, value in self._active.items()
+        }
+
+    @property
+    def active_paths(self) -> tuple[str, ...]:
+        """Return active leaf names without copying their potentially large values."""
+
+        return tuple(self._active)
 
     @property
     def decisions(self) -> Mapping[str, AuditDecision]:
@@ -189,8 +276,36 @@ class RequestAudit:
             raise RequestAuditError(f"request leaf {path!r} was accounted for twice")
         self._decisions[path] = decision
 
-    def consumed(self, path: str) -> None:
-        self._record(path, Consumed(path))
+    def require_matches_request(self, req: Request) -> None:
+        """Reject an audit created for different or subsequently changed input."""
+
+        current = active_request_leaves(req)
+        audit_paths = set(self._active)
+        current_paths = set(current)
+        missing = sorted(current_paths - audit_paths)
+        extra = sorted(audit_paths - current_paths)
+        changed = sorted(
+            path
+            for path in audit_paths & current_paths
+            if not _same_audit_value(self._active[path], current[path])
+        )
+        if missing or extra or changed:
+            raise RequestAuditError(
+                "audit does not match request: "
+                f"missing={missing}, extra={extra}, changed={changed}"
+            )
+
+    def consumed(self, path: str, *wire_evidence: WireEvidence) -> None:
+        if not wire_evidence:
+            raise RequestAuditError(
+                f"consumed request leaf {path!r} requires wire evidence"
+            )
+        if not all(
+            isinstance(evidence, (WireObservation, WireVerifier))
+            for evidence in wire_evidence
+        ):
+            raise TypeError("wire evidence must be WireObservation or WireVerifier")
+        self._record(path, Consumed(path, tuple(wire_evidence)))
 
     def rejected(self, path: str, reason: str) -> None:
         self._record(path, Rejected(path, reason))
@@ -203,6 +318,8 @@ class RequestAudit:
     def passthrough(self, path: str, destination: str) -> None:
         if not path.startswith("dialect_options."):
             raise RequestAuditError("only dialect options may use Passthrough")
+        if not isinstance(destination, str) or not destination:
+            raise RequestAuditError("Passthrough destination must be non-empty")
         self._record(path, Passthrough(path, destination))
 
     def raise_rejections(self) -> None:
@@ -218,36 +335,55 @@ class RequestAudit:
                 "unaccounted request leaves: " + ", ".join(sorted(missing))
             )
 
-        consumed = {
-            path
-            for path, decision in self._decisions.items()
-            if isinstance(decision, Consumed)
-        }
-        if consumed != set(prepared.consumed_paths):
-            missing_observation = consumed - set(prepared.consumed_paths)
-            unclaimed = set(prepared.consumed_paths) - consumed
-            detail: list[str] = []
-            if missing_observation:
-                detail.append("unobserved=" + ",".join(sorted(missing_observation)))
-            if unclaimed:
-                detail.append("unclaimed=" + ",".join(sorted(unclaimed)))
-            raise RequestAuditError(
-                "prepared consumption mismatch: " + "; ".join(detail)
-            )
+        verified: set[int] = set()
+        for path, decision in self._decisions.items():
+            if isinstance(decision, Consumed):
+                evidence_items = decision.wire_evidence
+            elif isinstance(decision, Passthrough):
+                option_key = path.removeprefix("dialect_options.")
+                if not option_key:
+                    raise RequestAuditError("dialect option keys must be non-empty")
+                evidence_items = (WireObservation((decision.destination, option_key)),)
+            else:
+                continue
 
-        expected_passthrough = {
-            path: decision
-            for path, decision in self._decisions.items()
-            if isinstance(decision, Passthrough)
-        }
-        if set(expected_passthrough) != set(prepared.passthrough):
-            raise RequestAuditError("prepared passthrough paths do not match decisions")
-        for path, decision in expected_passthrough.items():
-            observed = prepared.passthrough[path]
-            if observed.destination != decision.destination:
-                raise RequestAuditError(f"passthrough destination changed for {path!r}")
-            if observed.value != self._active[path]:
-                raise RequestAuditError(f"passthrough value changed for {path!r}")
+            for evidence in evidence_items:
+                if isinstance(evidence, WireObservation):
+                    actual = _wire_value(prepared.body, evidence.destination)
+                    destination = _wire_destination(evidence.destination)
+                    if actual is _MISSING_WIRE_VALUE:
+                        raise RequestAuditError(
+                            f"prepared wire field {destination!r} is missing for "
+                            f"{path!r}"
+                        )
+                    try:
+                        expected = _canonical_json(self._active[path])
+                    except (TypeError, ValueError) as exc:
+                        raise RequestAuditError(
+                            f"request leaf {path!r} requires a WireVerifier"
+                        ) from exc
+                    if _canonical_json(actual) != expected:
+                        raise RequestAuditError(
+                            f"prepared wire value changed for {path!r} at "
+                            f"{destination!r}"
+                        )
+                    continue
+
+                verifier_id = id(evidence)
+                if verifier_id in verified:
+                    continue
+                verified.add(verifier_id)
+                mismatch = evidence.verify(prepared.body)
+                if mismatch is not None and (
+                    not isinstance(mismatch, str) or not mismatch.strip()
+                ):
+                    raise TypeError(
+                        "WireVerifier.verify() must return None or a non-empty string"
+                    )
+                if mismatch is not None:
+                    raise RequestAuditError(
+                        f"prepared wire mismatch for {path!r}: {mismatch}"
+                    )
 
 
 def request_capability(path: str) -> str | None:

--- a/sieval/core/models/dialect.py
+++ b/sieval/core/models/dialect.py
@@ -111,6 +111,10 @@ class PreparedRequest:
     ``body`` is the sole authority for provider request fields.  ``execute``
     may use ``context`` for response lifting, but must not reconstruct or add
     request fields outside this body.
+
+    ``model`` and ``stream_options`` carry no audit evidence: neither derives
+    from a request leaf.  Everything that lowers one must be provable through
+    ``Consumed.wire_evidence``, and ``dialect_options`` may not override either.
     """
 
     operation: str
@@ -255,6 +259,11 @@ class RequestAudit:
 
     @property
     def active(self) -> Mapping[str, object]:
+        """Return active leaves with their values, each a detached snapshot.
+
+        Costs one deep copy per leaf; prefer ``active_paths`` to iterate names.
+        """
+
         return {
             path: _snapshot_audit_value(value) for path, value in self._active.items()
         }

--- a/sieval/core/models/dialects/openai_chat.py
+++ b/sieval/core/models/dialects/openai_chat.py
@@ -10,10 +10,12 @@ AI-Generated Code - GPT-5.6 (OpenAI)
 import json
 import math
 from collections.abc import Callable, Mapping, Sequence
+from copy import deepcopy
 from dataclasses import dataclass
 from types import MappingProxyType
 from typing import Any, cast
 
+from sieval.core.models._shared import copy_json_value, thaw_json_mapping
 from sieval.core.models.capabilities import (
     CAPABILITY_KEYS,
     Capability,
@@ -30,10 +32,11 @@ from sieval.core.models.dialect import (
     OutputContract,
     OutputContractError,
     OutputRule,
-    PassthroughObservation,
     PreparedRequest,
     RequestAudit,
     RuntimePlanView,
+    WireEvidence,
+    WireObservation,
     active_request_leaves,
     validate_reasoning,
     validate_request_invariants,
@@ -58,6 +61,7 @@ from sieval.core.models.ir import (
     TopKEntry,
     UsageStats,
 )
+from sieval.core.types import JSONValue
 
 from ._usage import usage_stats
 
@@ -242,7 +246,6 @@ _CANONICAL_WIRE_KEYS = BINDING_RESOURCE_KEYS | frozenset(
 
 @dataclass(frozen=True)
 class _ChatContext:
-    messages: list[dict[str, Any]]
     request: Request
 
 
@@ -478,12 +481,221 @@ def _response_format(req: Request) -> dict[str, Any] | None:
     if params.format == "json_object":
         return {"type": "json_object"}
     schema: dict[str, Any] = {
-        "name": params.name or "response",
+        "name": params.name if params.name is not None else "response",
         "schema": dict(params.schema or {}),
     }
     if params.strict is not None:
         schema["strict"] = params.strict
     return {"type": "json_schema", "json_schema": schema}
+
+
+def _canonical_message_json(value: object) -> str:
+    return json.dumps(
+        copy_json_value(value, "chat message value"),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    )
+
+
+def _verify_json_string(
+    actual: object,
+    expected: object,
+    path: str,
+) -> str | None:
+    if not isinstance(actual, str):
+        return f"{path} must be a string"
+    if isinstance(expected, str):
+        if actual != expected:
+            return f"{path} changed"
+        return None
+    try:
+        parsed = json.loads(actual)
+    except json.JSONDecodeError:
+        return f"{path} is not valid JSON"
+    if _canonical_message_json(parsed) != _canonical_message_json(expected):
+        return f"{path} changed"
+    return None
+
+
+def _verify_inline_part(
+    expected: TextPart | ImagePart,
+    actual: object,
+    path: str,
+) -> str | None:
+    if not isinstance(actual, Mapping):
+        return f"{path} must be an object"
+    actual_mapping = cast(Mapping[str, object], actual)
+    if isinstance(expected, TextPart):
+        if set(actual_mapping) != {"type", "text"}:
+            return f"{path} has unexpected text-part fields"
+        if (
+            actual_mapping.get("type") != "text"
+            or actual_mapping.get("text") != expected.text
+        ):
+            return f"{path} changed"
+        return None
+
+    if set(actual_mapping) != {"type", "image_url"}:
+        return f"{path} has unexpected image-part fields"
+    if actual_mapping.get("type") != "image_url":
+        return f"{path}.type changed"
+    image = actual_mapping.get("image_url")
+    if not isinstance(image, Mapping):
+        return f"{path}.image_url must be an object"
+    image_mapping = cast(Mapping[str, object], image)
+    expected_keys = {"url"}
+    if expected.detail is not None:
+        expected_keys.add("detail")
+    if set(image_mapping) != expected_keys:
+        return f"{path}.image_url fields changed"
+    expected_url = (
+        expected.url
+        if expected.url is not None
+        else (
+            f"data:{expected.media_type or 'application/octet-stream'};"
+            f"base64,{expected.data}"
+        )
+    )
+    if image_mapping.get("url") != expected_url:
+        return f"{path}.image_url.url changed"
+    if expected.detail is not None and image_mapping.get("detail") != expected.detail:
+        return f"{path}.image_url.detail changed"
+    return None
+
+
+def _verify_tool_calls(
+    expected: list[ToolCallPart],
+    actual: object,
+    path: str,
+) -> str | None:
+    if not isinstance(actual, list):
+        return f"{path} must be a list"
+    if len(actual) != len(expected):
+        return f"{path} count changed"
+    for index, (source, item) in enumerate(zip(expected, actual, strict=True)):
+        item_path = f"{path}[{index}]"
+        if not isinstance(item, Mapping):
+            return f"{item_path} must be an object"
+        if set(item) != {"id", "type", "function"}:
+            return f"{item_path} fields changed"
+        if item.get("id") != source.call_id or item.get("type") != "function":
+            return f"{item_path} identity changed"
+        function = item.get("function")
+        if not isinstance(function, Mapping):
+            return f"{item_path}.function must be an object"
+        if set(function) != {"name", "arguments"}:
+            return f"{item_path}.function fields changed"
+        if function.get("name") != source.name:
+            return f"{item_path}.function.name changed"
+        mismatch = _verify_json_string(
+            function.get("arguments"),
+            source.arguments,
+            f"{item_path}.function.arguments",
+        )
+        if mismatch is not None:
+            return mismatch
+    return None
+
+
+def _verify_message(
+    expected: ChatMessage,
+    actual: object,
+    index: int,
+) -> str | None:
+    path = f"body.messages[{index}]"
+    if not isinstance(actual, Mapping):
+        return f"{path} must be an object"
+    actual_mapping = cast(Mapping[str, object], actual)
+    if actual_mapping.get("role") != expected.role:
+        return f"{path}.role changed"
+    if expected.name is None:
+        if "name" in actual_mapping:
+            return f"{path}.name was added"
+    elif actual_mapping.get("name") != expected.name:
+        return f"{path}.name changed"
+
+    inline = [
+        part for part in expected.content if isinstance(part, TextPart | ImagePart)
+    ]
+    calls = [part for part in expected.content if isinstance(part, ToolCallPart)]
+    results = [part for part in expected.content if isinstance(part, ToolResultPart)]
+    allowed = {"role", "content"}
+    if expected.name is not None:
+        allowed.add("name")
+
+    if results:
+        if len(results) != 1 or calls or inline:
+            return f"{path} has an invalid tool-result source shape"
+        allowed.add("tool_call_id")
+        if set(actual_mapping) != allowed:
+            return f"{path} tool-result fields changed"
+        result = results[0]
+        if actual_mapping.get("tool_call_id") != result.call_id:
+            return f"{path}.tool_call_id changed"
+        return _verify_json_string(
+            actual_mapping.get("content"),
+            result.result,
+            f"{path}.content",
+        )
+
+    if calls:
+        allowed.add("tool_calls")
+    if set(actual_mapping) != allowed:
+        return f"{path} fields changed"
+    if calls:
+        mismatch = _verify_tool_calls(
+            calls,
+            actual_mapping.get("tool_calls"),
+            f"{path}.tool_calls",
+        )
+        if mismatch is not None:
+            return mismatch
+
+    if "content" not in actual_mapping:
+        return f"{path}.content is missing"
+    content = actual_mapping["content"]
+    if not inline:
+        return None if content is None else f"{path}.content changed"
+    if all(isinstance(part, TextPart) for part in inline):
+        expected_text = "".join(cast(TextPart, part).text for part in inline)
+        return None if content == expected_text else f"{path}.content changed"
+    if not isinstance(content, list):
+        return f"{path}.content must be a list"
+    if len(content) != len(inline):
+        return f"{path}.content item count changed"
+    for part_index, (source, item) in enumerate(zip(inline, content, strict=True)):
+        mismatch = _verify_inline_part(
+            source,
+            item,
+            f"{path}.content[{part_index}]",
+        )
+        if mismatch is not None:
+            return mismatch
+    return None
+
+
+@dataclass(frozen=True)
+class _ChatMessagesVerifier:
+    source: ChatInput
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "source", deepcopy(self.source))
+
+    def verify(self, body: Mapping[str, JSONValue]) -> str | None:
+        messages = body.get("messages")
+        if not isinstance(messages, list):
+            return "body.messages must be a list"
+        if len(messages) != len(self.source.messages):
+            return "body.messages count changed"
+        for index, (expected, actual) in enumerate(
+            zip(self.source.messages, messages, strict=True)
+        ):
+            mismatch = _verify_message(expected, actual, index)
+            if mismatch is not None:
+                return mismatch
+        return None
 
 
 class OpenAIChatDialect:
@@ -516,12 +728,13 @@ class OpenAIChatDialect:
     def validate_request(
         self, req: Request, audit: RequestAudit, plan: RuntimePlanView
     ) -> None:
+        audit.require_matches_request(req)
         del plan
         reorders_message = isinstance(req.input, ChatInput) and any(
             _has_inline_content_after_tool_call(message)
             for message in req.input.messages
         )
-        for path in audit.active:
+        for path in audit.active_paths:
             if path == "dialect_options":
                 audit.noop(
                     path,
@@ -580,6 +793,11 @@ class OpenAIChatDialect:
                 req.structured_output.format not in {"json_object", "json_schema"}
             ):
                 audit.rejected(path, "unsupported Chat Completions response format")
+            elif path == "structured_output.name" and req.structured_output.name == "":
+                audit.rejected(
+                    path,
+                    "Chat Completions structured-output name must be non-empty",
+                )
             elif (
                 path
                 in {
@@ -595,7 +813,9 @@ class OpenAIChatDialect:
                 )
             elif path.startswith("dialect_options."):
                 key = path.removeprefix("dialect_options.")
-                if key in {"prefill", "prefix"}:
+                if not key:
+                    audit.rejected(path, "dialect option keys must be non-empty")
+                elif key in {"prefill", "prefix"}:
                     audit.rejected(path, _PREFILL_UNSUPPORTED_REASON)
                 elif key in _CANONICAL_WIRE_KEYS:
                     audit.rejected(
@@ -604,17 +824,18 @@ class OpenAIChatDialect:
                     )
 
     def prepare(self, req: Request, audit: RequestAudit) -> PreparedRequest:
+        audit.require_matches_request(req)
+        audit.raise_rejections()
         if not isinstance(req.input, ChatInput):
             raise TypeError("openai_chat requires ChatInput")
+        messages_verifier = _ChatMessagesVerifier(req.input)
         messages = [_message_to_wire(message) for message in req.input.messages]
         params: dict[str, Any] = {}
-        consumed: set[str] = set()
-        passthrough: dict[str, PassthroughObservation] = {}
+        active_paths = frozenset(audit.active_paths)
 
-        def consume(path: str) -> None:
-            if path in audit.active and path not in audit.decisions:
-                audit.consumed(path)
-                consumed.add(path)
+        def consume(path: str, *wire: WireEvidence) -> None:
+            if path in active_paths and path not in audit.decisions:
+                audit.consumed(path, *wire)
 
         for path in (
             "input.chat",
@@ -626,7 +847,7 @@ class OpenAIChatDialect:
             "input.modality.tool_call",
             "input.modality.tool_result",
         ):
-            consume(path)
+            consume(path, messages_verifier)
 
         sampling = req.sampling
         sampling_wire = {
@@ -641,29 +862,44 @@ class OpenAIChatDialect:
             path = f"sampling.{name}"
             if value is not None:
                 params[name] = value
-                consume(path)
+                consume(path, WireObservation((name,)))
         if sampling.stop is not None:
             params["stop"] = list(sampling.stop)
-            consume("sampling.stop")
+            consume(
+                "sampling.stop",
+                WireObservation(("stop",)),
+            )
         if sampling.n != 1:
             params["n"] = sampling.n
-            consume("sampling.n")
+            consume("sampling.n", WireObservation(("n",)))
 
         extra_body: dict[str, Any] = {}
         if sampling.top_k is not None:
             extra_body["top_k"] = sampling.top_k
-            consume("sampling.top_k")
+            consume(
+                "sampling.top_k",
+                WireObservation(("extra_body", "top_k")),
+            )
         if req.scoring.sampled_logprobs:
             params["logprobs"] = True
-            consume("scoring.sampled_logprobs")
+            consume(
+                "scoring.sampled_logprobs",
+                WireObservation(("logprobs",)),
+            )
         if req.scoring.top_logprobs > 0:
             params["top_logprobs"] = req.scoring.top_logprobs
-            consume("scoring.top_logprobs")
+            consume(
+                "scoring.top_logprobs",
+                WireObservation(("top_logprobs",)),
+            )
 
         reasoning = req.reasoning
         if reasoning.effort is not None:
             params["reasoning_effort"] = reasoning.effort
-            consume("reasoning.effort")
+            consume(
+                "reasoning.effort",
+                WireObservation(("reasoning_effort",)),
+            )
         if reasoning.summary == "none":
             # Current Chat Completions compatibility servers expose visible
             # reasoning independently of the request; summary is a documented
@@ -675,24 +911,51 @@ class OpenAIChatDialect:
 
         if req.tools.functions:
             params["tools"] = [dict(item) for item in req.tools.functions]
-            consume("tools.functions")
+            consume(
+                "tools.functions",
+                WireObservation(("tools",)),
+            )
         if req.tools.choice is not None:
             params["tool_choice"] = req.tools.choice
-            consume("tools.choice")
+            consume(
+                "tools.choice",
+                WireObservation(("tool_choice",)),
+            )
         if req.tools.parallel is not None:
             params["parallel_tool_calls"] = req.tools.parallel
-            consume("tools.parallel")
+            consume(
+                "tools.parallel",
+                WireObservation(("parallel_tool_calls",)),
+            )
 
         response_format = _response_format(req)
         if response_format is not None:
             params["response_format"] = response_format
-        for item in ("format", "schema", "name", "strict"):
-            consume(f"structured_output.{item}")
+            consume(
+                "structured_output.format",
+                WireObservation(("response_format", "type")),
+            )
+            if req.structured_output.format == "json_schema":
+                consume(
+                    "structured_output.schema",
+                    WireObservation(("response_format", "json_schema", "schema")),
+                )
+                consume(
+                    "structured_output.name",
+                    WireObservation(("response_format", "json_schema", "name")),
+                )
+                consume(
+                    "structured_output.strict",
+                    WireObservation(("response_format", "json_schema", "strict")),
+                )
 
         if req.scheduling.stream:
             params["stream"] = True
             params["stream_options"] = {"include_usage": True}
-            consume("scheduling.stream")
+            consume(
+                "scheduling.stream",
+                WireObservation(("stream",)),
+            )
         else:
             params["stream"] = False
 
@@ -703,16 +966,19 @@ class OpenAIChatDialect:
                     continue
                 extra_body[key] = option_value
                 audit.passthrough(path, "extra_body")
-                passthrough[path] = PassthroughObservation("extra_body", option_value)
         if extra_body:
             params["extra_body"] = extra_body
 
+        wire_body: dict[str, Any] = {
+            "model": self._requested_model_id,
+            "messages": messages,
+            **params,
+        }
+
         return PreparedRequest(
             operation="chat.completions.create",
-            body=params,
-            consumed_paths=frozenset(consumed),
-            passthrough=passthrough,
-            context=_ChatContext(messages, req),
+            body=wire_body,
+            context=_ChatContext(req),
         )
 
     def _structured_output(
@@ -880,13 +1146,20 @@ class OpenAIChatDialect:
         if not isinstance(prepared.context, _ChatContext):
             raise TypeError("openai_chat received an invalid prepared context")
         context = prepared.context
-        params = dict(prepared.body)
-        raw = await self._client.chat.completions.create(
-            model=self._requested_model_id,
-            messages=context.messages,
-            **params,
+        body = prepared.thaw_body()
+        stream = body.get("stream")
+        if not isinstance(stream, bool):
+            raise TypeError("openai_chat prepared body has an invalid stream flag")
+        params = thaw_json_mapping(
+            {
+                key: value
+                for key, value in body.items()
+                if key not in {"model", "messages"}
+            },
+            "chat request parameters",
         )
-        if params["stream"]:
+        raw = await self._client.chat.completions.create(**body)
+        if stream:
             return await self._lift_stream(raw, context.request, params)
         return self._lift(raw, context.request, params)
 

--- a/sieval/core/models/dialects/openai_completions.py
+++ b/sieval/core/models/dialects/openai_completions.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass, field
 from types import MappingProxyType
 from typing import Any
 
+from sieval.core.models._shared import thaw_json_mapping
 from sieval.core.models.capabilities import (
     CAPABILITY_KEYS,
     Capability,
@@ -33,11 +34,11 @@ from sieval.core.models.dialect import (
     OutputContract,
     OutputContractError,
     OutputRule,
-    PassthroughObservation,
     PreparedRequest,
     RequestAudit,
-    RequestAuditError,
     RuntimePlanView,
+    WireEvidence,
+    WireObservation,
     active_request_leaves,
     validate_input_scoring,
     validate_request_invariants,
@@ -205,8 +206,23 @@ _IR_OWNED_BODY_KEYS = BINDING_RESOURCE_KEYS | frozenset(
 class _CompletionContext:
     n: int
     input_scoring: bool
-    stream: bool
-    request_params: Mapping[str, JSONValue]
+
+
+@dataclass(frozen=True)
+class _CompletionsLogprobsVerifier:
+    expected: int
+
+    def verify(self, body: Mapping[str, JSONValue]) -> str | None:
+        if "logprobs" not in body:
+            return "body.logprobs is missing"
+        actual = body["logprobs"]
+        if (
+            not isinstance(actual, int)
+            or isinstance(actual, bool)
+            or actual != self.expected
+        ):
+            return "body.logprobs does not match the request's top-logprobs setting"
+        return None
 
 
 @dataclass(frozen=True)
@@ -223,16 +239,6 @@ class _LegacyPlan:
         default_factory=dict
     )
     required_output_channels: frozenset[str] = frozenset()
-
-
-def _ensure_matching_audit(req: Request, audit: RequestAudit) -> None:
-    active = active_request_leaves(req)
-    if audit.active != active:
-        missing = sorted(set(active) - set(audit.active))
-        extra = sorted(set(audit.active) - set(active))
-        raise RequestAuditError(
-            f"audit does not match request: missing={missing}, extra={extra}"
-        )
 
 
 def _completion_top_logprobs(raw: object) -> list[dict[str, float]] | None:
@@ -373,13 +379,15 @@ class OpenAICompletionsDialect:
     ) -> None:
         """Reject non-completion semantics before any client operation."""
 
-        _ensure_matching_audit(req, audit)
-        for path in audit.active:
+        audit.require_matches_request(req)
+        for path in audit.active_paths:
             if path in _CONSUMED_PATHS or path == "dialect_options":
                 continue
             if path.startswith("dialect_options."):
                 key = path.removeprefix("dialect_options.")
-                if key in {"prefill", "prefix"}:
+                if not key:
+                    audit.rejected(path, "dialect option keys must be non-empty")
+                elif key in {"prefill", "prefix"}:
                     audit.rejected(path, _PREFILL_UNSUPPORTED_REASON)
                 elif key in _IR_OWNED_BODY_KEYS:
                     audit.rejected(
@@ -395,29 +403,32 @@ class OpenAICompletionsDialect:
         del plan
 
     def prepare(self, req: Request, audit: RequestAudit) -> PreparedRequest:
-        """Lower one validated request and attach exact audit observations."""
+        """Lower one validated request and register exact audit observations."""
 
-        _ensure_matching_audit(req, audit)
+        audit.require_matches_request(req)
         audit.raise_rejections()
         if not isinstance(req.input, CompletionInput):
             raise DialectError("OpenAI completions requires CompletionInput")
 
-        body: dict[str, Any] = {
+        body: dict[str, JSONValue] = {
             "model": self._model,
             "prompt": req.input.text,
             "stream": req.scheduling.stream,
         }
-        consumed: set[str] = set()
-        passthrough: dict[str, PassthroughObservation] = {}
 
-        def consume(path: str) -> None:
-            audit.consumed(path)
-            consumed.add(path)
+        def consume(path: str, *wire: WireEvidence) -> None:
+            audit.consumed(path, *wire)
 
-        consume("input.completion")
+        consume(
+            "input.completion",
+            WireObservation(("prompt",)),
+        )
         if req.input.suffix is not None:
             body["suffix"] = req.input.suffix
-            consume("input.completion.suffix")
+            consume(
+                "input.completion.suffix",
+                WireObservation(("suffix",)),
+            )
 
         sampling = req.sampling
         simple_sampling = {
@@ -431,32 +442,56 @@ class OpenAICompletionsDialect:
         for name, value in simple_sampling.items():
             if value is not None:
                 body[name] = value
-                consume(f"sampling.{name}")
+                consume(
+                    f"sampling.{name}",
+                    WireObservation((name,)),
+                )
         if sampling.stop is not None:
             body["stop"] = list(sampling.stop)
-            consume("sampling.stop")
+            consume(
+                "sampling.stop",
+                WireObservation(("stop",)),
+            )
         if sampling.n != 1:
             body["n"] = sampling.n
-            consume("sampling.n")
+            consume("sampling.n", WireObservation(("n",)))
 
         extra_body: dict[str, JSONValue] = {}
         if sampling.top_k is not None:
             extra_body["top_k"] = sampling.top_k
-            consume("sampling.top_k")
+            consume(
+                "sampling.top_k",
+                WireObservation(("extra_body", "top_k")),
+            )
 
         scoring = req.scoring
         if scoring.input_scoring:
             body["echo"] = True
-            consume("scoring.input_scoring")
-        if scoring.sampled_logprobs:
-            consume("scoring.sampled_logprobs")
-        if scoring.top_logprobs > 0:
-            consume("scoring.top_logprobs")
         if scoring.sampled_logprobs or scoring.input_scoring:
             body["logprobs"] = scoring.top_logprobs
+        logprobs_verifier = _CompletionsLogprobsVerifier(scoring.top_logprobs)
+        if scoring.input_scoring:
+            consume(
+                "scoring.input_scoring",
+                WireObservation(("echo",)),
+                logprobs_verifier,
+            )
+        if scoring.sampled_logprobs:
+            consume(
+                "scoring.sampled_logprobs",
+                logprobs_verifier,
+            )
+        if scoring.top_logprobs > 0:
+            consume(
+                "scoring.top_logprobs",
+                WireObservation(("logprobs",)),
+            )
 
         if req.scheduling.stream:
-            consume("scheduling.stream")
+            consume(
+                "scheduling.stream",
+                WireObservation(("stream",)),
+            )
 
         options = req.dialect_options
         if options is not None:
@@ -469,26 +504,18 @@ class OpenAICompletionsDialect:
                 path = f"dialect_options.{key}"
                 extra_body[key] = option_value
                 audit.passthrough(path, "extra_body")
-                passthrough[path] = PassthroughObservation("extra_body", option_value)
 
         if req.scheduling.stream and "stream_options" not in extra_body:
             body["stream_options"] = {"include_usage": True}
         if extra_body:
             body["extra_body"] = extra_body
 
-        request_params = {
-            key: value for key, value in body.items() if key not in {"model", "prompt"}
-        }
         prepared = PreparedRequest(
             operation="completions.create",
             body=body,
-            consumed_paths=frozenset(consumed),
-            passthrough=passthrough,
             context=_CompletionContext(
                 n=sampling.n,
                 input_scoring=scoring.input_scoring,
-                stream=req.scheduling.stream,
-                request_params=request_params,
             ),
         )
         return prepared
@@ -504,10 +531,22 @@ class OpenAICompletionsDialect:
         if not isinstance(context, _CompletionContext):
             raise DialectError("prepared completions request has invalid context")
 
-        raw = await self._client.completions.create(**dict(prepared.body))
-        if context.stream:
-            return await self._lift_stream(raw, context)
-        return self._lift(raw, context)
+        body = prepared.thaw_body()
+        stream = body.get("stream")
+        if not isinstance(stream, bool):
+            raise DialectError("prepared completions request has invalid stream flag")
+        request_params = thaw_json_mapping(
+            {
+                key: value
+                for key, value in body.items()
+                if key not in {"model", "prompt"}
+            },
+            "completion request parameters",
+        )
+        raw = await self._client.completions.create(**body)
+        if stream:
+            return await self._lift_stream(raw, context, request_params)
+        return self._lift(raw, context, request_params)
 
     async def arun(self, req: Request) -> Response:
         """One-cycle direct compatibility path; Model uses the split contract."""
@@ -524,21 +563,37 @@ class OpenAICompletionsDialect:
         self.output_contract.validate(plan, req, response)
         return response
 
-    def _lift(self, raw: object, context: _CompletionContext) -> Response:
-        accumulator = _Accumulator(context, streaming=False)
+    def _lift(
+        self,
+        raw: object,
+        context: _CompletionContext,
+        request_params: Mapping[str, JSONValue],
+    ) -> Response:
+        accumulator = _Accumulator(
+            context,
+            streaming=False,
+            request_params=request_params,
+        )
         accumulator.capture_metadata(raw)
         accumulator.capture_choices(getattr(raw, "choices", ()))
         usage = _completions_usage_stats(getattr(raw, "usage", None))
         return accumulator.response(usage)
 
     async def _lift_stream(
-        self, stream: object, context: _CompletionContext
+        self,
+        stream: object,
+        context: _CompletionContext,
+        request_params: Mapping[str, JSONValue],
     ) -> Response:
         if not isinstance(stream, AsyncIterable):
             raise OutputContractError(
                 "streaming completions response is not asynchronously iterable"
             )
-        accumulator = _Accumulator(context, streaming=True)
+        accumulator = _Accumulator(
+            context,
+            streaming=True,
+            request_params=request_params,
+        )
         usage: UsageStats | None = None
         async for chunk in stream:
             accumulator.capture_metadata(chunk)
@@ -550,9 +605,16 @@ class OpenAICompletionsDialect:
 
 
 class _Accumulator:
-    def __init__(self, context: _CompletionContext, *, streaming: bool) -> None:
+    def __init__(
+        self,
+        context: _CompletionContext,
+        *,
+        streaming: bool,
+        request_params: Mapping[str, JSONValue],
+    ) -> None:
         self._context = context
         self._streaming = streaming
+        self._request_params = request_params
         self._texts = [""] * context.n
         self._finish_reasons = [""] * context.n
         self._seen_indices: set[int] = set()
@@ -702,7 +764,7 @@ class _Accumulator:
             top_logprobs=top,
             input_scoring=input_scoring,
             usage=usage,
-            request_params=self._context.request_params,
+            request_params=self._request_params,
             response_model=self._response_model,
             system_fingerprint=self._system_fingerprint,
         )

--- a/sieval/core/models/dialects/openai_completions.py
+++ b/sieval/core/models/dialects/openai_completions.py
@@ -467,7 +467,16 @@ class OpenAICompletionsDialect:
         scoring = req.scoring
         if scoring.input_scoring:
             body["echo"] = True
-        if scoring.sampled_logprobs or scoring.input_scoring:
+        # ``top_logprobs`` is claimed against ``body.logprobs`` below, so emit
+        # the field whenever any of the three leaves needs it.  Its arm is
+        # unreachable through ``validate_request_invariants``, which requires
+        # ``sampled_logprobs`` alongside it; without it the split contract
+        # would claim a field this body never emitted.
+        if (
+            scoring.sampled_logprobs
+            or scoring.input_scoring
+            or scoring.top_logprobs > 0
+        ):
             body["logprobs"] = scoring.top_logprobs
         logprobs_verifier = _CompletionsLogprobsVerifier(scoring.top_logprobs)
         if scoring.input_scoring:

--- a/sieval/core/models/reconcile.py
+++ b/sieval/core/models/reconcile.py
@@ -17,7 +17,7 @@ from typing import Protocol, cast
 from sieval.core.types import JSONValue
 
 from ._fingerprint import fingerprint_mapping
-from ._shared import freeze_json_mapping, thaw_json_value
+from ._shared import copy_json_value, freeze_json_mapping
 from .capabilities import (
     CAPABILITY_KEYS,
     CAPABILITY_SPECS,
@@ -153,7 +153,9 @@ class ServingRequirement:
     def __post_init__(self) -> None:
         if self.capability not in CAPABILITY_SPECS:
             raise ValueError(f"unknown serving capability {self.capability!r}")
-        object.__setattr__(self, "minimums", _freeze_json(self.minimums, "minimums"))
+        object.__setattr__(
+            self, "minimums", freeze_json_mapping(self.minimums, "minimums")
+        )
         object.__setattr__(self, "sources", _source_tuple(self.sources))
         if self.verifier is not None:
             _nonempty(self.verifier, "serving verifier")
@@ -183,10 +185,10 @@ class Configured:
 
     def __post_init__(self) -> None:
         object.__setattr__(
-            self, "launch_patch", _freeze_json(self.launch_patch, "launch_patch")
+            self, "launch_patch", freeze_json_mapping(self.launch_patch, "launch_patch")
         )
         object.__setattr__(
-            self, "evidence", _freeze_json(self.evidence, "serving evidence")
+            self, "evidence", freeze_json_mapping(self.evidence, "serving evidence")
         )
         if any(check.stage is not CheckStage.REQUEST for check in self.request_checks):
             raise ValueError("Configured.request_checks must use request stage")
@@ -285,7 +287,7 @@ class BindingReconcileInput:
         object.__setattr__(
             self,
             "declarations",
-            _freeze_json(self.declarations, "capability declarations"),
+            freeze_json_mapping(self.declarations, "capability declarations"),
         )
         request_intents: dict[CapabilityKey, CapabilityIntent] = {}
         for key, intent in self.request_intents.items():
@@ -340,12 +342,12 @@ class DeploymentReconcileInput:
         object.__setattr__(
             self,
             "recipe_parameters",
-            _freeze_json(self.recipe_parameters, "recipe_parameters"),
+            freeze_json_mapping(self.recipe_parameters, "recipe_parameters"),
         )
         object.__setattr__(
             self,
             "explicit_parameters",
-            _freeze_json(self.explicit_parameters, "explicit_parameters"),
+            freeze_json_mapping(self.explicit_parameters, "explicit_parameters"),
         )
 
     @property
@@ -428,7 +430,7 @@ class BindingCapabilityPlan:
         object.__setattr__(
             self,
             "declared_capabilities",
-            _freeze_json(self.declared_capabilities, "declared_capabilities"),
+            freeze_json_mapping(self.declared_capabilities, "declared_capabilities"),
         )
         object.__setattr__(
             self,
@@ -461,7 +463,7 @@ class BindingCapabilityPlan:
             "capability_minimums",
             MappingProxyType(
                 {
-                    key: _freeze_json(value, f"capability_minimums.{key}")
+                    key: freeze_json_mapping(value, f"capability_minimums.{key}")
                     for key, value in self.capability_minimums.items()
                 }
             ),
@@ -540,17 +542,17 @@ class DeploymentCapabilityPlan:
         object.__setattr__(
             self,
             "recipe_parameters",
-            _freeze_json(self.recipe_parameters, "recipe_parameters"),
+            freeze_json_mapping(self.recipe_parameters, "recipe_parameters"),
         )
         object.__setattr__(
             self,
             "explicit_parameters",
-            _freeze_json(self.explicit_parameters, "explicit_parameters"),
+            freeze_json_mapping(self.explicit_parameters, "explicit_parameters"),
         )
         object.__setattr__(
             self,
             "launch_patch",
-            _freeze_json(self.launch_patch, "launch_patch"),
+            freeze_json_mapping(self.launch_patch, "launch_patch"),
         )
         for name in ("serving_requirements", "setup_checks", "request_checks"):
             object.__setattr__(self, name, tuple(getattr(self, name)))
@@ -564,7 +566,7 @@ class DeploymentCapabilityPlan:
             "outcome_evidence",
             MappingProxyType(
                 {
-                    key: _freeze_json(value, f"outcome_evidence.{key}")
+                    key: freeze_json_mapping(value, f"outcome_evidence.{key}")
                     for key, value in self.outcome_evidence.items()
                 }
             ),
@@ -633,12 +635,12 @@ class RuntimeBindingPlan:
         object.__setattr__(
             self,
             "declared_capabilities",
-            _freeze_json(self.declared_capabilities, "declared_capabilities"),
+            freeze_json_mapping(self.declared_capabilities, "declared_capabilities"),
         )
         object.__setattr__(
             self,
             "effective_capabilities",
-            _freeze_json(self.effective_capabilities, "effective_capabilities"),
+            freeze_json_mapping(self.effective_capabilities, "effective_capabilities"),
         )
         object.__setattr__(
             self, "available_capabilities", frozenset(self.available_capabilities)
@@ -654,7 +656,7 @@ class RuntimeBindingPlan:
             "capability_minimums",
             MappingProxyType(
                 {
-                    key: _freeze_json(value, f"capability_minimums.{key}")
+                    key: freeze_json_mapping(value, f"capability_minimums.{key}")
                     for key, value in self.capability_minimums.items()
                 }
             ),
@@ -1773,16 +1775,13 @@ def _nonempty(value: object, name: str) -> None:
         raise TypeError(f"{name} must be a non-empty string")
 
 
-_freeze_json = freeze_json_mapping
-
-
 def _freeze_request_defaults(value: RequestDefaults, path: str) -> RequestDefaults:
     """Detach and deeply freeze defaults before they become plan evidence."""
 
     if not isinstance(value, RequestDefaults):
         raise TypeError(f"{path} must be RequestDefaults")
     frozen = RequestDefaults()
-    object.__setattr__(frozen, "values", _freeze_json(value.values, path))
+    object.__setattr__(frozen, "values", freeze_json_mapping(value.values, path))
     return frozen
 
 
@@ -1802,13 +1801,13 @@ def _freeze_capability_intent(value: CapabilityIntent, path: str) -> CapabilityI
     object.__setattr__(
         frozen,
         "minimums",
-        _freeze_json(value.minimums, f"{path}.minimums"),
+        freeze_json_mapping(value.minimums, f"{path}.minimums"),
     )
     return frozen
 
 
 def _thaw_json(value: object) -> JSONValue:
-    return thaw_json_value(value, "serialized value")
+    return copy_json_value(value, "serialized value")
 
 
 def _json_sequence(value: JSONValue) -> tuple[str | int | float | bool | None, ...]:

--- a/sieval/core/models/reconcile.py
+++ b/sieval/core/models/reconcile.py
@@ -8,17 +8,16 @@ AI-Generated Code - GPT-5.6 (OpenAI)
 """
 
 import json
-import math
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
 from enum import StrEnum
 from types import MappingProxyType
-from typing import Never, Protocol, Self, cast
+from typing import Protocol, cast
 
 from sieval.core.types import JSONValue
 
 from ._fingerprint import fingerprint_mapping
-from ._shared import copy_json_value
+from ._shared import freeze_json_mapping, thaw_json_value
 from .capabilities import (
     CAPABILITY_KEYS,
     CAPABILITY_SPECS,
@@ -1774,68 +1773,7 @@ def _nonempty(value: object, name: str) -> None:
         raise TypeError(f"{name} must be a non-empty string")
 
 
-class _FrozenJSONList(list[JSONValue]):
-    """List-shaped JSON value that rejects mutation while preserving equality."""
-
-    def _immutable(self, *args: object, **kwargs: object) -> Never:
-        del self, args, kwargs
-        raise TypeError("frozen JSON sequences do not support mutation")
-
-    def __copy__(self) -> Self:
-        return self
-
-    def __deepcopy__(self, memo: dict[int, object]) -> Self:
-        del memo
-        return self
-
-
-# ``list`` exposes several mutation spellings, including in-place operators.
-# Install the same guard for all of them so nested JSON sequences remain
-# list-compatible without leaving a normal mutation path open.
-for _method_name in (
-    "append",
-    "clear",
-    "extend",
-    "insert",
-    "pop",
-    "remove",
-    "reverse",
-    "sort",
-    "__delitem__",
-    "__iadd__",
-    "__imul__",
-    "__setitem__",
-):
-    setattr(_FrozenJSONList, _method_name, _FrozenJSONList._immutable)
-del _method_name
-
-
-def _freeze_json_value(value: object, path: str) -> JSONValue:
-    if value is None or isinstance(value, (str, bool, int)):
-        return value
-    if isinstance(value, float):
-        if not math.isfinite(value):
-            raise ValueError(f"{path} must not contain non-finite floats")
-        return value
-    if isinstance(value, Mapping):
-        copied: dict[str, JSONValue] = {}
-        for key, item in value.items():
-            if not isinstance(key, str):
-                raise TypeError(f"{path} keys must be strings")
-            copied[key] = _freeze_json_value(item, f"{path}.{key}")
-        return MappingProxyType(copied)
-    if isinstance(value, (list, tuple)):
-        return _FrozenJSONList(
-            _freeze_json_value(item, f"{path}[{index}]")
-            for index, item in enumerate(value)
-        )
-    raise TypeError(f"{path} contains non-JSON value {type(value).__name__}")
-
-
-def _freeze_json(value: Mapping[str, JSONValue], path: str) -> Mapping[str, JSONValue]:
-    frozen = _freeze_json_value(value, path)
-    assert isinstance(frozen, Mapping)
-    return cast(Mapping[str, JSONValue], frozen)
+_freeze_json = freeze_json_mapping
 
 
 def _freeze_request_defaults(value: RequestDefaults, path: str) -> RequestDefaults:
@@ -1870,7 +1808,7 @@ def _freeze_capability_intent(value: CapabilityIntent, path: str) -> CapabilityI
 
 
 def _thaw_json(value: object) -> JSONValue:
-    return copy_json_value(value, "serialized value")
+    return thaw_json_value(value, "serialized value")
 
 
 def _json_sequence(value: JSONValue) -> tuple[str | int | float | bool | None, ...]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,12 +20,12 @@ import random
 import sys
 import threading
 import time
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping
 from contextlib import contextmanager, suppress
 from dataclasses import dataclass
 from pathlib import Path
 from types import ModuleType
-from typing import Any
+from typing import Any, cast
 
 import anyio
 import psutil
@@ -64,6 +64,7 @@ from sieval.core.runners.runner import TaskRunnerConfig
 from sieval.core.tasks.context import TaskContext, TaskStage
 from sieval.core.tasks.saver import TaskSaver
 from sieval.core.tasks.task import Task
+from sieval.core.types import JSONValue
 
 
 # ===================================================================
@@ -302,6 +303,20 @@ class MockDataset(Dataset):
 # while the wire layer stays canned. Subclass mocks override
 # ``_stub_arun`` and chain via ``super()``.
 # ===================================================================
+@dataclass(frozen=True)
+class _ObservedPathVerifier:
+    path: str
+
+    def verify(self, body: Mapping[str, JSONValue]) -> str | None:
+        observed = body.get("observed")
+        if not isinstance(observed, Mapping):
+            return f"body.observed omitted {self.path!r}"
+        observed_mapping = cast(Mapping[str, object], observed)
+        if observed_mapping.get(self.path) is not True:
+            return f"body.observed omitted {self.path!r}"
+        return None
+
+
 class HandlerTransport:
     """Dialect double: forwards ``execute`` to a handler coroutine.
 
@@ -327,16 +342,15 @@ class HandlerTransport:
         del req, audit, plan
 
     def prepare(self, req: Request, audit: RequestAudit) -> PreparedRequest:
-        consumed = frozenset(
-            path for path in audit.active if path not in audit.decisions
+        consumed = sorted(
+            path for path in audit.active_paths if path not in audit.decisions
         )
+        body = {"observed": dict.fromkeys(consumed, True)}
         for path in consumed:
-            audit.consumed(path)
+            audit.consumed(path, _ObservedPathVerifier(path))
         return PreparedRequest(
             operation="handler",
-            body={},
-            consumed_paths=consumed,
-            passthrough={},
+            body=body,
             context=req,
         )
 

--- a/tests/unit/core/models/dialects/test_openai_chat.py
+++ b/tests/unit/core/models/dialects/test_openai_chat.py
@@ -4,12 +4,15 @@ AI-Generated Code - GPT-5.6 (OpenAI)
 """
 
 from collections.abc import Iterable, Mapping
+from copy import deepcopy
+from dataclasses import replace
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+import sieval.core.models.dialects.openai_chat as openai_chat_module
 from sieval.core.models.capabilities import Capability, ReasoningOptions, Supported
 from sieval.core.models.dialect import (
     DialectError,
@@ -223,6 +226,61 @@ class TestWireTranslation:
         }
         assert response.structured_output is not None
         assert response.structured_output.value == {"answer": 42}
+
+    @pytest.mark.anyio
+    async def test_multiple_text_parts_preserve_their_exact_concatenation(self) -> None:
+        dialect, create = _dialect()
+
+        await dialect.arun(
+            Request(
+                input=_chat(
+                    ChatMessage(
+                        "user",
+                        (TextPart("alpha"), TextPart("beta"), TextPart("alpha")),
+                    )
+                )
+            )
+        )
+
+        assert _awaited_kwargs(create)["messages"] == [
+            {"role": "user", "content": "alphabetaalpha"}
+        ]
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize("stream", [False, True], ids=["non-stream", "stream"])
+    async def test_request_params_snapshot_matches_pre_await_wire(
+        self, stream: bool
+    ) -> None:
+        raw = (
+            _AsyncItems([_chunk(content="ok", finish_reason="stop")])
+            if stream
+            else _response()
+        )
+        dialect, create = _dialect(raw)
+        original = {"mode": "sent"}
+        sent: dict[str, Any] = {}
+
+        async def mutate_after_capture(**kwargs: Any) -> object:
+            sent.update(deepcopy(kwargs))
+            original["mode"] = "changed after response"
+            kwargs["extra_body"]["vendor"]["mode"] = "changed inside SDK"
+            return raw
+
+        create.side_effect = mutate_after_capture
+        response = await dialect.arun(
+            Request(
+                input=_chat(),
+                scheduling=SchedulingParams(stream=stream),
+                dialect_options=DialectOptions(
+                    "openai_chat",
+                    {"vendor": original},
+                ),
+            )
+        )
+
+        assert sent["extra_body"] == {"vendor": {"mode": "sent"}}
+        assert response.request_params is not None
+        assert response.request_params["extra_body"] == {"vendor": {"mode": "sent"}}
 
     @pytest.mark.anyio
     async def test_empty_matching_dialect_options_are_an_explicit_noop(self) -> None:
@@ -474,6 +532,8 @@ class TestPreflightRejections:
         dialect.validate_request(req, audit, SimpleNamespace())
         with pytest.raises(RequestAuditError):
             audit.raise_rejections()
+        with pytest.raises(RequestAuditError):
+            dialect.prepare(req, audit)
 
         create.assert_not_awaited()
 
@@ -499,14 +559,172 @@ class TestPreflightRejections:
         with pytest.raises(TypeError, match="requires ChatInput"):
             dialect.prepare(req, RequestAudit(active_request_leaves(req)))
 
+    def test_audit_rejects_a_consumed_field_removed_from_the_wire_body(self) -> None:
+        dialect, _ = _dialect()
+        req = Request(
+            input=_chat(),
+            sampling=SamplingParams(temperature=0.25),
+        )
+        audit = RequestAudit(active_request_leaves(req))
+        dialect.validate_request(req, audit, SimpleNamespace())
+        prepared = dialect.prepare(req, audit)
+        body = dict(prepared.body)
+        del body["temperature"]
+
+        with pytest.raises(RequestAuditError, match=r"body\.temperature.*missing"):
+            audit.finish(replace(prepared, body=body))
+
+    @pytest.mark.anyio
+    async def test_message_lowering_bug_is_rejected_before_io(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        dialect, create = _dialect()
+        req = Request(input=_chat(ChatMessage("user", (TextPart("secret"),))))
+        original = openai_chat_module._message_to_wire
+
+        def drop_content(message: ChatMessage) -> dict[str, Any]:
+            wire = original(message)
+            wire.pop("content", None)
+            return wire
+
+        monkeypatch.setattr(openai_chat_module, "_message_to_wire", drop_content)
+
+        with pytest.raises(RequestAuditError, match="messages"):
+            await dialect.arun(req)
+
+        create.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_response_format_lowering_bug_is_rejected_before_io(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        dialect, create = _dialect(_response(_choice(0, '{"ok":true}')))
+        req = Request(
+            input=_chat(),
+            structured_output=StructuredOutputParams(
+                format="json_schema",
+                schema={"type": "object"},
+                name="answer",
+                strict=False,
+            ),
+        )
+        original = openai_chat_module._response_format
+
+        def drop_strict(request: Request) -> dict[str, Any] | None:
+            wire = original(request)
+            assert wire is not None
+            wire["json_schema"].pop("strict", None)
+            return wire
+
+        monkeypatch.setattr(openai_chat_module, "_response_format", drop_strict)
+
+        with pytest.raises(RequestAuditError, match=r"strict.*missing"):
+            await dialect.arun(req)
+
+        create.assert_not_awaited()
+
+    def test_messages_verifier_checks_nested_semantics(self) -> None:
+        dialect, _ = _dialect()
+        req = Request(
+            input=_chat(
+                ChatMessage(
+                    "user",
+                    (
+                        TextPart("look"),
+                        ImagePart(url="https://example.test/image.png", detail="high"),
+                    ),
+                    name="named-user",
+                ),
+                ChatMessage(
+                    "assistant",
+                    (ToolCallPart("call-1", "inspect", {"value": 1}),),
+                ),
+                ChatMessage("tool", (ToolResultPart("call-1", {"ok": True}),)),
+            )
+        )
+        audit = RequestAudit(active_request_leaves(req))
+        dialect.validate_request(req, audit, SimpleNamespace())
+        prepared = dialect.prepare(req, audit)
+
+        mutations = (
+            lambda body: body["messages"][0].__setitem__("name", "changed"),
+            lambda body: body["messages"][0]["content"][1]["image_url"].__setitem__(
+                "detail", "low"
+            ),
+            lambda body: body["messages"][1]["tool_calls"][0].__setitem__(
+                "id", "changed"
+            ),
+            lambda body: body["messages"][2].__setitem__("content", '{"ok":false}'),
+        )
+        for mutate in mutations:
+            body = cast(Any, prepared.thaw_body())
+            mutate(body)
+            with pytest.raises(RequestAuditError, match="messages"):
+                audit.finish(replace(prepared, body=body))
+
+    def test_finished_prepared_messages_cannot_be_mutated(self) -> None:
+        dialect, _ = _dialect()
+        req = Request(input=_chat())
+        audit = RequestAudit(active_request_leaves(req))
+        dialect.validate_request(req, audit, SimpleNamespace())
+        prepared = dialect.prepare(req, audit)
+        audit.finish(prepared)
+
+        messages = cast(Any, prepared.body["messages"])
+        with pytest.raises(TypeError):
+            messages[0]["content"] = "changed"
+
+    def test_chat_rejects_an_audit_for_another_request(self) -> None:
+        dialect, create = _dialect()
+        req_a = Request(input=_chat(ChatMessage("user", (TextPart("A"),))))
+        req_b = Request(input=_chat(ChatMessage("user", (TextPart("B"),))))
+
+        audit = RequestAudit(active_request_leaves(req_a))
+        with pytest.raises(RequestAuditError, match=r"changed=.*input.chat"):
+            dialect.validate_request(req_b, audit, SimpleNamespace())
+
+        audit = RequestAudit(active_request_leaves(req_a))
+        dialect.validate_request(req_a, audit, SimpleNamespace())
+        with pytest.raises(RequestAuditError, match=r"changed=.*input.chat"):
+            dialect.prepare(req_b, audit)
+
+        create.assert_not_awaited()
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize(
+        "req",
+        [
+            Request(
+                input=_chat(),
+                structured_output=StructuredOutputParams(
+                    format="json_schema",
+                    schema={"type": "object"},
+                    name="",
+                ),
+            ),
+            Request(
+                input=_chat(),
+                dialect_options=DialectOptions("openai_chat", {"": 1}),
+            ),
+        ],
+        ids=["empty-structured-output-name", "empty-option-key"],
+    )
+    async def test_empty_wire_names_are_explicit_audit_rejections(
+        self, req: Request
+    ) -> None:
+        dialect, create = _dialect()
+
+        with pytest.raises(RequestAuditError, match="non-empty"):
+            await dialect.arun(req)
+
+        create.assert_not_awaited()
+
     @pytest.mark.anyio
     async def test_execute_rejects_invalid_prepared_context(self) -> None:
         dialect, create = _dialect()
         prepared = PreparedRequest(
             operation="chat.completions.create",
             body={"stream": False},
-            consumed_paths=frozenset(),
-            passthrough={},
         )
 
         with pytest.raises(TypeError, match="invalid prepared context"):

--- a/tests/unit/core/models/dialects/test_openai_chat.py
+++ b/tests/unit/core/models/dialects/test_openai_chat.py
@@ -3,7 +3,7 @@
 AI-Generated Code - GPT-5.6 (OpenAI)
 """
 
-from collections.abc import Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from copy import deepcopy
 from dataclasses import replace
 from types import SimpleNamespace
@@ -18,6 +18,7 @@ from sieval.core.models.dialect import (
     DialectError,
     OutputContractError,
     PreparedRequest,
+    Rejected,
     RequestAudit,
     RequestAuditError,
     active_request_leaves,
@@ -640,27 +641,155 @@ class TestPreflightRejections:
                     (ToolCallPart("call-1", "inspect", {"value": 1}),),
                 ),
                 ChatMessage("tool", (ToolResultPart("call-1", {"ok": True}),)),
+                # All-text content lowers to a concatenated string, not a part
+                # list — a different verifier branch from the mixed message.
+                ChatMessage("user", (TextPart("al"), TextPart("pha"))),
             )
         )
         audit = RequestAudit(active_request_leaves(req))
         dialect.validate_request(req, audit, SimpleNamespace())
         prepared = dialect.prepare(req, audit)
 
-        mutations = (
-            lambda body: body["messages"][0].__setitem__("name", "changed"),
-            lambda body: body["messages"][0]["content"][1]["image_url"].__setitem__(
-                "detail", "low"
+        # One entry per field the verifier proves: an unexercised guard can be
+        # deleted with the suite still green, which is the weakness this
+        # verifier exists to remove, reintroduced one level up.
+        mutations: tuple[tuple[str, Callable[[Any], object]], ...] = (
+            ("name", lambda body: body["messages"][0].__setitem__("name", "changed")),
+            ("role", lambda body: body["messages"][0].__setitem__("role", "system")),
+            (
+                "text",
+                lambda body: body["messages"][0]["content"][0].__setitem__(
+                    "text", "l00k"
+                ),
             ),
-            lambda body: body["messages"][1]["tool_calls"][0].__setitem__(
-                "id", "changed"
+            (
+                "image url",
+                lambda body: body["messages"][0]["content"][1]["image_url"].__setitem__(
+                    "url", "https://example.test/other.png"
+                ),
             ),
-            lambda body: body["messages"][2].__setitem__("content", '{"ok":false}'),
+            (
+                "image detail",
+                lambda body: body["messages"][0]["content"][1]["image_url"].__setitem__(
+                    "detail", "low"
+                ),
+            ),
+            (
+                "content part count",
+                lambda body: body["messages"][0]["content"].append(
+                    {"type": "text", "text": "extra"}
+                ),
+            ),
+            (
+                "tool-call id",
+                lambda body: body["messages"][1]["tool_calls"][0].__setitem__(
+                    "id", "changed"
+                ),
+            ),
+            (
+                "tool-call name",
+                lambda body: body["messages"][1]["tool_calls"][0][
+                    "function"
+                ].__setitem__("name", "changed"),
+            ),
+            (
+                "tool-call arguments",
+                lambda body: body["messages"][1]["tool_calls"][0][
+                    "function"
+                ].__setitem__("arguments", '{"value":2}'),
+            ),
+            (
+                "tool-call count",
+                lambda body: body["messages"][1]["tool_calls"].append(
+                    {
+                        "id": "call-2",
+                        "type": "function",
+                        "function": {"name": "inspect", "arguments": "{}"},
+                    }
+                ),
+            ),
+            (
+                "tool-result id",
+                lambda body: body["messages"][2].__setitem__("tool_call_id", "changed"),
+            ),
+            (
+                "tool-result content",
+                lambda body: body["messages"][2].__setitem__("content", '{"ok":false}'),
+            ),
+            (
+                "concatenated text",
+                lambda body: body["messages"][3].__setitem__("content", "phaal"),
+            ),
+            (
+                "message count",
+                lambda body: body["messages"].append(
+                    {"role": "user", "content": "injected"}
+                ),
+            ),
+            ("message order", lambda body: body["messages"].reverse()),
         )
-        for mutate in mutations:
+        survived: list[str] = []
+        for label, mutate in mutations:
             body = cast(Any, prepared.thaw_body())
             mutate(body)
-            with pytest.raises(RequestAuditError, match="messages"):
+            try:
                 audit.finish(replace(prepared, body=body))
+            except RequestAuditError as exc:
+                assert "messages" in str(exc), f"{label}: {exc}"
+                continue
+            survived.append(label)
+        assert not survived, f"message mutations the verifier accepted: {survived}"
+
+    def test_messages_verifier_accepts_the_honest_wire_body(self) -> None:
+        dialect, _ = _dialect()
+        req = Request(
+            input=_chat(
+                ChatMessage(
+                    "user",
+                    (
+                        TextPart("look"),
+                        ImagePart(url="https://example.test/image.png", detail="high"),
+                    ),
+                    name="named-user",
+                ),
+                ChatMessage(
+                    "assistant",
+                    (ToolCallPart("call-1", "inspect", {"value": 1}),),
+                ),
+                ChatMessage("tool", (ToolResultPart("call-1", {"ok": True}),)),
+                # All-text content lowers to a concatenated string, not a part
+                # list — a different verifier branch from the mixed message.
+                ChatMessage("user", (TextPart("al"), TextPart("pha"))),
+            )
+        )
+        audit = RequestAudit(active_request_leaves(req))
+        dialect.validate_request(req, audit, SimpleNamespace())
+        prepared = dialect.prepare(req, audit)
+
+        audit.finish(prepared)
+
+    def test_messages_verifier_ignores_tool_argument_reformatting(self) -> None:
+        """Mapping arguments are serialized by the dialect, so whitespace is
+        not part of the request's meaning and must not read as a mismatch."""
+
+        dialect, _ = _dialect()
+        req = Request(
+            input=_chat(
+                ChatMessage(
+                    "assistant",
+                    (ToolCallPart("call-1", "inspect", {"value": 1}),),
+                ),
+            )
+        )
+        audit = RequestAudit(active_request_leaves(req))
+        dialect.validate_request(req, audit, SimpleNamespace())
+        prepared = dialect.prepare(req, audit)
+        body = cast(Any, prepared.thaw_body())
+        body["messages"][0]["tool_calls"][0]["function"]["arguments"] = (
+            '{ "value" : 1 }'
+        )
+
+        audit.finish(replace(prepared, body=body))
 
     def test_finished_prepared_messages_cannot_be_mutated(self) -> None:
         dialect, _ = _dialect()
@@ -718,6 +847,48 @@ class TestPreflightRejections:
             await dialect.arun(req)
 
         create.assert_not_awaited()
+
+    @pytest.mark.parametrize(
+        ("req", "path"),
+        [
+            (
+                Request(
+                    input=_chat(),
+                    structured_output=StructuredOutputParams(
+                        format="json_schema",
+                        schema={"type": "object"},
+                        name="",
+                    ),
+                ),
+                "structured_output.name",
+            ),
+            (
+                Request(
+                    input=_chat(),
+                    dialect_options=DialectOptions("openai_chat", {"": 1}),
+                ),
+                "dialect_options.",
+            ),
+        ],
+        ids=["empty-structured-output-name", "empty-option-key"],
+    )
+    def test_empty_wire_names_are_rejected_during_validation(
+        self, req: Request, path: str
+    ) -> None:
+        """Pin *which* layer rejects, not merely that something does.
+
+        ``finish()`` is a backstop with the same wording, so matching only the
+        message still passes with this dialect's check deleted.
+        """
+
+        dialect, _ = _dialect()
+        audit = RequestAudit(active_request_leaves(req))
+
+        dialect.validate_request(req, audit, SimpleNamespace())
+
+        decision = audit.decisions[path]
+        assert isinstance(decision, Rejected)
+        assert "non-empty" in decision.reason
 
     @pytest.mark.anyio
     async def test_execute_rejects_invalid_prepared_context(self) -> None:

--- a/tests/unit/core/models/dialects/test_openai_completions.py
+++ b/tests/unit/core/models/dialects/test_openai_completions.py
@@ -24,6 +24,7 @@ from sieval.core.models.dialect import (
     OutputContractError,
     Passthrough,
     PreparedRequest,
+    Rejected,
     RequestAudit,
     RequestAuditError,
     active_request_leaves,
@@ -32,6 +33,7 @@ from sieval.core.models.dialects.openai_completions import (
     CAPABILITY_DECISIONS,
     OUTPUT_CONTRACT,
     OpenAICompletionsDialect,
+    _CompletionsLogprobsVerifier,
 )
 from sieval.core.models.ir import (
     ChatInput,
@@ -229,6 +231,19 @@ class TestValidationAndAudit:
         with pytest.raises(RequestAuditError, match="top-logprobs setting"):
             audit.finish(replace(prepared, body=body))
 
+    def test_logprobs_verifier_rejects_a_boolean_wire_value(self) -> None:
+        """``True == 1``, so only the bool guard rejects this.
+
+        Unreachable through ``finish()``: a positive expected count also carries
+        a ``WireObservation`` on ``body.logprobs``, which rejects the bool
+        first.  Pinning the guard directly is the only way to cover it.
+        """
+
+        verifier = _CompletionsLogprobsVerifier(1)
+
+        assert verifier.verify({"logprobs": 1}) is None
+        assert verifier.verify({"logprobs": True}) is not None
+
     def test_prepare_rejects_chat_input_defensively(self) -> None:
         req = Request(input=ChatInput((ChatMessage("user", (TextPart("hello"),)),)))
         dialect, _ = _dialect(_response())
@@ -262,6 +277,26 @@ class TestValidationAndAudit:
             await dialect.arun(req)
 
         create.assert_not_awaited()
+
+    def test_empty_dialect_option_key_is_rejected_during_validation(self) -> None:
+        """Pin *which* layer rejects, not merely that something does.
+
+        ``finish()`` is a backstop with the same wording, so matching only the
+        message still passes with this dialect's check deleted.
+        """
+
+        req = Request(
+            input=CompletionInput("prompt"),
+            dialect_options=DialectOptions("openai_completions", {"": 1}),
+        )
+        dialect, _ = _dialect(_response())
+        audit = RequestAudit(active_request_leaves(req))
+
+        dialect.validate_request(req, audit, _Plan())
+
+        decision = audit.decisions["dialect_options."]
+        assert isinstance(decision, Rejected)
+        assert "non-empty" in decision.reason
 
     @pytest.mark.anyio
     @pytest.mark.parametrize(

--- a/tests/unit/core/models/dialects/test_openai_completions.py
+++ b/tests/unit/core/models/dialects/test_openai_completions.py
@@ -4,8 +4,10 @@ AI-Generated Code - GPT-5.6 (OpenAI)
 """
 
 from collections.abc import Mapping
-from dataclasses import dataclass, field
+from copy import deepcopy
+from dataclasses import dataclass, field, replace
 from types import SimpleNamespace
+from typing import cast
 from unittest.mock import AsyncMock
 
 import pytest
@@ -183,9 +185,49 @@ class TestValidationAndAudit:
         with pytest.raises(RequestAuditError, match="audit does not match"):
             dialect.validate_request(req, audit, _Plan())
 
+    def test_prepare_rejects_an_audit_for_another_request(self) -> None:
+        req_a = Request(input=CompletionInput("A"))
+        req_b = Request(input=CompletionInput("B"))
+        dialect, create = _dialect(_response())
+        audit = RequestAudit(active_request_leaves(req_a))
+        dialect.validate_request(req_a, audit, _Plan())
+
+        with pytest.raises(RequestAuditError, match=r"changed=.*input.completion"):
+            dialect.prepare(req_b, audit)
+
+        create.assert_not_awaited()
+
     def test_empty_model_id_is_rejected(self) -> None:
         with pytest.raises(ValueError, match="model must not be empty"):
             OpenAICompletionsDialect(object(), "")
+
+    def test_audit_rejects_a_consumed_field_removed_from_the_wire_body(self) -> None:
+        req = Request(
+            input=CompletionInput("prompt"),
+            sampling=SamplingParams(temperature=0.25),
+        )
+        dialect, _ = _dialect(_response())
+        audit = RequestAudit(active_request_leaves(req))
+        dialect.validate_request(req, audit, _Plan())
+        prepared = dialect.prepare(req, audit)
+        body = dict(prepared.body)
+        del body["temperature"]
+
+        with pytest.raises(RequestAuditError, match=r"body\.temperature.*missing"):
+            audit.finish(replace(prepared, body=body))
+
+    def test_logprobs_verifier_rejects_equal_float_wire_value(self) -> None:
+        req = Request(
+            input=CompletionInput("prompt"),
+            scoring=ScoringParams(input_scoring=True),
+        )
+        dialect, _ = _dialect(_response())
+        audit, prepared = _prepare(dialect, req)
+        body = dict(prepared.body)
+        body["logprobs"] = 0.0
+
+        with pytest.raises(RequestAuditError, match="top-logprobs setting"):
+            audit.finish(replace(prepared, body=body))
 
     def test_prepare_rejects_chat_input_defensively(self) -> None:
         req = Request(input=ChatInput((ChatMessage("user", (TextPart("hello"),)),)))
@@ -207,11 +249,26 @@ class TestValidationAndAudit:
         assert "extra_body" not in prepared.body
 
     @pytest.mark.anyio
+    async def test_empty_dialect_option_key_is_an_explicit_audit_rejection(
+        self,
+    ) -> None:
+        req = Request(
+            input=CompletionInput("prompt"),
+            dialect_options=DialectOptions("openai_completions", {"": 1}),
+        )
+        dialect, create = _dialect(_response())
+
+        with pytest.raises(RequestAuditError, match="non-empty"):
+            await dialect.arun(req)
+
+        create.assert_not_awaited()
+
+    @pytest.mark.anyio
     @pytest.mark.parametrize(
         "prepared",
         [
-            PreparedRequest("wrong", {}, frozenset(), {}),
-            PreparedRequest("completions.create", {}, frozenset(), {}),
+            PreparedRequest("wrong", {}),
+            PreparedRequest("completions.create", {}),
         ],
     )
     async def test_execute_rejects_invalid_prepared_request(
@@ -406,6 +463,44 @@ class TestWirePreparation:
             "max_tokens": 3,
             "extra_body": kwargs["extra_body"],
         }
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize("stream", [False, True], ids=["non-stream", "stream"])
+    async def test_request_params_snapshot_matches_pre_await_wire(
+        self, stream: bool
+    ) -> None:
+        raw = (
+            _AsyncItems([_response(_choice(text="ok"))])
+            if stream
+            else _response(_choice(text="ok"))
+        )
+        dialect, create = _dialect(raw)
+        original = {"mode": "sent"}
+        sent: dict[str, object] = {}
+
+        async def mutate_after_capture(**kwargs: object) -> object:
+            sent.update(deepcopy(kwargs))
+            original["mode"] = "changed after response"
+            extra_body = cast(dict[str, object], kwargs["extra_body"])
+            vendor = cast(dict[str, object], extra_body["vendor"])
+            vendor["mode"] = "changed inside SDK"
+            return raw
+
+        create.side_effect = mutate_after_capture
+        response = await dialect.arun(
+            Request(
+                input=CompletionInput("prompt"),
+                scheduling=SchedulingParams(stream=stream),
+                dialect_options=DialectOptions(
+                    "openai_completions",
+                    {"vendor": original},
+                ),
+            )
+        )
+
+        assert sent["extra_body"] == {"vendor": {"mode": "sent"}}
+        assert response.request_params is not None
+        assert response.request_params["extra_body"] == {"vendor": {"mode": "sent"}}
 
 
 class TestInputScoringBoundary:

--- a/tests/unit/core/models/test_dialect.py
+++ b/tests/unit/core/models/test_dialect.py
@@ -14,10 +14,10 @@ from sieval.core.models.dialect import (
     OutputContract,
     OutputContractError,
     OutputRule,
-    PassthroughObservation,
     PreparedRequest,
     RequestAudit,
     RequestAuditError,
+    WireObservation,
     active_request_capabilities,
     active_request_leaves,
     active_response_channels,
@@ -78,6 +78,22 @@ def _all_rules(guarantee=Guarantee.BEST_EFFORT):
         for name, (role, _) in response_field_contract().items()
         if role == "channel"
     }
+
+
+@dataclass(frozen=True)
+class _MismatchVerifier:
+    message: str | None
+
+    def verify(self, body: Mapping[str, JSONValue]) -> str | None:
+        del body
+        return self.message
+
+
+@dataclass(frozen=True)
+class _BrokenVerifier:
+    def verify(self, body: Mapping[str, JSONValue]) -> str | None:
+        del body
+        raise RuntimeError("verifier bug")
 
 
 class TestLeafDerivation:
@@ -253,29 +269,57 @@ class TestRequestAudit:
     def test_omitted_leaf_fails(self):
         audit = RequestAudit({"input.completion": "x"})
         with pytest.raises(RequestAuditError, match="unaccounted"):
-            audit.finish(PreparedRequest("create", {}, frozenset(), {}))
+            audit.finish(PreparedRequest("create", {}))
 
     def test_double_accounting_fails(self):
         audit = RequestAudit({"input.completion": "x"})
-        audit.consumed("input.completion")
+        audit.consumed(
+            "input.completion",
+            WireObservation(("prompt",)),
+        )
         with pytest.raises(RequestAuditError, match="twice"):
             audit.noop("input.completion", "equivalent")
 
-    def test_unclaimed_prepared_consumption_fails(self):
-        audit = RequestAudit({"input.completion": "x"})
-        audit.noop("input.completion", "empty body is semantically equivalent")
-        prepared = PreparedRequest("create", {}, frozenset({"input.completion"}), {})
-        with pytest.raises(RequestAuditError, match="unclaimed"):
-            audit.finish(prepared)
+    def test_prepared_request_detaches_the_wire_body(self):
+        body = {"extra_body": {"stop_ids": [1, 2]}}
+
+        prepared = PreparedRequest("create", body)
+        body["extra_body"]["stop_ids"].append(3)
+
+        assert prepared.body == {"extra_body": {"stop_ids": [1, 2]}}
+
+    def test_prepared_request_recursively_freezes_the_wire_body(self):
+        prepared = PreparedRequest(
+            "create",
+            {"messages": [{"role": "user", "content": ["x"]}]},
+        )
+
+        messages = cast(Any, prepared.body["messages"])
+        with pytest.raises(TypeError, match="frozen JSON sequences"):
+            messages.append({"role": "user", "content": ["y"]})
+        with pytest.raises(TypeError):
+            messages[0]["role"] = "assistant"
+        with pytest.raises(TypeError, match="frozen JSON sequences"):
+            messages[0]["content"].append("y")
+
+    def test_prepared_request_thaws_one_detached_mutable_body(self):
+        prepared = PreparedRequest(
+            "create",
+            {"extra_body": {"stop_ids": [1, 2]}},
+        )
+
+        thawed = prepared.thaw_body()
+        cast(Any, thawed["extra_body"])["stop_ids"].append(3)
+
+        assert thawed == {"extra_body": {"stop_ids": [1, 2, 3]}}
+        assert prepared.body == {"extra_body": {"stop_ids": [1, 2]}}
 
     def test_passthrough_destination_and_value_are_verified(self):
         audit = RequestAudit({"dialect_options.min_p": 0.1})
         audit.passthrough("dialect_options.min_p", "extra_body")
         altered = PreparedRequest(
             "create",
-            {},
-            frozenset(),
-            {"dialect_options.min_p": PassthroughObservation("extra_body", 0.2)},
+            {"extra_body": {"min_p": 0.2}},
         )
         with pytest.raises(RequestAuditError, match="value changed"):
             audit.finish(altered)
@@ -288,9 +332,13 @@ class TestRequestAudit:
 
     def test_active_and_decisions_views_are_detached(self):
         audit = RequestAudit({"input.completion": "x"})
+        assert audit.active_paths == ("input.completion",)
         active = cast(dict[str, object], audit.active)
         active["extra"] = True
-        audit.consumed("input.completion")
+        audit.consumed(
+            "input.completion",
+            WireObservation(("prompt",)),
+        )
         decisions = cast(dict[str, object], audit.decisions)
         decisions.clear()
 
@@ -300,7 +348,10 @@ class TestRequestAudit:
     def test_decision_must_reference_an_active_leaf(self):
         audit = RequestAudit({"input.completion": "x"})
         with pytest.raises(RequestAuditError, match="inactive leaf"):
-            audit.consumed("sampling.temperature")
+            audit.consumed(
+                "sampling.temperature",
+                WireObservation(("temperature",)),
+            )
 
     def test_noop_requires_a_documented_reason(self):
         audit = RequestAudit({"input.completion": "x"})
@@ -312,26 +363,97 @@ class TestRequestAudit:
         with pytest.raises(RequestAuditError, match="only dialect options"):
             audit.passthrough("input.completion", "body")
 
-    def test_consumed_leaf_requires_prepared_observation(self):
+    def test_consumed_leaf_requires_wire_evidence(self):
         audit = RequestAudit({"input.completion": "x"})
-        audit.consumed("input.completion")
-        with pytest.raises(RequestAuditError, match="unobserved"):
-            audit.finish(PreparedRequest("create", {}, frozenset(), {}))
+        with pytest.raises(RequestAuditError, match="requires wire evidence"):
+            audit.consumed("input.completion")
+
+    def test_consumed_leaf_requires_its_observed_wire_field(self):
+        audit = RequestAudit({"sampling.temperature": 0.25})
+        audit.consumed(
+            "sampling.temperature",
+            WireObservation(("temperature",)),
+        )
+        prepared = PreparedRequest(
+            "create",
+            {},
+        )
+
+        with pytest.raises(RequestAuditError, match="wire field.*missing"):
+            audit.finish(prepared)
+
+    def test_consumed_leaf_requires_its_observed_wire_value(self):
+        audit = RequestAudit({"sampling.temperature": 0.25})
+        audit.consumed(
+            "sampling.temperature",
+            WireObservation(("temperature",)),
+        )
+        prepared = PreparedRequest(
+            "create",
+            {"temperature": 0.5},
+        )
+
+        with pytest.raises(RequestAuditError, match="wire value changed"):
+            audit.finish(prepared)
+
+    def test_wire_observation_uses_the_audited_source_value(self):
+        audit = RequestAudit({"structured_output.strict": False})
+        audit.consumed(
+            "structured_output.strict",
+            WireObservation(("response_format", "json_schema", "strict")),
+        )
+        prepared = PreparedRequest(
+            "create",
+            {"response_format": {"json_schema": {"strict": True}}},
+        )
+
+        with pytest.raises(RequestAuditError, match="wire value changed"):
+            audit.finish(prepared)
+
+    def test_wire_verifier_reports_only_declared_mismatches(self):
+        audit = RequestAudit({"input.chat": object()})
+        audit.consumed("input.chat", _MismatchVerifier("messages changed"))
+
+        with pytest.raises(RequestAuditError, match="messages changed"):
+            audit.finish(PreparedRequest("create", {"messages": []}))
+
+    def test_wire_verifier_implementation_errors_are_not_wrapped(self):
+        audit = RequestAudit({"input.chat": object()})
+        audit.consumed("input.chat", _BrokenVerifier())
+
+        with pytest.raises(RuntimeError, match="verifier bug"):
+            audit.finish(PreparedRequest("create", {"messages": []}))
+
+    def test_request_match_uses_a_detached_nested_snapshot(self):
+        nested = {"mode": "sent"}
+        req = Request(
+            input=CompletionInput("x"),
+            dialect_options=DialectOptions(
+                "openai_completions",
+                {"vendor": nested},
+            ),
+        )
+        audit = RequestAudit(active_request_leaves(req))
+        nested["mode"] = "changed"
+
+        with pytest.raises(
+            RequestAuditError,
+            match=r"changed=.*dialect_options.vendor",
+        ):
+            audit.require_matches_request(req)
 
     def test_passthrough_paths_and_destinations_must_match(self):
         audit = RequestAudit({"dialect_options.min_p": 0.1})
         audit.passthrough("dialect_options.min_p", "extra_body")
 
-        with pytest.raises(RequestAuditError, match="paths do not match"):
-            audit.finish(PreparedRequest("create", {}, frozenset(), {}))
+        with pytest.raises(RequestAuditError, match="wire field.*missing"):
+            audit.finish(PreparedRequest("create", {}))
 
         altered = PreparedRequest(
             "create",
-            {},
-            frozenset(),
-            {"dialect_options.min_p": PassthroughObservation("body", 0.1)},
+            {"body": {"min_p": 0.1}},
         )
-        with pytest.raises(RequestAuditError, match="destination changed"):
+        with pytest.raises(RequestAuditError, match="wire field.*missing"):
             audit.finish(altered)
 
 


### PR DESCRIPTION
## Type

- fix — bug fix or alignment correction

## Summary

- Verify consumed request fields against immutable snapshots of the original request instead of dialect-provided expected values.
- Add source-aware verification for Chat messages, including ordering, roles, mixed content, images, tool calls, and tool results.
- Verify structured-output `type`, `schema`, `name`, and `strict` fields independently.
- Recursively freeze prepared wire bodies and reject audit/request mismatches before provider I/O.
- Derive persisted Chat and Completions request parameters from the exact body supplied to the provider SDK.
- Reject empty structured-output names and empty dialect-option keys with `RequestAuditError`.
- Share the frozen-JSON implementation between prepared requests and capability reconciliation.

## Related Issues

Fixes #127

## Test Plan

### Automated

- [x] Lint/format clean (`ruff check && ruff format --check`)
- [x] Type check clean (`ty check` or `mypy --strict`)
- [x] Unit tests pass (`pdm run pytest`)

### Manual

- [x] Verified message lowering that drops `content` is rejected before provider I/O.
- [x] Verified response-format lowering that drops or changes `strict=False` is rejected before provider I/O.
- [x] Verified message count, order, role, text, image, tool-call, and tool-result changes are rejected.
- [x] Verified audits created for request A cannot validate or prepare request B in either OpenAI dialect.
- [x] Verified prepared request bodies reject nested mutation after audit completion.
- [x] Verified streaming and non-streaming provenance remains equal to the actual SDK payload after caller or SDK mutation.
- [x] Verified empty structured-output names and empty dialect-option keys are rejected before provider I/O.
- [x] Verified all provider interactions use fake SDK clients; no real provider was contacted.

## Checklist

### Required (all PRs)

- [x] PR title follows conventional format (`type(scope): description`)
- [x] No internal paths, credentials, or personal info in committed files
- [x] AI-generated code has `AI-Generated Code - <model> (<provider>)` in module docstring
- [x] No new upper-layer dependencies added to `core/`
- [x] Deleted code verified — no remaining call sites depend on it