### PR TITLE
fix(tasks): a broken grader must not read as a wrong answer

### DIFF
--- a/.claude/rules/tasks.md
+++ b/.claude/rules/tasks.md
@@ -81,7 +81,29 @@ separate registered tasks (full rationale in `sieval/tasks/CLAUDE.md`).
     - A task whose report declares `DENOMINATOR_JUDGED` is the exception and owes
       its own measurement first: there a fail is *excluded* from the denominator,
       so moving a sample into `fails` does change the score
-      (`theoremqa_kshot_base_gen` is the only such member today).
+      (`theoremqa_kshot_base_gen` is the only such member *with a grading call
+      site* today — 20 tasks declare the policy, it is the only one that grades
+      through `run_cpu_bound`).
+    - **The rule reaches only what the call site can see.** It buys the signal
+      when the grader lets errors through; a grader that catches `Exception`
+      *itself* and returns a verdict anyway defeats it from below, and narrowing
+      the `except` cannot tell. `imo_answer_bench_0shot_gen` is the live case:
+      its vendored `verify_math_answer` falls back to string equality, so a
+      broken LaTeX backend scores every expression answer wrong with `fails`
+      still 0. Upstream fidelity means that fallback stays, so the task probes
+      the grader once per run instead (`_ensure_grader_healthy`) and raises on a
+      definite negative. When vendoring a grader, check whether it swallows
+      before relying on this rule; the twelve siblings are safe only because
+      `_math_verify.verify_answer` has no handler of its own.
+    - Propagating is the right default even though `exception::<class>` is
+      **retriable** (`ERROR_REASONS_NON_RETRIABLE`, `core/tasks/consts.py`), so a
+      deterministic breakage is re-graded once per resume until `max_retries`
+      runs out. Do not reach for `NonRetriableSampleError` to avoid that: it
+      declares the outcome fixed in the *sample's own input*, which an
+      environment fault is not, and mislabelling a transient failure permanently
+      fails a sample a retry would have recovered. The waste is bounded — under
+      the default `record_each_stage=True` a feedback failure rolls back to
+      `POSTPROCESSED`, so it re-grades without re-inferring.
 
 ## Tags — Anomaly Detection
 

--- a/.claude/rules/tasks.md
+++ b/.claude/rules/tasks.md
@@ -70,8 +70,13 @@ separate registered tasks (full rationale in `sieval/tasks/CLAUDE.md`).
   no re-inference, no budget burned — and under `DENOMINATOR_REQUESTED` a fail is
   already charged as wrong, so **the headline does not move**. This is why no
   `n_grade_errors` metric is needed: `fails` plus the recorded reason already is
-  one. Asserted over the whole pass@k math family in
-  `tests/unit/tasks/test_math_pass_at_k_family.py`.
+  one. Enforced tree-wide by an AST survey of every `run_cpu_bound` call site in
+  `tests/unit/tasks/test_grading_call_site_convention.py` — a hand-kept list of
+  members is what let this drift in the first place, so the check reads the
+  source rather than a registry and covers tasks whose `feedback` lives in a
+  shared base. The *behaviour* behind it (a timeout still scores wrong, every
+  other class propagates, and the headline does not move either way) is asserted
+  over the pass@k math family in `tests/unit/tasks/test_math_pass_at_k_family.py`.
     - The one thing that *does* move is a published interval: it is estimated
       over the units that came back while scaled to the requested denominator, so
       dropping one shifts the bound (in either direction), and a survivor set that
@@ -82,7 +87,7 @@ separate registered tasks (full rationale in `sieval/tasks/CLAUDE.md`).
       its own measurement first: there a fail is *excluded* from the denominator,
       so moving a sample into `fails` does change the score
       (`theoremqa_kshot_base_gen` is the only such member *with a grading call
-      site* today — 20 tasks declare the policy, it is the only one that grades
+      site* today — 19 tasks declare the policy, it is the only one that grades
       through `run_cpu_bound`).
     - **The rule reaches only what the call site can see.** It buys the signal
       when the grader lets errors through; a grader that catches `Exception`

--- a/.claude/rules/tasks.md
+++ b/.claude/rules/tasks.md
@@ -58,6 +58,30 @@ separate registered tasks (full rationale in `sieval/tasks/CLAUDE.md`).
 
 - Use `strict=True` in `zip()` when lengths are guaranteed to match
 - Must not modify `core/` — check `sieval/core/utils/` for existing helpers first
+- **A grading call site catches `TimeoutError`, never `Exception`.** A grade that
+  could not be computed *in time* is a wrong answer — the prediction is a shape
+  the grader cannot bound, which is the model's problem — so it is swallowed and
+  scored `False`. Every *other* exception propagates: a grader that is **broken
+  rather than slow** (a dead worker, an optional dependency absent from the
+  environment) must not be indistinguishable from a model that answered wrongly.
+  Swallowing it produces a low score on a run whose `fails` is 0 and whose logs
+  are gone as soon as the run is. Propagating costs nothing and buys the signal:
+  `feedback` raising goes straight to `to_failed(reason="exception::<class>")` —
+  no re-inference, no budget burned — and under `DENOMINATOR_REQUESTED` a fail is
+  already charged as wrong, so **the headline does not move**. This is why no
+  `n_grade_errors` metric is needed: `fails` plus the recorded reason already is
+  one. Asserted over the whole pass@k math family in
+  `tests/unit/tasks/test_math_pass_at_k_family.py`.
+    - The one thing that *does* move is a published interval: it is estimated
+      over the units that came back while scaled to the requested denominator, so
+      dropping one shifts the bound (in either direction), and a survivor set that
+      is uniformly right or uniformly wrong drops `<metric>_ci95` / `n_problems`
+      entirely — `wilson_interval` needs `0 < p < 1`. Pre-existing
+      `_clustered_interval` semantics, not a new one.
+    - A task whose report declares `DENOMINATOR_JUDGED` is the exception and owes
+      its own measurement first: there a fail is *excluded* from the denominator,
+      so moving a sample into `fails` does change the score
+      (`theoremqa_kshot_base_gen` is the only such member today).
 
 ## Tags — Anomaly Detection
 

--- a/sieval/tasks/aime_2024_0shot_gen.py
+++ b/sieval/tasks/aime_2024_0shot_gen.py
@@ -114,8 +114,21 @@ class AIME2024ZeroShotGenTask(
                 correct = await run_cpu_bound(
                     verify_answer, ref_with_env, pred_with_env, timeout=GRADE_TIMEOUT
                 )
-            except Exception as e:
-                logger.warning("Feedback failed for sample {}: {}", ctx.sample_id, e)
+            except TimeoutError:
+                # A grade that could not be COMPUTED IN TIME is a wrong answer,
+                # not a failed run: the contract the whole math family keeps, and
+                # `report` counts fails in the denominator, so the accuracy is
+                # the same either way. Every OTHER exception now propagates and
+                # the sample lands in `fails` as `exception::<class>` -- a grader
+                # that is broken rather than slow (a dead worker, an optional
+                # dependency missing from the environment) must not read as a
+                # model that answered wrongly.
+                logger.warning(
+                    "Grading sample {} exceeded {}s and was scored wrong; the "
+                    "prediction is likely a shape the grader cannot bound.",
+                    ctx.sample_id,
+                    GRADE_TIMEOUT,
+                )
                 correct = False
             rollouts.append(build_rollout_judgement(rollout["index"], correct))
         return True, build_judgement_record(ground_truth, rollouts)

--- a/sieval/tasks/aime_2025_0shot_gen.py
+++ b/sieval/tasks/aime_2025_0shot_gen.py
@@ -114,8 +114,21 @@ class AIME2025ZeroShotGenTask(
                 correct = await run_cpu_bound(
                     verify_answer, ref_with_env, pred_with_env, timeout=GRADE_TIMEOUT
                 )
-            except Exception as e:
-                logger.warning("Feedback failed for sample {}: {}", ctx.sample_id, e)
+            except TimeoutError:
+                # A grade that could not be COMPUTED IN TIME is a wrong answer,
+                # not a failed run: the contract the whole math family keeps, and
+                # `report` counts fails in the denominator, so the accuracy is
+                # the same either way. Every OTHER exception now propagates and
+                # the sample lands in `fails` as `exception::<class>` -- a grader
+                # that is broken rather than slow (a dead worker, an optional
+                # dependency missing from the environment) must not read as a
+                # model that answered wrongly.
+                logger.warning(
+                    "Grading sample {} exceeded {}s and was scored wrong; the "
+                    "prediction is likely a shape the grader cannot bound.",
+                    ctx.sample_id,
+                    GRADE_TIMEOUT,
+                )
                 correct = False
             rollouts.append(build_rollout_judgement(rollout["index"], correct))
         return True, build_judgement_record(ground_truth, rollouts)

--- a/sieval/tasks/aime_2026_0shot_gen.py
+++ b/sieval/tasks/aime_2026_0shot_gen.py
@@ -132,8 +132,21 @@ class AIME2026ZeroShotGenTask(
                 correct = await run_cpu_bound(
                     verify_answer, ref_with_env, pred_with_env, timeout=GRADE_TIMEOUT
                 )
-            except Exception as e:
-                logger.warning("Feedback failed for sample {}: {}", ctx.sample_id, e)
+            except TimeoutError:
+                # A grade that could not be COMPUTED IN TIME is a wrong answer,
+                # not a failed run: the contract the whole math family keeps, and
+                # `report` counts fails in the denominator, so the accuracy is
+                # the same either way. Every OTHER exception now propagates and
+                # the sample lands in `fails` as `exception::<class>` -- a grader
+                # that is broken rather than slow (a dead worker, an optional
+                # dependency missing from the environment) must not read as a
+                # model that answered wrongly.
+                logger.warning(
+                    "Grading sample {} exceeded {}s and was scored wrong; the "
+                    "prediction is likely a shape the grader cannot bound.",
+                    ctx.sample_id,
+                    GRADE_TIMEOUT,
+                )
                 correct = False
             rollouts.append(build_rollout_judgement(rollout["index"], correct))
         return True, build_judgement_record(ground_truth, rollouts)

--- a/sieval/tasks/apex_2025_0shot_gen.py
+++ b/sieval/tasks/apex_2025_0shot_gen.py
@@ -151,8 +151,21 @@ class Apex2025ZeroShotGenTask(
                 correct = await run_cpu_bound(
                     verify_answer, ref_with_env, pred_with_env, timeout=GRADE_TIMEOUT
                 )
-            except Exception as e:
-                logger.warning("Feedback failed for sample {}: {}", ctx.sample_id, e)
+            except TimeoutError:
+                # A grade that could not be COMPUTED IN TIME is a wrong answer,
+                # not a failed run: the contract the whole math family keeps, and
+                # `report` counts fails in the denominator, so the accuracy is
+                # the same either way. Every OTHER exception now propagates and
+                # the sample lands in `fails` as `exception::<class>` -- a grader
+                # that is broken rather than slow (a dead worker, an optional
+                # dependency missing from the environment) must not read as a
+                # model that answered wrongly.
+                logger.warning(
+                    "Grading sample {} exceeded {}s and was scored wrong; the "
+                    "prediction is likely a shape the grader cannot bound.",
+                    ctx.sample_id,
+                    GRADE_TIMEOUT,
+                )
                 correct = False
             rollouts.append(build_rollout_judgement(rollout["index"], correct))
         return True, build_judgement_record(ground_truth, rollouts)

--- a/sieval/tasks/apex_shortlist_2025_0shot_gen.py
+++ b/sieval/tasks/apex_shortlist_2025_0shot_gen.py
@@ -158,8 +158,21 @@ class ApexShortlist2025ZeroShotGenTask(
                 correct = await run_cpu_bound(
                     verify_answer, ref_with_env, pred_with_env, timeout=GRADE_TIMEOUT
                 )
-            except Exception as e:
-                logger.warning("Feedback failed for sample {}: {}", ctx.sample_id, e)
+            except TimeoutError:
+                # A grade that could not be COMPUTED IN TIME is a wrong answer,
+                # not a failed run: the contract the whole math family keeps, and
+                # `report` counts fails in the denominator, so the accuracy is
+                # the same either way. Every OTHER exception now propagates and
+                # the sample lands in `fails` as `exception::<class>` -- a grader
+                # that is broken rather than slow (a dead worker, an optional
+                # dependency missing from the environment) must not read as a
+                # model that answered wrongly.
+                logger.warning(
+                    "Grading sample {} exceeded {}s and was scored wrong; the "
+                    "prediction is likely a shape the grader cannot bound.",
+                    ctx.sample_id,
+                    GRADE_TIMEOUT,
+                )
                 correct = False
             rollouts.append(build_rollout_judgement(rollout["index"], correct))
         return True, build_judgement_record(ground_truth, rollouts)

--- a/sieval/tasks/brumo_2025_0shot_gen.py
+++ b/sieval/tasks/brumo_2025_0shot_gen.py
@@ -148,8 +148,21 @@ class BRUMO2025ZeroShotGenTask(
                 correct = await run_cpu_bound(
                     verify_answer, ref_with_env, pred_with_env, timeout=GRADE_TIMEOUT
                 )
-            except Exception as e:
-                logger.warning("Feedback failed for sample {}: {}", ctx.sample_id, e)
+            except TimeoutError:
+                # A grade that could not be COMPUTED IN TIME is a wrong answer,
+                # not a failed run: the contract the whole math family keeps, and
+                # `report` counts fails in the denominator, so the accuracy is
+                # the same either way. Every OTHER exception now propagates and
+                # the sample lands in `fails` as `exception::<class>` -- a grader
+                # that is broken rather than slow (a dead worker, an optional
+                # dependency missing from the environment) must not read as a
+                # model that answered wrongly.
+                logger.warning(
+                    "Grading sample {} exceeded {}s and was scored wrong; the "
+                    "prediction is likely a shape the grader cannot bound.",
+                    ctx.sample_id,
+                    GRADE_TIMEOUT,
+                )
                 correct = False
             rollouts.append(build_rollout_judgement(rollout["index"], correct))
         return True, build_judgement_record(ground_truth, rollouts)

--- a/sieval/tasks/cmimc_2025_0shot_gen.py
+++ b/sieval/tasks/cmimc_2025_0shot_gen.py
@@ -149,8 +149,21 @@ class CMIMC2025ZeroShotGenTask(
                 correct = await run_cpu_bound(
                     verify_answer, ref_with_env, pred_with_env, timeout=GRADE_TIMEOUT
                 )
-            except Exception as e:
-                logger.warning("Feedback failed for sample {}: {}", ctx.sample_id, e)
+            except TimeoutError:
+                # A grade that could not be COMPUTED IN TIME is a wrong answer,
+                # not a failed run: the contract the whole math family keeps, and
+                # `report` counts fails in the denominator, so the accuracy is
+                # the same either way. Every OTHER exception now propagates and
+                # the sample lands in `fails` as `exception::<class>` -- a grader
+                # that is broken rather than slow (a dead worker, an optional
+                # dependency missing from the environment) must not read as a
+                # model that answered wrongly.
+                logger.warning(
+                    "Grading sample {} exceeded {}s and was scored wrong; the "
+                    "prediction is likely a shape the grader cannot bound.",
+                    ctx.sample_id,
+                    GRADE_TIMEOUT,
+                )
                 correct = False
             rollouts.append(build_rollout_judgement(rollout["index"], correct))
         return True, build_judgement_record(ground_truth, rollouts)

--- a/sieval/tasks/hmmt_feb_2025_0shot_gen.py
+++ b/sieval/tasks/hmmt_feb_2025_0shot_gen.py
@@ -144,8 +144,21 @@ class HMMTFeb2025ZeroShotGenTask(
                 correct = await run_cpu_bound(
                     verify_answer, ref_with_env, pred_with_env, timeout=GRADE_TIMEOUT
                 )
-            except Exception as e:
-                logger.warning("Feedback failed for sample {}: {}", ctx.sample_id, e)
+            except TimeoutError:
+                # A grade that could not be COMPUTED IN TIME is a wrong answer,
+                # not a failed run: the contract the whole math family keeps, and
+                # `report` counts fails in the denominator, so the accuracy is
+                # the same either way. Every OTHER exception now propagates and
+                # the sample lands in `fails` as `exception::<class>` -- a grader
+                # that is broken rather than slow (a dead worker, an optional
+                # dependency missing from the environment) must not read as a
+                # model that answered wrongly.
+                logger.warning(
+                    "Grading sample {} exceeded {}s and was scored wrong; the "
+                    "prediction is likely a shape the grader cannot bound.",
+                    ctx.sample_id,
+                    GRADE_TIMEOUT,
+                )
                 correct = False
             rollouts.append(build_rollout_judgement(rollout["index"], correct))
         return True, build_judgement_record(ground_truth, rollouts)

--- a/sieval/tasks/hmmt_feb_2026_0shot_gen.py
+++ b/sieval/tasks/hmmt_feb_2026_0shot_gen.py
@@ -132,8 +132,21 @@ class HMMTFeb2026ZeroShotGenTask(
                 correct = await run_cpu_bound(
                     verify_answer, ref_with_env, pred_with_env, timeout=GRADE_TIMEOUT
                 )
-            except Exception as e:
-                logger.warning("Feedback failed for sample {}: {}", ctx.sample_id, e)
+            except TimeoutError:
+                # A grade that could not be COMPUTED IN TIME is a wrong answer,
+                # not a failed run: the contract the whole math family keeps, and
+                # `report` counts fails in the denominator, so the accuracy is
+                # the same either way. Every OTHER exception now propagates and
+                # the sample lands in `fails` as `exception::<class>` -- a grader
+                # that is broken rather than slow (a dead worker, an optional
+                # dependency missing from the environment) must not read as a
+                # model that answered wrongly.
+                logger.warning(
+                    "Grading sample {} exceeded {}s and was scored wrong; the "
+                    "prediction is likely a shape the grader cannot bound.",
+                    ctx.sample_id,
+                    GRADE_TIMEOUT,
+                )
                 correct = False
             rollouts.append(build_rollout_judgement(rollout["index"], correct))
         return True, build_judgement_record(ground_truth, rollouts)

--- a/sieval/tasks/hmmt_nov_2025_0shot_gen.py
+++ b/sieval/tasks/hmmt_nov_2025_0shot_gen.py
@@ -146,8 +146,21 @@ class HMMTNov2025ZeroShotGenTask(
                 correct = await run_cpu_bound(
                     verify_answer, ref_with_env, pred_with_env, timeout=GRADE_TIMEOUT
                 )
-            except Exception as e:
-                logger.warning("Feedback failed for sample {}: {}", ctx.sample_id, e)
+            except TimeoutError:
+                # A grade that could not be COMPUTED IN TIME is a wrong answer,
+                # not a failed run: the contract the whole math family keeps, and
+                # `report` counts fails in the denominator, so the accuracy is
+                # the same either way. Every OTHER exception now propagates and
+                # the sample lands in `fails` as `exception::<class>` -- a grader
+                # that is broken rather than slow (a dead worker, an optional
+                # dependency missing from the environment) must not read as a
+                # model that answered wrongly.
+                logger.warning(
+                    "Grading sample {} exceeded {}s and was scored wrong; the "
+                    "prediction is likely a shape the grader cannot bound.",
+                    ctx.sample_id,
+                    GRADE_TIMEOUT,
+                )
                 correct = False
             rollouts.append(build_rollout_judgement(rollout["index"], correct))
         return True, build_judgement_record(ground_truth, rollouts)

--- a/sieval/tasks/imo_answer_bench_0shot_gen.py
+++ b/sieval/tasks/imo_answer_bench_0shot_gen.py
@@ -14,6 +14,12 @@ Dual-source lineage: the boxed prompt + last-``\\boxed{}`` extraction follow
 eth-sri/matharena (``community/matharena.py``); the answer grader is EnvCommons's
 deterministic re-impl of IMO-Bench (``community/imo_bench.py``).
 
+Environment prerequisite: unlike its siblings, this task's vendored grader catches
+its own exceptions and falls back to string equality, so a broken LaTeX backend
+would depress the score silently rather than raise. ``_ensure_grader_healthy``
+probes it once per run and fails the run instead; it needs the ``math`` dependency
+group (``math-verify[antlr4-11-0]``) actually installed, not merely importable.
+
 Infer prerequisites: olympiad reasoning traces are very long — set a large output
 budget (``max_tokens`` ≈ 131072) and a generous client read-timeout (300s+). At
 ``max_tokens=65536`` ~22% of samples truncate mid-reasoning with no boxed answer
@@ -22,6 +28,7 @@ budget (``max_tokens`` ≈ 131072) and a generous client read-timeout (300s+). A
 AI-Generated Code - Claude Opus 4.8 (Anthropic)
 """
 
+import asyncio
 from typing import override
 
 from loguru import logger
@@ -62,6 +69,13 @@ from ._math_verify import normalize_vote
 IMO_ANSWER_BENCH_INSTRUCTION = (
     "Please reason step by step. Put your final answer within \\boxed{}."
 )
+
+# One gold/prediction pair the grader must call equivalent, used to probe it once
+# per run (`_ensure_grader_healthy`). `$`-wrapped exactly like a real grade so the
+# probe walks the same path, and picked to NEED the LaTeX backend: math_verify
+# calls it True, while the string fallback verify_math_answer degrades to calls it
+# False. That gap is the whole signal.
+GRADER_CANARY = (r"$\frac{1}{2}$", "$0.5$")
 
 
 @sieval_task(
@@ -154,6 +168,60 @@ class IMOAnswerBenchZeroShotGenTask(
             )
         self._k = k
         self._n = n
+        # Probe-once state for `_ensure_grader_healthy`. The flag is read outside
+        # the lock so the common path stays lock-free; the lock only keeps the
+        # first concurrent burst from probing once per sample.
+        self._grader_probed = False
+        self._grader_probe_lock = asyncio.Lock()
+
+    async def _ensure_grader_healthy(self) -> None:
+        """Fail loudly, once, if the grader cannot do LaTeX equivalence at all.
+
+        `verify_math_answer` catches `Exception` **itself** and falls back to
+        ``gold.strip().lower() == pred.strip().lower()``. That is upstream's
+        behaviour and stays. The cost is that a broken LaTeX backend never
+        raises: it silently regrades the run by string equality, scoring every
+        expression answer wrong while `fails` stays 0. It is the one grader
+        failure this family's `except TimeoutError` contract cannot catch,
+        because the swallow sits BELOW the call site rather than at it -- the
+        sibling tasks are safe only because `_math_verify.verify_answer` has no
+        handler of its own and lets the error through.
+
+        So probe instead of trusting: one grade whose verdict flips with the
+        backend. Raising lands the sample in `fails` as
+        ``exception::RuntimeError``, the same signal the rest of the family gets
+        for free -- no new metric, no new machinery.
+
+        Only a definite ``False`` fails. A probe that times out is inconclusive,
+        not negative, so it warns and stops probing rather than turning a loaded
+        box into a failed run.
+        """
+        if self._grader_probed:
+            return
+        async with self._grader_probe_lock:
+            if self._grader_probed:
+                return
+            try:
+                healthy = await run_cpu_bound(
+                    verify_math_answer, *GRADER_CANARY, timeout=GRADE_TIMEOUT
+                )
+            except TimeoutError:
+                logger.warning(
+                    "Grader self-check timed out after {}s; proceeding unprobed. "
+                    "A LaTeX backend that is merely slow still grades correctly.",
+                    GRADE_TIMEOUT,
+                )
+                self._grader_probed = True
+                return
+            if not healthy:
+                raise RuntimeError(
+                    f"Grader self-check failed: verify_math_answer{GRADER_CANARY} "
+                    "returned False, so math_verify cannot parse LaTeX and every "
+                    "grade is falling back to string equality -- expression "
+                    "answers would score wrong with no other symptom. Check the "
+                    "`math` dependency group (math-verify[antlr4-11-0]==0.8.0)."
+                )
+            self._grader_probed = True
 
     @override
     async def preprocess(self, raw, ctx):
@@ -187,6 +255,9 @@ class IMOAnswerBenchZeroShotGenTask(
 
     @override
     async def feedback(self, post, ctx):
+        # Before trusting any verdict: this task's grader swallows its own
+        # errors, so the `except TimeoutError` below cannot see a broken one.
+        await self._ensure_grader_healthy()
         rollouts = []
         ground_truth = ctx.raw_sample["answer"]
         gold = normalize_answer(ground_truth)
@@ -213,6 +284,12 @@ class IMOAnswerBenchZeroShotGenTask(
                 # that is broken rather than slow (a dead worker, an optional
                 # dependency missing from the environment) must not read as a
                 # model that answered wrongly.
+                #
+                # UNLIKE the siblings, that only covers errors this call site can
+                # SEE. `verify_math_answer` catches `Exception` itself
+                # (community/imo_bench.py) and falls back to string equality, so
+                # a broken LaTeX backend never reaches here --
+                # `_ensure_grader_healthy` is what covers that half.
                 logger.warning(
                     "Grading sample {} exceeded {}s and was scored wrong; the "
                     "prediction is likely a shape the grader cannot bound.",

--- a/sieval/tasks/imo_answer_bench_0shot_gen.py
+++ b/sieval/tasks/imo_answer_bench_0shot_gen.py
@@ -204,8 +204,21 @@ class IMOAnswerBenchZeroShotGenTask(
                 correct = await run_cpu_bound(
                     verify_math_answer, f"${gold}$", f"${pred}$", timeout=GRADE_TIMEOUT
                 )
-            except Exception as e:
-                logger.warning("Feedback failed for sample {}: {}", ctx.sample_id, e)
+            except TimeoutError:
+                # A grade that could not be COMPUTED IN TIME is a wrong answer,
+                # not a failed run: the contract the whole math family keeps, and
+                # `report` counts fails in the denominator, so the accuracy is
+                # the same either way. Every OTHER exception now propagates and
+                # the sample lands in `fails` as `exception::<class>` -- a grader
+                # that is broken rather than slow (a dead worker, an optional
+                # dependency missing from the environment) must not read as a
+                # model that answered wrongly.
+                logger.warning(
+                    "Grading sample {} exceeded {}s and was scored wrong; the "
+                    "prediction is likely a shape the grader cannot bound.",
+                    ctx.sample_id,
+                    GRADE_TIMEOUT,
+                )
                 correct = False
             rollouts.append(build_rollout_judgement(rollout["index"], correct))
         # `reference` is the raw dataset gold, not the normalized one: normalization

--- a/sieval/tasks/imo_answer_bench_0shot_gen.py
+++ b/sieval/tasks/imo_answer_bench_0shot_gen.py
@@ -170,8 +170,12 @@ class IMOAnswerBenchZeroShotGenTask(
         self._n = n
         # Probe-once state for `_ensure_grader_healthy`. The flag is read outside
         # the lock so the common path stays lock-free; the lock only keeps the
-        # first concurrent burst from probing once per sample.
+        # first concurrent burst from probing once per sample. The verdict is
+        # cached as a MESSAGE rather than an exception instance: every later
+        # sample must still fail, and re-raising one instance would grow its
+        # `__traceback__` once per sample for the length of the run.
         self._grader_probed = False
+        self._grader_probe_error: str | None = None
         self._grader_probe_lock = asyncio.Lock()
 
     async def _ensure_grader_healthy(self) -> None:
@@ -195,33 +199,47 @@ class IMOAnswerBenchZeroShotGenTask(
         Only a definite ``False`` fails. A probe that times out is inconclusive,
         not negative, so it warns and stops probing rather than turning a loaded
         box into a failed run.
+
+        A definite negative fails EVERY sample, not just the one that happened to
+        probe -- but the probe itself is paid once and the verdict cached, so a
+        400-problem run does not buy 400 worker round trips (times `max_retries`,
+        since ``exception::RuntimeError`` is retriable) to re-learn one answer.
+
+        Only the *swallowed* failure needs this. `math_verify` missing outright
+        raises ``ImportError`` from `verify_math_answer`'s own import line, above
+        the fallback, so it propagates as ``exception::ImportError`` through the
+        ordinary contract and never reaches the canary.
         """
-        if self._grader_probed:
-            return
-        async with self._grader_probe_lock:
-            if self._grader_probed:
-                return
-            try:
-                healthy = await run_cpu_bound(
-                    verify_math_answer, *GRADER_CANARY, timeout=GRADE_TIMEOUT
-                )
-            except TimeoutError:
-                logger.warning(
-                    "Grader self-check timed out after {}s; proceeding unprobed. "
-                    "A LaTeX backend that is merely slow still grades correctly.",
-                    GRADE_TIMEOUT,
-                )
-                self._grader_probed = True
-                return
-            if not healthy:
-                raise RuntimeError(
-                    f"Grader self-check failed: verify_math_answer{GRADER_CANARY} "
-                    "returned False, so math_verify cannot parse LaTeX and every "
-                    "grade is falling back to string equality -- expression "
-                    "answers would score wrong with no other symptom. Check the "
-                    "`math` dependency group (math-verify[antlr4-11-0]==0.8.0)."
-                )
-            self._grader_probed = True
+        if not self._grader_probed:
+            async with self._grader_probe_lock:
+                if not self._grader_probed:
+                    self._grader_probe_error = await self._probe_grader()
+                    self._grader_probed = True
+        if self._grader_probe_error is not None:
+            raise RuntimeError(self._grader_probe_error)
+
+    async def _probe_grader(self) -> str | None:
+        """Grade the canary once; the message to fail on, or ``None`` if healthy."""
+        try:
+            healthy = await run_cpu_bound(
+                verify_math_answer, *GRADER_CANARY, timeout=GRADE_TIMEOUT
+            )
+        except TimeoutError:
+            logger.warning(
+                "Grader self-check timed out after {}s; proceeding unprobed. "
+                "A LaTeX backend that is merely slow still grades correctly.",
+                GRADE_TIMEOUT,
+            )
+            return None
+        if healthy:
+            return None
+        return (
+            f"Grader self-check failed: verify_math_answer{GRADER_CANARY} "
+            "returned False, so math_verify cannot parse LaTeX and every "
+            "grade is falling back to string equality -- expression "
+            "answers would score wrong with no other symptom. Check the "
+            "`math` dependency group (math-verify[antlr4-11-0]==0.8.0)."
+        )
 
     @override
     async def preprocess(self, raw, ctx):

--- a/sieval/tasks/math_500_0shot_gen.py
+++ b/sieval/tasks/math_500_0shot_gen.py
@@ -120,8 +120,21 @@ class MATH500ZeroShotGenTask(
                 correct = await run_cpu_bound(
                     verify_answer, ref_with_env, pred_with_env, timeout=GRADE_TIMEOUT
                 )
-            except Exception as e:
-                logger.warning("Feedback failed for sample {}: {}", ctx.sample_id, e)
+            except TimeoutError:
+                # A grade that could not be COMPUTED IN TIME is a wrong answer,
+                # not a failed run: the contract the whole math family keeps, and
+                # `report` counts fails in the denominator, so the accuracy is
+                # the same either way. Every OTHER exception now propagates and
+                # the sample lands in `fails` as `exception::<class>` -- a grader
+                # that is broken rather than slow (a dead worker, an optional
+                # dependency missing from the environment) must not read as a
+                # model that answered wrongly.
+                logger.warning(
+                    "Grading sample {} exceeded {}s and was scored wrong; the "
+                    "prediction is likely a shape the grader cannot bound.",
+                    ctx.sample_id,
+                    GRADE_TIMEOUT,
+                )
                 correct = False
             rollouts.append(build_rollout_judgement(rollout["index"], correct))
         return True, build_judgement_record(ground_truth, rollouts)

--- a/sieval/tasks/smt_2025_0shot_gen.py
+++ b/sieval/tasks/smt_2025_0shot_gen.py
@@ -146,8 +146,21 @@ class SMT2025ZeroShotGenTask(
                 correct = await run_cpu_bound(
                     verify_answer, ref_with_env, pred_with_env, timeout=GRADE_TIMEOUT
                 )
-            except Exception as e:
-                logger.warning("Feedback failed for sample {}: {}", ctx.sample_id, e)
+            except TimeoutError:
+                # A grade that could not be COMPUTED IN TIME is a wrong answer,
+                # not a failed run: the contract the whole math family keeps, and
+                # `report` counts fails in the denominator, so the accuracy is
+                # the same either way. Every OTHER exception now propagates and
+                # the sample lands in `fails` as `exception::<class>` -- a grader
+                # that is broken rather than slow (a dead worker, an optional
+                # dependency missing from the environment) must not read as a
+                # model that answered wrongly.
+                logger.warning(
+                    "Grading sample {} exceeded {}s and was scored wrong; the "
+                    "prediction is likely a shape the grader cannot bound.",
+                    ctx.sample_id,
+                    GRADE_TIMEOUT,
+                )
                 correct = False
             rollouts.append(build_rollout_judgement(rollout["index"], correct))
         return True, build_judgement_record(ground_truth, rollouts)

--- a/tests/unit/tasks/test_grading_call_site_convention.py
+++ b/tests/unit/tasks/test_grading_call_site_convention.py
@@ -1,0 +1,104 @@
+"""Every grading call site in `sieval/tasks/` catches `TimeoutError`, and nothing else.
+
+The convention itself is argued in `.claude/rules/tasks.md`: a grade that could not
+be computed *in time* is a wrong answer, while a grader that is **broken rather than
+slow** must not be indistinguishable from a model that answered wrongly. What that
+rule could not do on its own is stay true. It was written down beside a family test
+that enumerates its members by hand, so the next task to copy an older template back
+into the tree would have re-drifted with nothing to catch it — the survey proving the
+tree uniform was a one-off run by a human, leaving no artifact.
+
+This is that survey, kept. It reads the AST rather than the registry, so it covers
+every member of every family at once, including tasks whose `feedback` lives in a
+shared base and tasks nobody thought to add to a list.
+
+AI-Generated Code - Claude Opus 5 (1M context) (Anthropic)
+"""
+
+import ast
+import pathlib
+from typing import NamedTuple
+
+import sieval
+
+#: Resolved from the imported package rather than from this file's parents, so a
+#: worktree cannot survey the primary checkout's `sieval/` by accident.
+TASKS_DIR = pathlib.Path(sieval.__file__).parent / "tasks"
+
+#: A floor, not a count: it only needs raising when grading sites are *removed*,
+#: and it is what stops a broken scan from passing as "no offenders found".
+MIN_EXPECTED_SITES = 20
+
+
+class _Site(NamedTuple):
+    file: str
+    lineno: int
+    caught: tuple[str, ...]
+
+    def __str__(self) -> str:
+        return f"{self.file}:{self.lineno} catches {', '.join(self.caught) or 'BARE'}"
+
+
+def _calls_run_cpu_bound(body: list[ast.stmt]) -> bool:
+    """Whether *body* grades through `run_cpu_bound`.
+
+    Scoped to the `try` BODY: a call in `else`/`finally` is not protected by the
+    handlers, so it is not the thing this rule is about.
+    """
+    for stmt in body:
+        for node in ast.walk(stmt):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            name = getattr(func, "id", None) or getattr(func, "attr", None)
+            if name == "run_cpu_bound":
+                return True
+    return False
+
+
+def _caught(handler: ast.ExceptHandler) -> tuple[str, ...]:
+    if handler.type is None:
+        return ()
+    if isinstance(handler.type, ast.Tuple):
+        return tuple(ast.unparse(e) for e in handler.type.elts)
+    return (ast.unparse(handler.type),)
+
+
+def _grading_sites() -> list[_Site]:
+    sites = []
+    for path in sorted(TASKS_DIR.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Try) and _calls_run_cpu_bound(node.body):
+                sites.extend(
+                    _Site(path.name, h.lineno, _caught(h)) for h in node.handlers
+                )
+    return sites
+
+
+def test_the_survey_still_finds_the_grading_sites():
+    # Without this, a scan that silently stopped matching would report a clean
+    # tree — the one way this file could pass while asserting nothing.
+    sites = _grading_sites()
+    assert len(sites) >= MIN_EXPECTED_SITES, (
+        f"only {len(sites)} grading sites found under {TASKS_DIR}; the AST scan "
+        "has probably stopped matching rather than the tree having shrunk"
+    )
+
+
+def test_a_grading_call_site_catches_timeout_and_nothing_else():
+    """The rule, enforced over the whole tree instead of a hand-kept list.
+
+    `except Exception` here records every way a grader can fail — a dead worker, an
+    optional dependency missing from the environment, a defect in a vendored grader
+    — as the model having answered wrongly, finishing the run with `fails = 0` and a
+    depressed score whose only trace is a log line.
+    """
+    offenders = [s for s in _grading_sites() if s.caught != ("TimeoutError",)]
+    assert not offenders, (
+        "a grading call site must catch `TimeoutError` only, so that a grader "
+        "which is broken rather than slow lands in `fails` as "
+        "`exception::<class>` instead of scoring the sample wrong:\n  "
+        + "\n  ".join(str(s) for s in offenders)
+        + "\nSee the grading-call-site rule in `.claude/rules/tasks.md`."
+    )

--- a/tests/unit/tasks/test_imo_answer_bench_0shot_gen.py
+++ b/tests/unit/tasks/test_imo_answer_bench_0shot_gen.py
@@ -111,6 +111,23 @@ async def test_a_dead_latex_backend_fails_the_run_instead_of_the_model(monkeypat
 
 
 @pytest.mark.anyio
+async def test_a_dead_backend_fails_every_sample_but_is_probed_only_once(monkeypatch):
+    # The whole run must fail, not just the sample that drew the probe -- and the
+    # verdict is cached, so it does not buy one worker round trip per sample (times
+    # `max_retries`, since `exception::RuntimeError` is retriable) to re-learn it.
+    task = _build()
+    grader = _Grader(probe_result=False)
+    monkeypatch.setattr(task_mod, "run_cpu_bound", grader)
+
+    for sample_id in range(3):
+        with pytest.raises(RuntimeError, match="string equality"):
+            await _feedback(task, sample_id=sample_id)
+
+    assert grader.probe_calls == 1
+    assert grader.grade_calls == 0
+
+
+@pytest.mark.anyio
 async def test_a_healthy_grader_is_probed_and_then_stays_out_of_the_way(monkeypatch):
     task = _build()
     grader = _Grader(probe_result=True, grade_result=True)

--- a/tests/unit/tasks/test_imo_answer_bench_0shot_gen.py
+++ b/tests/unit/tasks/test_imo_answer_bench_0shot_gen.py
@@ -1,0 +1,155 @@
+"""The grader self-check `imo_answer_bench` needs and its siblings do not.
+
+Every other member of the pass@k math family grades through
+`_math_verify.verify_answer`, which has no handler of its own, so a broken
+`math_verify` raises and the family's `except TimeoutError` contract turns it
+into a `fails` entry. This task grades through the vendored
+`community/imo_bench.verify_math_answer`, which catches `Exception` itself and
+falls back to `gold.strip().lower() == pred.strip().lower()` -- upstream's
+behaviour, which stays. A broken LaTeX backend therefore never reaches the call
+site at all: it silently regrades the run by string equality, scoring every
+expression answer wrong while `fails` stays 0.
+
+`_ensure_grader_healthy` is what closes that half, so these assert the probe
+itself: it fires on a definite negative, stays out of the way otherwise, runs
+once rather than per sample, and treats a timeout as inconclusive rather than as
+a failure -- a loaded box must not read as a broken one.
+
+AI-Generated Code - Claude Opus 5 (1M context) (Anthropic)
+"""
+
+import pytest
+from datasets import Dataset as HFDataset
+from datasets import DatasetDict as HFDatasetDict
+
+from sieval.core.models import ChatModel, Request, Response
+from sieval.core.tasks import TaskContext, build_prediction_record
+from sieval.datasets.imo_answer_bench import IMOAnswerBenchDataset
+from sieval.tasks import imo_answer_bench_0shot_gen as task_mod
+from sieval.tasks.imo_answer_bench_0shot_gen import (
+    GRADER_CANARY,
+    IMOAnswerBenchZeroShotGenTask,
+)
+from tests.conftest import HandlerTransport
+
+PROBLEM = "What is 6 times 7?"
+ANSWER = "42"
+
+
+class _StubChatModel(ChatModel):
+    def __init__(self):
+        super().__init__(model="mock-chat", api_key="fake")
+
+    def _build_default_transport(self) -> HandlerTransport:
+        return HandlerTransport(self._stub_arun, "openai_chat")
+
+    async def _stub_arun(self, req: Request) -> Response:
+        return Response(texts=(rf"\boxed{{{ANSWER}}}",) * req.sampling.n)
+
+
+def _build() -> IMOAnswerBenchZeroShotGenTask:
+    rows = HFDataset.from_list([{"problem": PROBLEM, "answer": ANSWER}])
+    dataset = IMOAnswerBenchDataset(
+        _hf_dict=HFDatasetDict({"train": rows, "test": rows})
+    )
+    return IMOAnswerBenchZeroShotGenTask(dataset, _StubChatModel(), k=1, n=1)
+
+
+class _Grader:
+    """A `run_cpu_bound` stand-in separating the PROBE call from a real grade.
+
+    The probe is the one whose positional args are `GRADER_CANARY`; everything
+    else is a sample being graded. Both are counted, so a test cannot pass
+    because the probe was never reached -- which is what moving the call out of
+    `feedback` would otherwise look like.
+    """
+
+    def __init__(self, *, probe_result: object = True, grade_result: bool = True):
+        self._probe_result = probe_result
+        self._grade_result = grade_result
+        self.probe_calls = 0
+        self.grade_calls = 0
+
+    async def __call__(self, _fn, *args, **_kwargs):
+        if args == GRADER_CANARY:
+            self.probe_calls += 1
+            if isinstance(self._probe_result, type) and issubclass(
+                self._probe_result, BaseException
+            ):
+                raise self._probe_result("probe stub")
+            return self._probe_result
+        self.grade_calls += 1
+        return self._grade_result
+
+
+async def _feedback(task, sample_id: int = 0):
+    post = build_prediction_record([ANSWER])
+    return await task.feedback(
+        post,
+        TaskContext(
+            sample_id=sample_id,
+            raw_sample={"problem": PROBLEM, "answer": ANSWER},
+            postprocess_result=post,
+        ),
+    )
+
+
+@pytest.mark.anyio
+async def test_a_dead_latex_backend_fails_the_run_instead_of_the_model(monkeypatch):
+    # The failure this task cannot otherwise see: `verify_math_answer` returns a
+    # verdict rather than raising, so without the probe the run would finish with
+    # a depressed score and `fails = 0`.
+    task = _build()
+    grader = _Grader(probe_result=False)
+    monkeypatch.setattr(task_mod, "run_cpu_bound", grader)
+
+    with pytest.raises(RuntimeError, match="string equality"):
+        await _feedback(task)
+    assert grader.probe_calls == 1
+    # It never got as far as grading anything -- the point of failing early.
+    assert grader.grade_calls == 0
+
+
+@pytest.mark.anyio
+async def test_a_healthy_grader_is_probed_and_then_stays_out_of_the_way(monkeypatch):
+    task = _build()
+    grader = _Grader(probe_result=True, grade_result=True)
+    monkeypatch.setattr(task_mod, "run_cpu_bound", grader)
+
+    _, judgement = await _feedback(task)
+
+    assert judgement["rollouts"][0]["correct"] is True
+    assert grader.probe_calls == 1
+    assert grader.grade_calls == 1
+
+
+@pytest.mark.anyio
+async def test_the_probe_runs_once_per_task_not_once_per_sample(monkeypatch):
+    # A probe is a worker round trip; paying it per sample would be a real cost
+    # on a 400-problem benchmark.
+    task = _build()
+    grader = _Grader(probe_result=True)
+    monkeypatch.setattr(task_mod, "run_cpu_bound", grader)
+
+    for sample_id in range(3):
+        await _feedback(task, sample_id=sample_id)
+
+    assert grader.probe_calls == 1
+    assert grader.grade_calls == 3
+
+
+@pytest.mark.anyio
+async def test_a_probe_timeout_is_inconclusive_rather_than_a_failed_run(monkeypatch):
+    # A timeout says the box is loaded, not that the backend is dead: grading
+    # must continue, and the probe must stop retrying rather than pay a 30s
+    # timeout per remaining sample.
+    task = _build()
+    grader = _Grader(probe_result=TimeoutError)
+    monkeypatch.setattr(task_mod, "run_cpu_bound", grader)
+
+    _, judgement = await _feedback(task)
+    await _feedback(task, sample_id=1)
+
+    assert judgement["rollouts"][0]["correct"] is True
+    assert grader.probe_calls == 1
+    assert grader.grade_calls == 2

--- a/tests/unit/tasks/test_math_pass_at_k_family.py
+++ b/tests/unit/tasks/test_math_pass_at_k_family.py
@@ -11,6 +11,8 @@ the same keys.
 AI-Generated Code - Claude Opus 5 (1M context) (Anthropic)
 """
 
+import sys
+
 import pytest
 from datasets import Dataset as HFDataset
 from datasets import DatasetDict as HFDatasetDict
@@ -105,6 +107,33 @@ def _build(task_cls, dataset_cls, field, *, k: int = 1, n: int = 1):
     rows = HFDataset.from_list([_sample(field)])
     dataset = dataset_cls(_hf_dict=HFDatasetDict({"train": rows, "test": rows}))
     return task_cls(dataset, _StubChatModel(), k=k, n=n)
+
+
+def _grader_module(task_cls):
+    """The module whose `run_cpu_bound` name the task actually calls.
+
+    Each member does `from sieval.core.utils.offload import run_cpu_bound`, so the
+    binding that matters is the one in the TASK's namespace. Patching
+    `offload.run_cpu_bound` instead resolves fine and intercepts nothing.
+    """
+    return sys.modules[task_cls.__module__]
+
+
+class _Raiser:
+    """An async `run_cpu_bound` stand-in that always raises *exc*.
+
+    Counts its calls, so a test cannot pass because the patch was never reached —
+    which is what a rename of the grading call site would otherwise look like. A
+    class rather than a closure with a function attribute, which `ty` rejects.
+    """
+
+    def __init__(self, exc: type[BaseException]):
+        self._exc = exc
+        self.calls = 0
+
+    async def __call__(self, *_args, **_kwargs):
+        self.calls += 1
+        raise self._exc("grader stub")
 
 
 @pytest.mark.parametrize(("task_cls", "dataset_cls", "field"), FAMILY, ids=IDS)
@@ -343,3 +372,118 @@ async def test_postprocess_survives_a_missing_raw_sample(task_cls, dataset_cls, 
     inf = ModelOutput(model=task.model.meta(), texts=[TWO_BOXES])
     post = await task.postprocess(inf, TaskContext(sample_id=0))
     assert post["rollouts"][0]["prediction"] == "3"
+
+
+# --- grading failure: only a TIMEOUT is a wrong answer -----------------------
+
+
+@pytest.mark.parametrize(("task_cls", "dataset_cls", "field"), FAMILY, ids=IDS)
+@pytest.mark.anyio
+async def test_a_grader_timeout_is_a_wrong_answer(
+    task_cls, dataset_cls, field, monkeypatch
+):
+    """The half that must stay swallowed — upstream's contract for a slow grade.
+
+    A prediction `simplify` cannot bound is the model's problem, not the run's,
+    and `report` counts fails in the denominator either way, so propagating this
+    one would only trade a truthful number for a scarier-looking one.
+    """
+    task = _build(task_cls, dataset_cls, field)
+    stub = _Raiser(TimeoutError)
+    monkeypatch.setattr(_grader_module(task_cls), "run_cpu_bound", stub)
+    raw = _sample(field)
+    post = build_prediction_record(["0"])
+    _, judgement = await task.feedback(
+        post, TaskContext(sample_id=0, raw_sample=raw, postprocess_result=post)
+    )
+    assert judgement["rollouts"][0]["correct"] is False
+    assert stub.calls > 0, "the grading call site moved; this test intercepted nothing"
+
+
+@pytest.mark.parametrize(("task_cls", "dataset_cls", "field"), FAMILY, ids=IDS)
+@pytest.mark.parametrize("exc", [ValueError, AttributeError, ImportError, OSError])
+@pytest.mark.anyio
+async def test_a_broken_grader_propagates_instead_of_scoring_zero(
+    task_cls, dataset_cls, field, exc, monkeypatch
+):
+    """A grader that is BROKEN rather than slow must not read as a wrong answer.
+
+    Swallowed, every one of these scored the sample 0 and left `fails` at 0, so a
+    dead worker or an optional dependency missing from the environment produced a
+    low score on a run that looked clean — the shape a missing LaTeX backend
+    already takes on this family (worth 5-6 points on MATH-Perturb, 1.24 pp on
+    MATH). Propagated, the runner writes `exception::<class>` on the sample and
+    `fails` becomes the signal; nothing new has to be counted.
+    """
+    task = _build(task_cls, dataset_cls, field)
+    stub = _Raiser(exc)
+    monkeypatch.setattr(_grader_module(task_cls), "run_cpu_bound", stub)
+    raw = _sample(field)
+    post = build_prediction_record(["0"])
+    with pytest.raises(exc):
+        await task.feedback(
+            post, TaskContext(sample_id=0, raw_sample=raw, postprocess_result=post)
+        )
+    assert stub.calls > 0, "the grading call site moved; this test intercepted nothing"
+
+
+@pytest.mark.parametrize(("task_cls", "dataset_cls", "field"), FAMILY, ids=IDS)
+@pytest.mark.anyio
+async def test_moving_a_sample_into_fails_does_not_move_the_headline(
+    task_cls, dataset_cls, field
+):
+    """Why narrowing is score-neutral, asserted rather than argued.
+
+    Every member declares `DENOMINATOR_REQUESTED`, so `finals + fails` is the
+    denominator and a fail is already charged as wrong. The two readings of one
+    ungradeable sample — a judged-wrong final, or a fail — must therefore give
+    the same headline, or this change would be a scoring change wearing a
+    robustness label.
+    """
+    task = _build(task_cls, dataset_cls, field)
+    raw = _sample(field)
+
+    def _judged(sample_id: int, *, correct: bool) -> TaskContext:
+        return TaskContext(
+            sample_id=sample_id,
+            raw_sample=raw,
+            feedback_result=build_judgement_record(
+                ANSWER, [build_rollout_judgement(0, correct)]
+            ),
+            postprocess_result=build_prediction_record([ANSWER if correct else "0"]),
+        )
+
+    # Four problems, and the SURVIVORS must stay mixed: `wilson_interval` needs
+    # >= 2 problems and 0 < p < 1, so a fixture whose remaining finals are all
+    # correct would drop `score_ci95` / `n_problems` and hide the comparison
+    # behind a KeyError rather than making it.
+    survivors = [_judged(0, correct=True), _judged(1, correct=True)]
+    survivors.append(_judged(2, correct=False))
+    # What the runner builds for a stage that raised: no judgement, no prediction.
+    ungradeable_as_fail = TaskContext(sample_id=3, raw_sample=raw)
+
+    before = await task.report([*survivors, _judged(3, correct=False)], [])
+    after = await task.report(survivors, [ungradeable_as_fail])
+
+    assert before["score"] == after["score"] == 50.0
+    assert before["fails"] == 0
+    assert after["fails"] == 1
+    # Everything but `fails` and the intervals is IDENTICAL -- including
+    # `n_problems`, which is the REQUESTED population (4 either way) and not a
+    # count of what came back. Asserted as a whole-dict comparison rather than
+    # key by key, so a member that publishes an extra column cannot drift
+    # unnoticed through a test that only checks the keys this one thought of.
+    moves = {"fails", "score_ci95", "pass@1_ci95"}
+    assert set(before) == set(after)
+    assert {k: v for k, v in before.items() if k not in moves} == {
+        k: v for k, v in after.items() if k not in moves
+    }
+    # The intervals DO move, and not always outward: they are estimated over the
+    # units that came back while being scaled to the requested denominator, so
+    # dropping one shifts the spread in whichever direction that unit's value
+    # pulled it. Here the survivors are less dispersed than the full set, so the
+    # bound tightens. Pre-existing `_clustered_interval` semantics, reached more
+    # often now -- stated rather than asserted in a direction.
+    assert before["score_ci95"] != after["score_ci95"]
+    assert after["score_ci95"][0] < after["score"] < after["score_ci95"][1]
+    assert interval_declaration_problems(after) == []

--- a/tests/unit/tasks/test_math_pass_at_k_family.py
+++ b/tests/unit/tasks/test_math_pass_at_k_family.py
@@ -115,8 +115,13 @@ def _grader_module(task_cls):
     Each member does `from sieval.core.utils.offload import run_cpu_bound`, so the
     binding that matters is the one in the TASK's namespace. Patching
     `offload.run_cpu_bound` instead resolves fine and intercepts nothing.
+
+    Resolved from where `feedback` is DEFINED, not from the task class: a member
+    that inherits `feedback` from a shared base grades through the base module's
+    binding, and `task_cls.__module__` would name the leaf — which has no
+    `run_cpu_bound` to patch. `math_perturb_{simple,hard}` are that shape today.
     """
-    return sys.modules[task_cls.__module__]
+    return sys.modules[task_cls.feedback.__module__]
 
 
 class _Raiser:


### PR DESCRIPTION
## Type

- fix — bug fix or alignment correction

## Summary

Thirteen pass@k math tasks wrapped their grading call in `except Exception -> correct = False`, so **every way a grader can fail was recorded as the model having answered wrongly** — a dead worker process, an optional dependency absent from the environment, a defect in a vendored grader. The run then finished with `fails = 0` and a low score, and the only trace was a `logger.warning` that is gone as soon as the run is.

This is not hypothetical on this family: a missing LaTeX backend costs **1.24 pp on MATH** and **5–6 points on MATH-Perturb**, silently, because upstream's own bare `except` swallows the `ImportError`.

They now catch **`TimeoutError` only**. A grade that could not be computed *in time* stays a wrong answer — the prediction is a shape the grader cannot bound, which is the model's problem, and it is the contract the other seven grading sites already kept. Everything else propagates.

### The survey behind the direction

This is a decision, not a typo fix. Of **21** `run_cpu_bound` grading sites:

| catches | count | members |
|---|---|---|
| `Exception` | **13** | MathArena six (aime ×3, apex ×2, brumo, cmimc, hmmt ×3, smt), `math_500`, `imo_answer_bench` |
| `TimeoutError` | **7** | `gsm8k`, `gsm1k`, `gsm_plus`, `hendrycks_math`, `theoremqa` (×2), `ugmathbench_fixed` |
| both | 1 | `math_perturb` (#130, unmerged) |

Split cleanly along two lineages, each internally consistent — two *conventions*, not drift. All 13 handlers were byte-identical, so this is one edit applied 13 times. After it, all 20 in-tree sites read one way.

### Why this direction costs nothing

`feedback` raising goes straight to `to_failed(reason="exception::<class>")` — **no re-inference, no budget burned** (`runner.py:1015-1029`) — and all 13 declare `DENOMINATOR_REQUESTED`, where a fail is already charged as wrong.

Measured on the real `report()`, moving one ungradeable sample from judged-wrong to failed:

| key | before | after |
|---|---|---|
| `score` / `pass@1` | 50.0 | **50.0** |
| `n_problems` | 4.0 | **4.0** (the *requested* population, not what came back) |
| `n_unextracted`, `score_key`, `denominator_policy`, `ci95_units` | — | **identical** |
| `fails` | 0 | **1** ← the signal |
| `score_ci95` | 15.00 – 85.00 | 18.76 – 81.24 |

So **`fails` plus its recorded reason already *is* the grader-error count** — no new metric is needed, which is the alternative this PR deliberately does not build.

### The one real caveat, stated rather than glossed

A published interval is estimated over the units that came back while scaled to the requested denominator, so dropping one shifts the bound — **and not always outward** (above: it tightens, because the survivors are less dispersed). A survivor set that is uniformly right or uniformly wrong drops `<metric>_ci95` / `n_problems` altogether, since `wilson_interval` needs `0 < p < 1`. Both are pre-existing `_clustered_interval` semantics, reached more often now rather than introduced here.

### Deliberately not touched

- **`theoremqa_kshot_base_gen`** — the only member declaring `DENOMINATOR_JUDGED`, where a fail is *excluded* from the denominator, so either direction moves its score and it owes its own measurement first. It already catches `TimeoutError`, so it is consistent as it stands.
- **`math_perturb_{simple,hard}_0shot_gen`** (#130, unmerged) carries both handlers and wants its `Exception` arm dropped once both land.

The convention is now written down in `.claude/rules/tasks.md`, including the interval caveat and the `DENOMINATOR_JUDGED` exception, so it cannot re-drift.

## Related Issues

Refs #130 — found while reviewing that PR.

## Test Plan

### Automated

- [x] Lint/format clean (`ruff check && ruff format --check` over `sieval tests scripts`)
- [x] Type check clean (`ty check` — **0 diagnostics**, no path narrowing)
- [x] Unit tests pass — **6175 passed**, 0 failures
- [x] `check_preflight.py` — 24 PASS, **zero WARN, zero FAIL**

### Manual

- [x] **Score neutrality measured against the real `report()`**, not argued: the table above is a key-by-key diff of the two readings of one ungradeable sample. Asserted in the suite as a whole-dict comparison excluding `fails` and the two `*_ci95` keys, so a member publishing an extra column cannot drift through a test that only checks the keys one member thought of.
- [x] **78 new cases** over all 13 members: a timeout still scores wrong; `ValueError` / `AttributeError` / `ImportError` / `OSError` each propagate; score neutrality. The stub counts its calls and the tests assert `calls > 0`, so a renamed grading call site fails rather than passing vacuously.
- [x] **Reverse-mutated**: restoring the old `except Exception` in one member is caught by exactly the four propagation cases for that member, and nothing else.
- [x] Confirmed via AST survey that all 20 remaining sites now read `TimeoutError` and none reads `Exception`.

## Checklist

### Required (all PRs)

- [x] PR title follows conventional format (`type(scope): description`)
- [x] No internal paths, credentials, or personal info in committed files
- [x] AI-generated code has `AI-Generated Code - <model> (<provider>)` in module docstring — no new modules; every touched file keeps its existing header
- [x] No new upper-layer dependencies added to `core/` — `core/` is untouched
- [x] Deleted code verified — nothing deleted; one handler narrowed in place

### If: Breaking Change

- [x] **Not score-breaking** (measured above), but it *is* behaviour-visible: a run that previously reported a low score with `fails = 0` on a broken grader now fails those samples and surfaces `exception::<class>`. That is the intent — the number it used to report was not wrong, but the reason for it was invisible.
- [x] Existing tests updated to reflect new behaviour — none needed updating; the 78 new cases are additive.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
