### PR TITLE
fix(models): stabilize legacy model provenance

### DIFF
--- a/sieval/cli/leaderboard/session.py
+++ b/sieval/cli/leaderboard/session.py
@@ -401,7 +401,11 @@ def _replace_provenance_tokens(
         re.compile(
             "|".join(
                 re.escape(runtime_value)
-                for runtime_value in sorted(replacements, key=len, reverse=True)
+                for runtime_value in sorted(
+                    replacements,
+                    key=lambda runtime_value: len(runtime_value),
+                    reverse=True,
+                )
             )
         )
         if replacements
@@ -706,16 +710,17 @@ def _project_external_deployment_plan(
 
         projected = _replace_provenance_tokens(evidence, replacements)
         assert isinstance(projected, Mapping)
+        projected_evidence = cast(Mapping[str, JSONValue], projected)
         if evidence.get("source") == "external_runtime_plans":
-            projected_fingerprints = projected.get("plan_fingerprints")
+            projected_fingerprints = projected_evidence.get("plan_fingerprints")
             assert isinstance(projected_fingerprints, list)
-            projected = {
-                **projected,
+            projected_evidence = {
+                **projected_evidence,
                 "plan_fingerprints": sorted(
                     {cast(str, item) for item in projected_fingerprints}
                 ),
             }
-        outcome_evidence[capability] = cast(Mapping[str, JSONValue], projected)
+        outcome_evidence[capability] = projected_evidence
 
     recipe_parameters = _replace_provenance_tokens(
         cast(JSONValue, plan.recipe_parameters), replacements

--- a/sieval/cli/leaderboard/session.py
+++ b/sieval/cli/leaderboard/session.py
@@ -326,6 +326,127 @@ def _model_value_paths(value: object) -> tuple[str, ...]:
     return tuple(sorted(found))
 
 
+def _is_uuid_scoped_legacy_plan(plan: RuntimeBindingPlan) -> bool:
+    """Return whether a plan still carries wrapper-private pool identity."""
+
+    identity = plan.connection_identity
+    quota_scope = identity.quota_scope
+    return quota_scope.startswith(
+        "legacy-private:"
+    ) and identity.credential_scope.startswith(f"{quota_scope}:")
+
+
+def _record_provenance_replacement(
+    replacements: dict[str, str],
+    ambiguous: set[str],
+    runtime_value: str,
+    stable_value: str,
+) -> None:
+    """Record a replacement, retaining collisions for fail-loud evidence checks."""
+
+    if runtime_value == stable_value:
+        return
+    if runtime_value in ambiguous:
+        return
+    previous = replacements.get(runtime_value)
+    if previous is not None and previous != stable_value:
+        del replacements[runtime_value]
+        ambiguous.add(runtime_value)
+        return
+    replacements[runtime_value] = stable_value
+
+
+def _record_plan_provenance_replacements(
+    replacements: dict[str, str],
+    ambiguous: set[str],
+    runtime_plan: RuntimeBindingPlan,
+    provenance_plan: RuntimeBindingPlan,
+) -> None:
+    """Map every runtime-only plan identity that can appear in evidence."""
+
+    pairs = (
+        (runtime_plan.binding_id, provenance_plan.binding_id),
+        (runtime_plan.root_deployment_key, provenance_plan.root_deployment_key),
+        (runtime_plan.fingerprint, provenance_plan.fingerprint),
+        (
+            runtime_plan.verification_fingerprint,
+            provenance_plan.verification_fingerprint,
+        ),
+        (
+            runtime_plan.binding_plan_fingerprint,
+            provenance_plan.binding_plan_fingerprint,
+        ),
+        (
+            runtime_plan.deployment_plan_fingerprint,
+            provenance_plan.deployment_plan_fingerprint,
+        ),
+        (
+            runtime_plan.connection_identity.credential_scope,
+            provenance_plan.connection_identity.credential_scope,
+        ),
+        (
+            runtime_plan.connection_identity.quota_scope,
+            provenance_plan.connection_identity.quota_scope,
+        ),
+    )
+    for runtime_value, stable_value in pairs:
+        _record_provenance_replacement(
+            replacements,
+            ambiguous,
+            runtime_value,
+            stable_value,
+        )
+
+
+def _replace_provenance_tokens(
+    value: JSONValue,
+    replacements: Mapping[str, str],
+) -> JSONValue:
+    """Recursively replace runtime identities, including embedded strings."""
+
+    if isinstance(value, str):
+        projected = value
+        for runtime_value in sorted(replacements, key=len, reverse=True):
+            projected = projected.replace(
+                runtime_value,
+                replacements[runtime_value],
+            )
+        return projected
+    if isinstance(value, list):
+        return [_replace_provenance_tokens(item, replacements) for item in value]
+    if isinstance(value, Mapping):
+        projected_mapping: dict[str, JSONValue] = {}
+        typed_mapping = cast(Mapping[str, JSONValue], value)
+        for key, item in typed_mapping.items():
+            projected_key = cast(str, _replace_provenance_tokens(key, replacements))
+            if projected_key in projected_mapping:
+                raise ValueError(
+                    "external provenance projection collapses evidence key "
+                    f"{projected_key!r}"
+                )
+            projected_mapping[projected_key] = _replace_provenance_tokens(
+                item, replacements
+            )
+        return projected_mapping
+    return value
+
+
+def _contains_provenance_token(value: JSONValue, token: str) -> bool:
+    """Return whether a runtime token survives anywhere in JSON evidence."""
+
+    if isinstance(value, str):
+        return token in value
+    if isinstance(value, list):
+        return any(_contains_provenance_token(item, token) for item in value)
+    if isinstance(value, Mapping):
+        typed_mapping = cast(Mapping[str, JSONValue], value)
+        return any(
+            token in key or _contains_provenance_token(item, token)
+            for key, item in typed_mapping.items()
+        )
+    return False
+
+
 class _PR1CompatibilityServingReconciler:
     """Keep existing scoring paths behind their named response guards.
 
@@ -1829,6 +1950,198 @@ class EvalSession:
                     )
                 found[plan.binding_id] = plan
         return tuple(found[key] for key in sorted(found))
+
+    def _external_provenance_plan(
+        self,
+        model: Model,
+        result: ReconcileResult,
+        binding_id: str,
+    ) -> RuntimeBindingPlan:
+        """Project a reconciled external plan without its runtime-only identity."""
+
+        runtime_plan = result.runtime_plans[binding_id]
+        if model._provenance_projector is None:
+            return runtime_plan
+        baseline = model._provenance_plan
+        if baseline is None:
+            raise ValueError(
+                f"external binding {binding_id!r} has incomplete baseline provenance"
+            )
+        source_baseline = model.runtime_plan
+        if source_baseline is None:
+            raise ValueError(f"external binding {binding_id!r} has no runtime plan")
+        binding_plan = result.binding_plans[binding_id]
+        stable_scope = ConnectionScope(
+            credential_scope=baseline.connection_identity.credential_scope,
+            retry_policy=baseline.connection_identity.retry_policy,
+            quota_scope=baseline.connection_identity.quota_scope,
+        )
+        provenance_binding_plan = dataclasses.replace(
+            binding_plan,
+            binding_id=baseline.binding_id,
+            root_deployment_key=baseline.root_deployment_key,
+            connection_scope=stable_scope,
+        )
+
+        projector = model._provenance_projector
+        replacements: dict[str, str] = {}
+        ambiguous_replacements: set[str] = set()
+        runtime_to_provenance: dict[str, str] = {}
+        _record_plan_provenance_replacements(
+            replacements,
+            ambiguous_replacements,
+            source_baseline,
+            baseline,
+        )
+        runtime_to_provenance[source_baseline.fingerprint] = baseline.fingerprint
+
+        for sources in self._task_role_model_sources.values():
+            for source in sources.values():
+                if not isinstance(source, Model) or source.runtime_plan is None:
+                    continue
+                source_plan = source.runtime_plan
+                if source_plan.root_deployment_key != runtime_plan.root_deployment_key:
+                    continue
+                if (
+                    source_plan.connection_identity != runtime_plan.connection_identity
+                    and _is_uuid_scoped_legacy_plan(source_plan)
+                ):
+                    raise ValueError(
+                        "deployment root mixes different UUID-scoped legacy "
+                        "connection identities; use separate roots"
+                    )
+                if source._provenance_projector is not None:
+                    provenance_plan = source._provenance_plan
+                    if provenance_plan is None:
+                        raise ValueError(
+                            "external legacy source has incomplete provenance: "
+                            f"{source_plan.binding_id}"
+                        )
+                elif (
+                    source_plan.connection_identity == runtime_plan.connection_identity
+                ):
+                    provenance_plan = projector(source_plan)
+                    if provenance_plan is None:
+                        raise ValueError(
+                            "external canonical source cannot be projected into "
+                            "legacy provenance: "
+                            f"{source_plan.binding_id}"
+                        )
+                else:
+                    # A genuinely canonical identity is already stable and may
+                    # remain verbatim in this legacy model's aggregate proof.
+                    provenance_plan = source_plan
+
+                previous = runtime_to_provenance.get(source_plan.fingerprint)
+                if previous is not None and previous != provenance_plan.fingerprint:
+                    raise ValueError(
+                        "external runtime plan has conflicting stable provenance "
+                        f"projections: {source_plan.fingerprint}"
+                    )
+                runtime_to_provenance[source_plan.fingerprint] = (
+                    provenance_plan.fingerprint
+                )
+                _record_plan_provenance_replacements(
+                    replacements,
+                    ambiguous_replacements,
+                    source_plan,
+                    provenance_plan,
+                )
+
+        _record_provenance_replacement(
+            replacements,
+            ambiguous_replacements,
+            runtime_plan.binding_plan_fingerprint,
+            provenance_binding_plan.fingerprint,
+        )
+        _record_provenance_replacement(
+            replacements,
+            ambiguous_replacements,
+            runtime_plan.binding_id,
+            provenance_binding_plan.binding_id,
+        )
+        _record_provenance_replacement(
+            replacements,
+            ambiguous_replacements,
+            runtime_plan.root_deployment_key,
+            provenance_binding_plan.root_deployment_key,
+        )
+        _record_provenance_replacement(
+            replacements,
+            ambiguous_replacements,
+            runtime_plan.connection_identity.credential_scope,
+            stable_scope.credential_scope,
+        )
+        _record_provenance_replacement(
+            replacements,
+            ambiguous_replacements,
+            runtime_plan.connection_identity.quota_scope,
+            stable_scope.quota_scope,
+        )
+
+        unresolved_result_tokens = {
+            runtime_plan.fingerprint,
+            runtime_plan.verification_fingerprint,
+            runtime_plan.deployment_plan_fingerprint,
+        } - replacements.keys()
+        unresolved_result_tokens.update(ambiguous_replacements)
+
+        deployment_plan = result.deployment_plans[runtime_plan.root_deployment_key]
+        outcome_evidence: dict[CapabilityKey, Mapping[str, JSONValue]] = {}
+        for capability, evidence in deployment_plan.outcome_evidence.items():
+            plan_fingerprints = evidence.get("plan_fingerprints")
+            if evidence.get("source") == "external_runtime_plans":
+                if not isinstance(plan_fingerprints, list) or not all(
+                    isinstance(fingerprint, str) for fingerprint in plan_fingerprints
+                ):
+                    raise TypeError(
+                        "external runtime plan evidence must contain string "
+                        "plan_fingerprints"
+                    )
+                typed_fingerprints = cast(list[str], plan_fingerprints)
+                missing = sorted(set(typed_fingerprints) - runtime_to_provenance.keys())
+                if missing:
+                    raise ValueError(
+                        "external provenance projection cannot resolve runtime plan "
+                        "fingerprint(s): " + ", ".join(missing)
+                    )
+
+            projected = _replace_provenance_tokens(evidence, replacements)
+            assert isinstance(projected, Mapping)
+            if evidence.get("source") == "external_runtime_plans":
+                projected_fingerprints = projected.get("plan_fingerprints")
+                assert isinstance(projected_fingerprints, list)
+                projected = {
+                    **projected,
+                    "plan_fingerprints": sorted(
+                        {cast(str, item) for item in projected_fingerprints}
+                    ),
+                }
+            leaked = sorted(
+                token
+                for token in unresolved_result_tokens
+                if _contains_provenance_token(cast(JSONValue, projected), token)
+            )
+            if leaked:
+                raise ValueError(
+                    "external provenance evidence contains unresolved runtime "
+                    "fingerprint(s): " + ", ".join(leaked)
+                )
+            outcome_evidence[capability] = cast(Mapping[str, JSONValue], projected)
+        provenance_deployment_plan = dataclasses.replace(
+            deployment_plan,
+            root_deployment_key=baseline.root_deployment_key,
+            outcome_evidence=outcome_evidence,
+        )
+
+        return dataclasses.replace(
+            runtime_plan,
+            binding_id=baseline.binding_id,
+            root_deployment_key=baseline.root_deployment_key,
+            connection_identity=baseline.connection_identity,
+            binding_plan_fingerprint=provenance_binding_plan.fingerprint,
+            deployment_plan_fingerprint=provenance_deployment_plan.fingerprint,
+        )
 
     def _validate_external_runtime_obligations(self, result: ReconcileResult) -> None:
         """Reject a rebound external plan that weakens its existing guarantees."""
@@ -3531,9 +3844,15 @@ class EvalSession:
                         binding.binding_id,
                     )
                     runtime_plan = result.runtime_plans[binding.binding_id]
+                    provenance_plan = self._external_provenance_plan(
+                        live_model,
+                        result,
+                        binding.binding_id,
+                    )
                     rebound = live_model.with_dialect(
                         runtime_plan.dialect_id, runtime_plan
                     )
+                    rebound = rebound._with_provenance_plan(provenance_plan)
                     if self.deterministic:
                         rebound = _apply_request_seed_decision_to_model(
                             rebound,

--- a/sieval/cli/leaderboard/session.py
+++ b/sieval/cli/leaderboard/session.py
@@ -391,78 +391,84 @@ def _record_plan_provenance_replacements(
         )
 
 
-def _replace_provenance_tokens(
-    value: JSONValue,
+def _replace_provenance_reference_text(
+    value: str,
     replacements: Mapping[str, str],
-) -> JSONValue:
-    """Recursively replace original runtime identities exactly once."""
+) -> str:
+    """Replace identity references in a field whose schema declares them.
 
-    pattern = (
-        re.compile(
-            "|".join(
-                re.escape(runtime_value)
-                for runtime_value in sorted(
-                    replacements,
-                    key=lambda runtime_value: len(runtime_value),
-                    reverse=True,
-                )
+    This helper is deliberately limited to provenance ``sources`` fields.  In
+    those fields, every occurrence of a known runtime token is an identity
+    reference by contract.  Arbitrary JSON, diagnostic text, mapping keys, and
+    user parameters must instead remain byte-for-byte unchanged and fail loud
+    if they contain a volatile token.
+    """
+
+    if not replacements:
+        return value
+    pattern = re.compile(
+        "|".join(
+            re.escape(runtime_value)
+            for runtime_value in sorted(
+                replacements,
+                key=lambda runtime_value: len(runtime_value),
+                reverse=True,
             )
         )
-        if replacements
-        else None
     )
+    return pattern.sub(lambda match: replacements[match.group(0)], value)
 
-    def project(current: JSONValue) -> JSONValue:
+
+def _provenance_tokens_in(
+    value: JSONValue,
+    runtime_tokens: frozenset[str],
+) -> frozenset[str]:
+    """Return volatile identity tokens present in unprojected JSON data."""
+
+    found: set[str] = set()
+
+    def visit(current: JSONValue) -> None:
         if isinstance(current, str):
-            if pattern is None:
-                return current
-            return pattern.sub(
-                lambda match: replacements[match.group(0)],
-                current,
-            )
+            found.update(token for token in runtime_tokens if token in current)
+            return
         if isinstance(current, list):
-            return [project(item) for item in current]
+            for item in current:
+                visit(item)
+            return
         if isinstance(current, Mapping):
-            projected_mapping: dict[str, JSONValue] = {}
             typed_mapping = cast(Mapping[str, JSONValue], current)
             for key, item in typed_mapping.items():
-                projected_key = cast(str, project(key))
-                if projected_key in projected_mapping:
-                    raise ValueError(
-                        "external provenance projection collapses evidence key "
-                        f"{projected_key!r}"
-                    )
-                projected_mapping[projected_key] = project(item)
-            return projected_mapping
-        return current
+                found.update(token for token in runtime_tokens if token in key)
+                visit(item)
 
-    return project(value)
+    visit(value)
+    return frozenset(found)
 
 
-def _contains_provenance_token(value: JSONValue, token: str) -> bool:
-    """Return whether a runtime token survives anywhere in JSON evidence."""
+def _reject_unprojected_provenance_tokens(
+    value: JSONValue,
+    runtime_tokens: frozenset[str],
+    *,
+    context: str,
+) -> None:
+    """Reject volatile identities in fields that provenance must not rewrite."""
 
-    if isinstance(value, str):
-        return token in value
-    if isinstance(value, list):
-        return any(_contains_provenance_token(item, token) for item in value)
-    if isinstance(value, Mapping):
-        typed_mapping = cast(Mapping[str, JSONValue], value)
-        return any(
-            token in key or _contains_provenance_token(item, token)
-            for key, item in typed_mapping.items()
+    leaked = sorted(_provenance_tokens_in(value, runtime_tokens))
+    if leaked:
+        raise ValueError(
+            f"{context} contains runtime identity token(s) in semantic data: "
+            + ", ".join(leaked)
         )
-    return False
 
 
-_EXTERNAL_PROVENANCE_PROJECTED_CHECK_FIELDS = frozenset({"reason"})
+_EXTERNAL_PROVENANCE_PROJECTED_CHECK_FIELDS = frozenset()
 _EXTERNAL_PROVENANCE_SEMANTIC_CHECK_FIELDS = frozenset(
-    {"capability", "stage", "verifier"}
+    {"capability", "stage", "verifier", "reason"}
 )
-_EXTERNAL_PROVENANCE_PROJECTED_REQUIREMENT_FIELDS = frozenset(
-    {"minimums", "sources", "reason"}
+_EXTERNAL_PROVENANCE_PROJECTED_REQUIREMENT_FIELDS = frozenset({"sources"})
+_EXTERNAL_PROVENANCE_SEMANTIC_REQUIREMENT_FIELDS = frozenset(
+    {"capability", "minimums", "verifier", "reason"}
 )
-_EXTERNAL_PROVENANCE_SEMANTIC_REQUIREMENT_FIELDS = frozenset({"capability", "verifier"})
 _EXTERNAL_PROVENANCE_PROJECTED_INTENT_FIELDS = frozenset({"sources"})
 _EXTERNAL_PROVENANCE_SEMANTIC_INTENT_FIELDS = frozenset(
     {"key", "required", "minimums", "request_defaults"}
@@ -472,7 +478,7 @@ _EXTERNAL_PROVENANCE_PROJECTED_CONNECTION_SCOPE_FIELDS = frozenset(
 )
 _EXTERNAL_PROVENANCE_SEMANTIC_CONNECTION_SCOPE_FIELDS = frozenset({"retry_policy"})
 _EXTERNAL_PROVENANCE_PROJECTED_BINDING_PLAN_FIELDS = frozenset(
-    {"binding_id", "root_deployment_key", "unavailable_capabilities"}
+    {"binding_id", "root_deployment_key"}
 )
 _EXTERNAL_PROVENANCE_SEMANTIC_BINDING_PLAN_FIELDS = frozenset(
     {
@@ -487,6 +493,7 @@ _EXTERNAL_PROVENANCE_SEMANTIC_BINDING_PLAN_FIELDS = frozenset(
         "output_channels",
         "required_output_channels",
         "route_intent",
+        "unavailable_capabilities",
     }
 )
 _EXTERNAL_PROVENANCE_SPECIAL_BINDING_PLAN_FIELDS = frozenset(
@@ -494,129 +501,112 @@ _EXTERNAL_PROVENANCE_SPECIAL_BINDING_PLAN_FIELDS = frozenset(
 )
 _EXTERNAL_PROVENANCE_COMPUTED_BINDING_PLAN_FIELDS = frozenset({"fingerprint"})
 _EXTERNAL_PROVENANCE_PROJECTED_DEPLOYMENT_PLAN_FIELDS = frozenset(
+    {"root_deployment_key"}
+)
+_EXTERNAL_PROVENANCE_SEMANTIC_DEPLOYMENT_PLAN_FIELDS = frozenset(
     {
-        "root_deployment_key",
         "engine_id",
         "desired_plan_fingerprint",
         "recipe_parameters",
         "explicit_parameters",
-        "serving_requirements",
         "launch_patch",
         "setup_checks",
         "request_checks",
-        "outcome_evidence",
+        "outcome_kinds",
     }
 )
-_EXTERNAL_PROVENANCE_SEMANTIC_DEPLOYMENT_PLAN_FIELDS = frozenset({"outcome_kinds"})
+_EXTERNAL_PROVENANCE_SPECIAL_DEPLOYMENT_PLAN_FIELDS = frozenset(
+    {"serving_requirements", "outcome_evidence"}
+)
 _EXTERNAL_PROVENANCE_COMPUTED_DEPLOYMENT_PLAN_FIELDS = frozenset({"fingerprint"})
 _EXTERNAL_PROVENANCE_PROJECTED_RECONCILE_INPUT_FIELDS = frozenset(
-    {
-        "root_deployment_key",
-        "recipe_parameters",
-        "explicit_parameters",
-        "prelaunch_plan",
-    }
+    {"root_deployment_key"}
 )
 _EXTERNAL_PROVENANCE_SEMANTIC_RECONCILE_INPUT_FIELDS = frozenset(
-    {"engine_id", "deployment", "plan"}
+    {"engine_id", "deployment", "plan", "recipe_parameters", "explicit_parameters"}
 )
+_EXTERNAL_PROVENANCE_SPECIAL_RECONCILE_INPUT_FIELDS = frozenset({"prelaunch_plan"})
 
 
-def _validate_external_provenance_schema() -> None:
-    """Fail when an externally visible projection field has no policy."""
-
-    policies = (
-        (
-            DeferredCheck,
-            _EXTERNAL_PROVENANCE_PROJECTED_CHECK_FIELDS
-            | _EXTERNAL_PROVENANCE_SEMANTIC_CHECK_FIELDS,
-        ),
-        (
-            ServingRequirement,
-            _EXTERNAL_PROVENANCE_PROJECTED_REQUIREMENT_FIELDS
-            | _EXTERNAL_PROVENANCE_SEMANTIC_REQUIREMENT_FIELDS,
-        ),
-        (
-            CapabilityIntent,
-            _EXTERNAL_PROVENANCE_PROJECTED_INTENT_FIELDS
-            | _EXTERNAL_PROVENANCE_SEMANTIC_INTENT_FIELDS,
-        ),
-        (
-            ConnectionScope,
-            _EXTERNAL_PROVENANCE_PROJECTED_CONNECTION_SCOPE_FIELDS
-            | _EXTERNAL_PROVENANCE_SEMANTIC_CONNECTION_SCOPE_FIELDS,
-        ),
-        (
-            BindingCapabilityPlan,
-            _EXTERNAL_PROVENANCE_PROJECTED_BINDING_PLAN_FIELDS
-            | _EXTERNAL_PROVENANCE_SEMANTIC_BINDING_PLAN_FIELDS
-            | _EXTERNAL_PROVENANCE_SPECIAL_BINDING_PLAN_FIELDS
-            | _EXTERNAL_PROVENANCE_COMPUTED_BINDING_PLAN_FIELDS,
-        ),
-        (
-            DeploymentCapabilityPlan,
-            _EXTERNAL_PROVENANCE_PROJECTED_DEPLOYMENT_PLAN_FIELDS
-            | _EXTERNAL_PROVENANCE_SEMANTIC_DEPLOYMENT_PLAN_FIELDS
-            | _EXTERNAL_PROVENANCE_COMPUTED_DEPLOYMENT_PLAN_FIELDS,
-        ),
-        (
-            DeploymentReconcileInput,
-            _EXTERNAL_PROVENANCE_PROJECTED_RECONCILE_INPUT_FIELDS
-            | _EXTERNAL_PROVENANCE_SEMANTIC_RECONCILE_INPUT_FIELDS,
-        ),
-    )
-    for record_type, classified_fields in policies:
-        record_fields = {item.name for item in dataclasses.fields(record_type)}
-        if record_fields == classified_fields:
-            continue
-        missing = sorted(record_fields - classified_fields)
-        stale = sorted(classified_fields - record_fields)
-        raise RuntimeError(
-            f"{record_type.__name__} external provenance policy is incomplete; "
-            f"missing={missing!r}, stale={stale!r}"
-        )
-
-
-def _replace_provenance_text(
-    value: str,
-    replacements: Mapping[str, str],
-) -> str:
-    projected = _replace_provenance_tokens(value, replacements)
-    assert isinstance(projected, str)
-    return projected
+_EXTERNAL_PROVENANCE_POLICIES = (
+    (
+        DeferredCheck,
+        _EXTERNAL_PROVENANCE_PROJECTED_CHECK_FIELDS
+        | _EXTERNAL_PROVENANCE_SEMANTIC_CHECK_FIELDS,
+    ),
+    (
+        ServingRequirement,
+        _EXTERNAL_PROVENANCE_PROJECTED_REQUIREMENT_FIELDS
+        | _EXTERNAL_PROVENANCE_SEMANTIC_REQUIREMENT_FIELDS,
+    ),
+    (
+        CapabilityIntent,
+        _EXTERNAL_PROVENANCE_PROJECTED_INTENT_FIELDS
+        | _EXTERNAL_PROVENANCE_SEMANTIC_INTENT_FIELDS,
+    ),
+    (
+        ConnectionScope,
+        _EXTERNAL_PROVENANCE_PROJECTED_CONNECTION_SCOPE_FIELDS
+        | _EXTERNAL_PROVENANCE_SEMANTIC_CONNECTION_SCOPE_FIELDS,
+    ),
+    (
+        BindingCapabilityPlan,
+        _EXTERNAL_PROVENANCE_PROJECTED_BINDING_PLAN_FIELDS
+        | _EXTERNAL_PROVENANCE_SEMANTIC_BINDING_PLAN_FIELDS
+        | _EXTERNAL_PROVENANCE_SPECIAL_BINDING_PLAN_FIELDS
+        | _EXTERNAL_PROVENANCE_COMPUTED_BINDING_PLAN_FIELDS,
+    ),
+    (
+        DeploymentCapabilityPlan,
+        _EXTERNAL_PROVENANCE_PROJECTED_DEPLOYMENT_PLAN_FIELDS
+        | _EXTERNAL_PROVENANCE_SEMANTIC_DEPLOYMENT_PLAN_FIELDS
+        | _EXTERNAL_PROVENANCE_SPECIAL_DEPLOYMENT_PLAN_FIELDS
+        | _EXTERNAL_PROVENANCE_COMPUTED_DEPLOYMENT_PLAN_FIELDS,
+    ),
+    (
+        DeploymentReconcileInput,
+        _EXTERNAL_PROVENANCE_PROJECTED_RECONCILE_INPUT_FIELDS
+        | _EXTERNAL_PROVENANCE_SEMANTIC_RECONCILE_INPUT_FIELDS
+        | _EXTERNAL_PROVENANCE_SPECIAL_RECONCILE_INPUT_FIELDS,
+    ),
+)
 
 
 def _project_provenance_check(
     check: DeferredCheck,
-    replacements: Mapping[str, str],
+    runtime_tokens: frozenset[str],
 ) -> DeferredCheck:
-    """Project diagnostic text without changing which verifier executes."""
+    """Preserve diagnostic text and reject volatile identity leakage."""
 
-    return dataclasses.replace(
-        check,
-        reason=_replace_provenance_text(check.reason, replacements),
+    _reject_unprojected_provenance_tokens(
+        check.reason,
+        runtime_tokens,
+        context="external provenance check reason",
     )
+    return check
 
 
 def _project_provenance_requirement(
     requirement: ServingRequirement,
     replacements: Mapping[str, str],
+    runtime_tokens: frozenset[str],
 ) -> ServingRequirement:
-    minimums = _replace_provenance_tokens(
-        cast(JSONValue, requirement.minimums), replacements
+    _reject_unprojected_provenance_tokens(
+        cast(JSONValue, requirement.minimums),
+        runtime_tokens,
+        context="external provenance serving minimums",
     )
-    assert isinstance(minimums, Mapping)
+    if requirement.reason is not None:
+        _reject_unprojected_provenance_tokens(
+            requirement.reason,
+            runtime_tokens,
+            context="external provenance serving reason",
+        )
     return dataclasses.replace(
         requirement,
-        minimums=cast(Mapping[str, JSONValue], minimums),
         sources=tuple(
-            _replace_provenance_text(source, replacements)
+            _replace_provenance_reference_text(source, replacements)
             for source in requirement.sources
-        ),
-        reason=(
-            None
-            if requirement.reason is None
-            else _replace_provenance_text(requirement.reason, replacements)
         ),
     )
 
@@ -624,13 +614,25 @@ def _project_provenance_requirement(
 def _project_provenance_intent(
     intent: CapabilityIntent,
     replacements: Mapping[str, str],
+    runtime_tokens: frozenset[str],
 ) -> CapabilityIntent:
     """Project diagnostic sources without changing the requested capability."""
 
+    _reject_unprojected_provenance_tokens(
+        cast(JSONValue, intent.minimums),
+        runtime_tokens,
+        context="external provenance intent minimums",
+    )
+    _reject_unprojected_provenance_tokens(
+        intent.request_defaults.to_json_value(),
+        runtime_tokens,
+        context="external provenance intent request defaults",
+    )
     return dataclasses.replace(
         intent,
         sources=tuple(
-            _replace_provenance_text(source, replacements) for source in intent.sources
+            _replace_provenance_reference_text(source, replacements)
+            for source in intent.sources
         ),
     )
 
@@ -646,35 +648,33 @@ def _project_external_binding_plan(
 ) -> BindingCapabilityPlan:
     """Build a stable view of every persisted binding-plan field."""
 
-    _validate_external_provenance_schema()
     projected = dataclasses.replace(
         plan,
         binding_id=binding_id,
         root_deployment_key=root_deployment_key,
         intents={
-            capability: _project_provenance_intent(intent, replacements)
+            capability: _project_provenance_intent(
+                intent,
+                replacements,
+                runtime_tokens,
+            )
             for capability, intent in plan.intents.items()
         },
-        unavailable_capabilities={
-            capability: _replace_provenance_text(reason, replacements)
-            for capability, reason in plan.unavailable_capabilities.items()
-        },
         serving_requirements=tuple(
-            _project_provenance_requirement(requirement, replacements)
+            _project_provenance_requirement(
+                requirement,
+                replacements,
+                runtime_tokens,
+            )
             for requirement in plan.serving_requirements
         ),
         connection_scope=connection_scope,
     )
-    leaked = sorted(
-        token
-        for token in runtime_tokens
-        if _contains_provenance_token(cast(JSONValue, projected.to_json_value()), token)
+    _reject_unprojected_provenance_tokens(
+        cast(JSONValue, projected.to_json_value()),
+        runtime_tokens,
+        context="external provenance binding plan",
     )
-    if leaked:
-        raise ValueError(
-            "external provenance binding plan contains unresolved runtime "
-            "identity token(s): " + ", ".join(leaked)
-        )
     return projected
 
 
@@ -688,10 +688,10 @@ def _project_external_deployment_plan(
 ) -> DeploymentCapabilityPlan:
     """Build a stable view of every persisted deployment-plan field."""
 
-    _validate_external_provenance_schema()
     outcome_evidence: dict[CapabilityKey, Mapping[str, JSONValue]] = {}
     for capability, evidence in plan.outcome_evidence.items():
         plan_fingerprints = evidence.get("plan_fingerprints")
+        projected_evidence: dict[str, JSONValue] = dict(evidence)
         if evidence.get("source") == "external_runtime_plans":
             if not isinstance(plan_fingerprints, list) or not all(
                 isinstance(fingerprint, str) for fingerprint in plan_fingerprints
@@ -707,71 +707,37 @@ def _project_external_deployment_plan(
                     "external provenance projection cannot resolve runtime plan "
                     "fingerprint(s): " + ", ".join(missing)
                 )
-
-        projected = _replace_provenance_tokens(evidence, replacements)
-        assert isinstance(projected, Mapping)
-        projected_evidence = cast(Mapping[str, JSONValue], projected)
-        if evidence.get("source") == "external_runtime_plans":
-            projected_fingerprints = projected_evidence.get("plan_fingerprints")
-            assert isinstance(projected_fingerprints, list)
-            projected_evidence = {
-                **projected_evidence,
-                "plan_fingerprints": sorted(
-                    {cast(str, item) for item in projected_fingerprints}
-                ),
-            }
+            projected_evidence["plan_fingerprints"] = sorted(
+                {runtime_to_provenance[item] for item in typed_fingerprints}
+            )
         outcome_evidence[capability] = projected_evidence
 
-    recipe_parameters = _replace_provenance_tokens(
-        cast(JSONValue, plan.recipe_parameters), replacements
-    )
-    explicit_parameters = _replace_provenance_tokens(
-        cast(JSONValue, plan.explicit_parameters), replacements
-    )
-    launch_patch = _replace_provenance_tokens(
-        cast(JSONValue, plan.launch_patch), replacements
-    )
-    assert isinstance(recipe_parameters, Mapping)
-    assert isinstance(explicit_parameters, Mapping)
-    assert isinstance(launch_patch, Mapping)
     projected_plan = dataclasses.replace(
         plan,
         root_deployment_key=root_deployment_key,
-        engine_id=_replace_provenance_text(plan.engine_id, replacements),
-        desired_plan_fingerprint=(
-            None
-            if plan.desired_plan_fingerprint is None
-            else _replace_provenance_text(plan.desired_plan_fingerprint, replacements)
-        ),
-        recipe_parameters=cast(Mapping[str, JSONValue], recipe_parameters),
-        explicit_parameters=cast(Mapping[str, JSONValue], explicit_parameters),
         serving_requirements=tuple(
-            _project_provenance_requirement(requirement, replacements)
+            _project_provenance_requirement(
+                requirement,
+                replacements,
+                runtime_tokens,
+            )
             for requirement in plan.serving_requirements
         ),
-        launch_patch=cast(Mapping[str, JSONValue], launch_patch),
         setup_checks=tuple(
-            _project_provenance_check(check, replacements)
+            _project_provenance_check(check, runtime_tokens)
             for check in plan.setup_checks
         ),
         request_checks=tuple(
-            _project_provenance_check(check, replacements)
+            _project_provenance_check(check, runtime_tokens)
             for check in plan.request_checks
         ),
         outcome_evidence=outcome_evidence,
     )
-    leaked = sorted(
-        token
-        for token in runtime_tokens
-        if _contains_provenance_token(
-            cast(JSONValue, projected_plan.to_json_value()), token
-        )
+    _reject_unprojected_provenance_tokens(
+        cast(JSONValue, projected_plan.to_json_value()),
+        runtime_tokens,
+        context="external provenance plan",
     )
-    if leaked:
-        raise ValueError(
-            "external provenance plan contains unresolved runtime identity "
-            "token(s): " + ", ".join(leaked)
-        )
     return projected_plan
 
 
@@ -2317,15 +2283,13 @@ class EvalSession:
                 runtime_plan = source.runtime_plan
                 if runtime_plan.root_deployment_key != root_deployment_key:
                     continue
-                if source._provenance_projector is None:
-                    provenance_plan = runtime_plan
-                else:
-                    provenance_plan = source._provenance_plan
-                    if provenance_plan is None:
-                        raise ValueError(
-                            "external legacy source has incomplete provenance: "
-                            f"{runtime_plan.binding_id}"
-                        )
+                provenance_plan = source.provenance_plan
+                if provenance_plan is None:
+                    raise ValueError(
+                        "external legacy source has incomplete provenance: "
+                        f"{runtime_plan.binding_id}"
+                    )
+                if provenance_plan != runtime_plan:
                     has_projection = True
 
                 previous = found.get(runtime_plan.binding_id)
@@ -2387,13 +2351,16 @@ class EvalSession:
     ) -> tuple[tuple[ServingRequirement, ...], DeploymentReconcileInput]:
         """Hide wrapper-private ownership identity from injected reconcilers."""
 
-        _validate_external_provenance_schema()
         context = self._external_provenance_context(deployment.root_deployment_key)
         if context is None:
             return requirements, deployment
 
         projected_requirements = tuple(
-            _project_provenance_requirement(requirement, context.replacements)
+            _project_provenance_requirement(
+                requirement,
+                context.replacements,
+                context.runtime_tokens,
+            )
             for requirement in requirements
         )
 
@@ -2406,19 +2373,9 @@ class EvalSession:
                 runtime_to_provenance=context.runtime_to_provenance,
                 runtime_tokens=context.runtime_tokens,
             )
-        recipe_parameters = _replace_provenance_tokens(
-            cast(JSONValue, deployment.recipe_parameters), context.replacements
-        )
-        explicit_parameters = _replace_provenance_tokens(
-            cast(JSONValue, deployment.explicit_parameters), context.replacements
-        )
-        assert isinstance(recipe_parameters, Mapping)
-        assert isinstance(explicit_parameters, Mapping)
         projected_deployment = dataclasses.replace(
             deployment,
             root_deployment_key=context.root_deployment_key,
-            recipe_parameters=cast(Mapping[str, JSONValue], recipe_parameters),
-            explicit_parameters=cast(Mapping[str, JSONValue], explicit_parameters),
             prelaunch_plan=prelaunch_plan,
         )
         projected_input: JSONValue = {
@@ -2427,16 +2384,11 @@ class EvalSession:
             ],
             "deployment": projected_deployment.to_json_value(),
         }
-        leaked = sorted(
-            token
-            for token in context.runtime_tokens
-            if _contains_provenance_token(projected_input, token)
+        _reject_unprojected_provenance_tokens(
+            projected_input,
+            context.runtime_tokens,
+            context="external reconciler inputs",
         )
-        if leaked:
-            raise ValueError(
-                "external reconciler inputs contain unresolved runtime identity "
-                "token(s): " + ", ".join(leaked)
-            )
         return projected_requirements, projected_deployment
 
     def _external_provenance_plan(
@@ -2448,9 +2400,7 @@ class EvalSession:
         """Project a reconciled external plan without its runtime-only identity."""
 
         runtime_plan = result.runtime_plans[binding_id]
-        if model._provenance_projector is None:
-            return runtime_plan
-        baseline = model._provenance_plan
+        baseline = model.provenance_plan
         if baseline is None:
             raise ValueError(
                 f"external binding {binding_id!r} has incomplete baseline provenance"
@@ -2458,6 +2408,8 @@ class EvalSession:
         source_baseline = model.runtime_plan
         if source_baseline is None:
             raise ValueError(f"external binding {binding_id!r} has no runtime plan")
+        if baseline == source_baseline:
+            return runtime_plan
         context = self._external_provenance_context(runtime_plan.root_deployment_key)
         if context is None:
             raise ValueError(
@@ -2537,25 +2489,18 @@ class EvalSession:
             binding_id=baseline.binding_id,
             root_deployment_key=baseline.root_deployment_key,
             request_checks=tuple(
-                _project_provenance_check(check, replacements)
+                _project_provenance_check(check, frozenset(runtime_tokens))
                 for check in runtime_plan.request_checks
             ),
             connection_identity=baseline.connection_identity,
             binding_plan_fingerprint=provenance_binding_plan.fingerprint,
             deployment_plan_fingerprint=provenance_deployment_plan.fingerprint,
         )
-        leaked = sorted(
-            token
-            for token in runtime_tokens
-            if _contains_provenance_token(
-                cast(JSONValue, provenance_plan.to_json_value()), token
-            )
+        _reject_unprojected_provenance_tokens(
+            cast(JSONValue, provenance_plan.to_json_value()),
+            frozenset(runtime_tokens),
+            context="external provenance plan",
         )
-        if leaked:
-            raise ValueError(
-                "external provenance plan contains unresolved runtime identity "
-                "token(s): " + ", ".join(leaked)
-            )
         return provenance_plan
 
     def _validate_external_runtime_obligations(self, result: ReconcileResult) -> None:
@@ -4264,10 +4209,10 @@ class EvalSession:
                         result,
                         binding.binding_id,
                     )
-                    rebound = live_model.with_dialect(
-                        runtime_plan.dialect_id, runtime_plan
+                    rebound = live_model.with_reconciled_plan(
+                        runtime_plan,
+                        provenance_plan,
                     )
-                    rebound = rebound._with_provenance_plan(provenance_plan)
                     if self.deterministic:
                         rebound = _apply_request_seed_decision_to_model(
                             rebound,

--- a/sieval/cli/leaderboard/session.py
+++ b/sieval/cli/leaderboard/session.py
@@ -13,7 +13,7 @@ import os
 import re
 import shlex
 import sys
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from datetime import UTC, datetime
 from enum import StrEnum
 from pathlib import Path
@@ -436,6 +436,9 @@ def _provenance_tokens_in(
                 visit(item)
             return
         if isinstance(current, Mapping):
+            # isinstance erases the type arguments; recover them rather than
+            # widen visit() to object, which would need an unreachable
+            # non-str key branch.
             typed_mapping = cast(Mapping[str, JSONValue], current)
             for key, item in typed_mapping.items():
                 found.update(token for token in runtime_tokens if token in key)
@@ -461,7 +464,10 @@ def _reject_unprojected_provenance_tokens(
         )
 
 
-_EXTERNAL_PROVENANCE_PROJECTED_CHECK_FIELDS = frozenset()
+# Deliberately empty: no DeferredCheck field is projected.  Which verifier
+# executes, at which stage, and why must all reach persisted evidence
+# byte-for-byte, so a runtime token here fails loud instead of being rewritten.
+_EXTERNAL_PROVENANCE_PROJECTED_CHECK_FIELDS: frozenset[str] = frozenset()
 _EXTERNAL_PROVENANCE_SEMANTIC_CHECK_FIELDS = frozenset(
     {"capability", "stage", "verifier", "reason"}
 )
@@ -572,18 +578,23 @@ _EXTERNAL_PROVENANCE_POLICIES = (
 )
 
 
-def _project_provenance_check(
-    check: DeferredCheck,
+def _reject_provenance_tokens_in_checks(
+    checks: Iterable[DeferredCheck],
     runtime_tokens: frozenset[str],
-) -> DeferredCheck:
-    """Preserve diagnostic text and reject volatile identity leakage."""
+) -> None:
+    """Reject volatile identity leakage in never-rewritten diagnostic text.
 
-    _reject_unprojected_provenance_tokens(
-        check.reason,
-        runtime_tokens,
-        context="external provenance check reason",
-    )
-    return check
+    No :class:`DeferredCheck` field is projected: which verifier executes and
+    why must survive into persisted evidence byte-for-byte.  This only fails
+    loud, so callers pass their original tuple through unchanged.
+    """
+
+    for check in checks:
+        _reject_unprojected_provenance_tokens(
+            check.reason,
+            runtime_tokens,
+            context="external provenance check reason",
+        )
 
 
 def _project_provenance_requirement(
@@ -592,7 +603,7 @@ def _project_provenance_requirement(
     runtime_tokens: frozenset[str],
 ) -> ServingRequirement:
     _reject_unprojected_provenance_tokens(
-        cast(JSONValue, requirement.minimums),
+        requirement.minimums,
         runtime_tokens,
         context="external provenance serving minimums",
     )
@@ -619,7 +630,7 @@ def _project_provenance_intent(
     """Project diagnostic sources without changing the requested capability."""
 
     _reject_unprojected_provenance_tokens(
-        cast(JSONValue, intent.minimums),
+        intent.minimums,
         runtime_tokens,
         context="external provenance intent minimums",
     )
@@ -671,7 +682,7 @@ def _project_external_binding_plan(
         connection_scope=connection_scope,
     )
     _reject_unprojected_provenance_tokens(
-        cast(JSONValue, projected.to_json_value()),
+        projected.to_json_value(),
         runtime_tokens,
         context="external provenance binding plan",
     )
@@ -693,14 +704,20 @@ def _project_external_deployment_plan(
         plan_fingerprints = evidence.get("plan_fingerprints")
         projected_evidence: dict[str, JSONValue] = dict(evidence)
         if evidence.get("source") == "external_runtime_plans":
-            if not isinstance(plan_fingerprints, list) or not all(
-                isinstance(fingerprint, str) for fingerprint in plan_fingerprints
+            if not isinstance(plan_fingerprints, list) or any(
+                not isinstance(fingerprint, str) for fingerprint in plan_fingerprints
             ):
                 raise TypeError(
                     "external runtime plan evidence must contain string "
                     "plan_fingerprints"
                 )
-            typed_fingerprints = cast(list[str], plan_fingerprints)
+            # Lossless after the guard above, and it gives the checker the
+            # element type that isinstance cannot carry out of the list.
+            typed_fingerprints = [
+                fingerprint
+                for fingerprint in plan_fingerprints
+                if isinstance(fingerprint, str)
+            ]
             missing = sorted(set(typed_fingerprints) - runtime_to_provenance.keys())
             if missing:
                 raise ValueError(
@@ -712,6 +729,8 @@ def _project_external_deployment_plan(
             )
         outcome_evidence[capability] = projected_evidence
 
+    _reject_provenance_tokens_in_checks(plan.setup_checks, runtime_tokens)
+    _reject_provenance_tokens_in_checks(plan.request_checks, runtime_tokens)
     projected_plan = dataclasses.replace(
         plan,
         root_deployment_key=root_deployment_key,
@@ -723,18 +742,10 @@ def _project_external_deployment_plan(
             )
             for requirement in plan.serving_requirements
         ),
-        setup_checks=tuple(
-            _project_provenance_check(check, runtime_tokens)
-            for check in plan.setup_checks
-        ),
-        request_checks=tuple(
-            _project_provenance_check(check, runtime_tokens)
-            for check in plan.request_checks
-        ),
         outcome_evidence=outcome_evidence,
     )
     _reject_unprojected_provenance_tokens(
-        cast(JSONValue, projected_plan.to_json_value()),
+        projected_plan.to_json_value(),
         runtime_tokens,
         context="external provenance plan",
     )
@@ -2484,20 +2495,20 @@ class EvalSession:
             runtime_to_provenance=runtime_to_provenance,
             runtime_tokens=frozenset(runtime_tokens),
         )
+        _reject_provenance_tokens_in_checks(
+            runtime_plan.request_checks,
+            frozenset(runtime_tokens),
+        )
         provenance_plan = dataclasses.replace(
             runtime_plan,
             binding_id=baseline.binding_id,
             root_deployment_key=baseline.root_deployment_key,
-            request_checks=tuple(
-                _project_provenance_check(check, frozenset(runtime_tokens))
-                for check in runtime_plan.request_checks
-            ),
             connection_identity=baseline.connection_identity,
             binding_plan_fingerprint=provenance_binding_plan.fingerprint,
             deployment_plan_fingerprint=provenance_deployment_plan.fingerprint,
         )
         _reject_unprojected_provenance_tokens(
-            cast(JSONValue, provenance_plan.to_json_value()),
+            provenance_plan.to_json_value(),
             frozenset(runtime_tokens),
             context="external provenance plan",
         )

--- a/sieval/cli/leaderboard/session.py
+++ b/sieval/cli/leaderboard/session.py
@@ -436,9 +436,8 @@ def _provenance_tokens_in(
                 visit(item)
             return
         if isinstance(current, Mapping):
-            # isinstance erases the type arguments; recover them rather than
-            # widen visit() to object, which would need an unreachable
-            # non-str key branch.
+            # isinstance erases the type arguments; widening visit() to object
+            # instead would need a non-str key branch that can never run.
             typed_mapping = cast(Mapping[str, JSONValue], current)
             for key, item in typed_mapping.items():
                 found.update(token for token in runtime_tokens if token in key)
@@ -464,9 +463,8 @@ def _reject_unprojected_provenance_tokens(
         )
 
 
-# Deliberately empty: no DeferredCheck field is projected.  Which verifier
-# executes, at which stage, and why must all reach persisted evidence
-# byte-for-byte, so a runtime token here fails loud instead of being rewritten.
+# Deliberately empty: no DeferredCheck field is projected, so a runtime token
+# in one fails loud instead of being rewritten.
 _EXTERNAL_PROVENANCE_PROJECTED_CHECK_FIELDS: frozenset[str] = frozenset()
 _EXTERNAL_PROVENANCE_SEMANTIC_CHECK_FIELDS = frozenset(
     {"capability", "stage", "verifier", "reason"}
@@ -582,11 +580,9 @@ def _reject_provenance_tokens_in_checks(
     checks: Iterable[DeferredCheck],
     runtime_tokens: frozenset[str],
 ) -> None:
-    """Reject volatile identity leakage in never-rewritten diagnostic text.
+    """Reject leaked identity in check text, which is never rewritten.
 
-    No :class:`DeferredCheck` field is projected: which verifier executes and
-    why must survive into persisted evidence byte-for-byte.  This only fails
-    loud, so callers pass their original tuple through unchanged.
+    Fails loud only, so callers pass their original tuple through unchanged.
     """
 
     for check in checks:
@@ -711,8 +707,8 @@ def _project_external_deployment_plan(
                     "external runtime plan evidence must contain string "
                     "plan_fingerprints"
                 )
-            # Lossless after the guard above, and it gives the checker the
-            # element type that isinstance cannot carry out of the list.
+            # Lossless after the guard above; carries the element type that
+            # isinstance cannot.
             typed_fingerprints = [
                 fingerprint
                 for fingerprint in plan_fingerprints

--- a/sieval/cli/leaderboard/session.py
+++ b/sieval/cli/leaderboard/session.py
@@ -10,6 +10,7 @@ import dataclasses
 import hashlib
 import json
 import os
+import re
 import shlex
 import sys
 from collections.abc import Callable, Mapping
@@ -86,12 +87,14 @@ from sieval.core.models.dialect_registry import (
     get_dialect_spec,
 )
 from sieval.core.models.reconcile import (
+    BindingCapabilityPlan,
     BindingReconcileInput,
     CannotVerify,
     CheckStage,
     Configured,
     ConnectionScope,
     DeferredCheck,
+    DeploymentCapabilityPlan,
     DeploymentReconcileInput,
     ReconcileBatch,
     ReconcileDiagnostic,
@@ -326,16 +329,6 @@ def _model_value_paths(value: object) -> tuple[str, ...]:
     return tuple(sorted(found))
 
 
-def _is_uuid_scoped_legacy_plan(plan: RuntimeBindingPlan) -> bool:
-    """Return whether a plan still carries wrapper-private pool identity."""
-
-    identity = plan.connection_identity
-    quota_scope = identity.quota_scope
-    return quota_scope.startswith(
-        "legacy-private:"
-    ) and identity.credential_scope.startswith(f"{quota_scope}:")
-
-
 def _record_provenance_replacement(
     replacements: dict[str, str],
     ambiguous: set[str],
@@ -402,33 +395,44 @@ def _replace_provenance_tokens(
     value: JSONValue,
     replacements: Mapping[str, str],
 ) -> JSONValue:
-    """Recursively replace runtime identities, including embedded strings."""
+    """Recursively replace original runtime identities exactly once."""
 
-    if isinstance(value, str):
-        projected = value
-        for runtime_value in sorted(replacements, key=len, reverse=True):
-            projected = projected.replace(
-                runtime_value,
-                replacements[runtime_value],
+    pattern = (
+        re.compile(
+            "|".join(
+                re.escape(runtime_value)
+                for runtime_value in sorted(replacements, key=len, reverse=True)
             )
-        return projected
-    if isinstance(value, list):
-        return [_replace_provenance_tokens(item, replacements) for item in value]
-    if isinstance(value, Mapping):
-        projected_mapping: dict[str, JSONValue] = {}
-        typed_mapping = cast(Mapping[str, JSONValue], value)
-        for key, item in typed_mapping.items():
-            projected_key = cast(str, _replace_provenance_tokens(key, replacements))
-            if projected_key in projected_mapping:
-                raise ValueError(
-                    "external provenance projection collapses evidence key "
-                    f"{projected_key!r}"
-                )
-            projected_mapping[projected_key] = _replace_provenance_tokens(
-                item, replacements
+        )
+        if replacements
+        else None
+    )
+
+    def project(current: JSONValue) -> JSONValue:
+        if isinstance(current, str):
+            if pattern is None:
+                return current
+            return pattern.sub(
+                lambda match: replacements[match.group(0)],
+                current,
             )
-        return projected_mapping
-    return value
+        if isinstance(current, list):
+            return [project(item) for item in current]
+        if isinstance(current, Mapping):
+            projected_mapping: dict[str, JSONValue] = {}
+            typed_mapping = cast(Mapping[str, JSONValue], current)
+            for key, item in typed_mapping.items():
+                projected_key = cast(str, project(key))
+                if projected_key in projected_mapping:
+                    raise ValueError(
+                        "external provenance projection collapses evidence key "
+                        f"{projected_key!r}"
+                    )
+                projected_mapping[projected_key] = project(item)
+            return projected_mapping
+        return current
+
+    return project(value)
 
 
 def _contains_provenance_token(value: JSONValue, token: str) -> bool:
@@ -445,6 +449,337 @@ def _contains_provenance_token(value: JSONValue, token: str) -> bool:
             for key, item in typed_mapping.items()
         )
     return False
+
+
+_EXTERNAL_PROVENANCE_PROJECTED_CHECK_FIELDS = frozenset({"reason"})
+_EXTERNAL_PROVENANCE_SEMANTIC_CHECK_FIELDS = frozenset(
+    {"capability", "stage", "verifier"}
+)
+_EXTERNAL_PROVENANCE_PROJECTED_REQUIREMENT_FIELDS = frozenset(
+    {"minimums", "sources", "reason"}
+)
+_EXTERNAL_PROVENANCE_SEMANTIC_REQUIREMENT_FIELDS = frozenset({"capability", "verifier"})
+_EXTERNAL_PROVENANCE_PROJECTED_INTENT_FIELDS = frozenset({"sources"})
+_EXTERNAL_PROVENANCE_SEMANTIC_INTENT_FIELDS = frozenset(
+    {"key", "required", "minimums", "request_defaults"}
+)
+_EXTERNAL_PROVENANCE_PROJECTED_CONNECTION_SCOPE_FIELDS = frozenset(
+    {"credential_scope", "quota_scope"}
+)
+_EXTERNAL_PROVENANCE_SEMANTIC_CONNECTION_SCOPE_FIELDS = frozenset({"retry_policy"})
+_EXTERNAL_PROVENANCE_PROJECTED_BINDING_PLAN_FIELDS = frozenset(
+    {"binding_id", "root_deployment_key", "unavailable_capabilities"}
+)
+_EXTERNAL_PROVENANCE_SEMANTIC_BINDING_PLAN_FIELDS = frozenset(
+    {
+        "requested_model_id",
+        "dialect_id",
+        "declared_capabilities",
+        "required_capabilities",
+        "available_capabilities",
+        "pending_capabilities",
+        "capability_minimums",
+        "request_defaults",
+        "output_channels",
+        "required_output_channels",
+        "route_intent",
+    }
+)
+_EXTERNAL_PROVENANCE_SPECIAL_BINDING_PLAN_FIELDS = frozenset(
+    {"intents", "serving_requirements", "connection_scope"}
+)
+_EXTERNAL_PROVENANCE_COMPUTED_BINDING_PLAN_FIELDS = frozenset({"fingerprint"})
+_EXTERNAL_PROVENANCE_PROJECTED_DEPLOYMENT_PLAN_FIELDS = frozenset(
+    {
+        "root_deployment_key",
+        "engine_id",
+        "desired_plan_fingerprint",
+        "recipe_parameters",
+        "explicit_parameters",
+        "serving_requirements",
+        "launch_patch",
+        "setup_checks",
+        "request_checks",
+        "outcome_evidence",
+    }
+)
+_EXTERNAL_PROVENANCE_SEMANTIC_DEPLOYMENT_PLAN_FIELDS = frozenset({"outcome_kinds"})
+_EXTERNAL_PROVENANCE_COMPUTED_DEPLOYMENT_PLAN_FIELDS = frozenset({"fingerprint"})
+_EXTERNAL_PROVENANCE_PROJECTED_RECONCILE_INPUT_FIELDS = frozenset(
+    {
+        "root_deployment_key",
+        "recipe_parameters",
+        "explicit_parameters",
+        "prelaunch_plan",
+    }
+)
+_EXTERNAL_PROVENANCE_SEMANTIC_RECONCILE_INPUT_FIELDS = frozenset(
+    {"engine_id", "deployment", "plan"}
+)
+
+
+def _validate_external_provenance_schema() -> None:
+    """Fail when an externally visible projection field has no policy."""
+
+    policies = (
+        (
+            DeferredCheck,
+            _EXTERNAL_PROVENANCE_PROJECTED_CHECK_FIELDS
+            | _EXTERNAL_PROVENANCE_SEMANTIC_CHECK_FIELDS,
+        ),
+        (
+            ServingRequirement,
+            _EXTERNAL_PROVENANCE_PROJECTED_REQUIREMENT_FIELDS
+            | _EXTERNAL_PROVENANCE_SEMANTIC_REQUIREMENT_FIELDS,
+        ),
+        (
+            CapabilityIntent,
+            _EXTERNAL_PROVENANCE_PROJECTED_INTENT_FIELDS
+            | _EXTERNAL_PROVENANCE_SEMANTIC_INTENT_FIELDS,
+        ),
+        (
+            ConnectionScope,
+            _EXTERNAL_PROVENANCE_PROJECTED_CONNECTION_SCOPE_FIELDS
+            | _EXTERNAL_PROVENANCE_SEMANTIC_CONNECTION_SCOPE_FIELDS,
+        ),
+        (
+            BindingCapabilityPlan,
+            _EXTERNAL_PROVENANCE_PROJECTED_BINDING_PLAN_FIELDS
+            | _EXTERNAL_PROVENANCE_SEMANTIC_BINDING_PLAN_FIELDS
+            | _EXTERNAL_PROVENANCE_SPECIAL_BINDING_PLAN_FIELDS
+            | _EXTERNAL_PROVENANCE_COMPUTED_BINDING_PLAN_FIELDS,
+        ),
+        (
+            DeploymentCapabilityPlan,
+            _EXTERNAL_PROVENANCE_PROJECTED_DEPLOYMENT_PLAN_FIELDS
+            | _EXTERNAL_PROVENANCE_SEMANTIC_DEPLOYMENT_PLAN_FIELDS
+            | _EXTERNAL_PROVENANCE_COMPUTED_DEPLOYMENT_PLAN_FIELDS,
+        ),
+        (
+            DeploymentReconcileInput,
+            _EXTERNAL_PROVENANCE_PROJECTED_RECONCILE_INPUT_FIELDS
+            | _EXTERNAL_PROVENANCE_SEMANTIC_RECONCILE_INPUT_FIELDS,
+        ),
+    )
+    for record_type, classified_fields in policies:
+        record_fields = {item.name for item in dataclasses.fields(record_type)}
+        if record_fields == classified_fields:
+            continue
+        missing = sorted(record_fields - classified_fields)
+        stale = sorted(classified_fields - record_fields)
+        raise RuntimeError(
+            f"{record_type.__name__} external provenance policy is incomplete; "
+            f"missing={missing!r}, stale={stale!r}"
+        )
+
+
+def _replace_provenance_text(
+    value: str,
+    replacements: Mapping[str, str],
+) -> str:
+    projected = _replace_provenance_tokens(value, replacements)
+    assert isinstance(projected, str)
+    return projected
+
+
+def _project_provenance_check(
+    check: DeferredCheck,
+    replacements: Mapping[str, str],
+) -> DeferredCheck:
+    """Project diagnostic text without changing which verifier executes."""
+
+    return dataclasses.replace(
+        check,
+        reason=_replace_provenance_text(check.reason, replacements),
+    )
+
+
+def _project_provenance_requirement(
+    requirement: ServingRequirement,
+    replacements: Mapping[str, str],
+) -> ServingRequirement:
+    minimums = _replace_provenance_tokens(
+        cast(JSONValue, requirement.minimums), replacements
+    )
+    assert isinstance(minimums, Mapping)
+    return dataclasses.replace(
+        requirement,
+        minimums=cast(Mapping[str, JSONValue], minimums),
+        sources=tuple(
+            _replace_provenance_text(source, replacements)
+            for source in requirement.sources
+        ),
+        reason=(
+            None
+            if requirement.reason is None
+            else _replace_provenance_text(requirement.reason, replacements)
+        ),
+    )
+
+
+def _project_provenance_intent(
+    intent: CapabilityIntent,
+    replacements: Mapping[str, str],
+) -> CapabilityIntent:
+    """Project diagnostic sources without changing the requested capability."""
+
+    return dataclasses.replace(
+        intent,
+        sources=tuple(
+            _replace_provenance_text(source, replacements) for source in intent.sources
+        ),
+    )
+
+
+def _project_external_binding_plan(
+    plan: BindingCapabilityPlan,
+    *,
+    binding_id: str,
+    root_deployment_key: str,
+    connection_scope: ConnectionScope,
+    replacements: Mapping[str, str],
+    runtime_tokens: frozenset[str],
+) -> BindingCapabilityPlan:
+    """Build a stable view of every persisted binding-plan field."""
+
+    _validate_external_provenance_schema()
+    projected = dataclasses.replace(
+        plan,
+        binding_id=binding_id,
+        root_deployment_key=root_deployment_key,
+        intents={
+            capability: _project_provenance_intent(intent, replacements)
+            for capability, intent in plan.intents.items()
+        },
+        unavailable_capabilities={
+            capability: _replace_provenance_text(reason, replacements)
+            for capability, reason in plan.unavailable_capabilities.items()
+        },
+        serving_requirements=tuple(
+            _project_provenance_requirement(requirement, replacements)
+            for requirement in plan.serving_requirements
+        ),
+        connection_scope=connection_scope,
+    )
+    leaked = sorted(
+        token
+        for token in runtime_tokens
+        if _contains_provenance_token(cast(JSONValue, projected.to_json_value()), token)
+    )
+    if leaked:
+        raise ValueError(
+            "external provenance binding plan contains unresolved runtime "
+            "identity token(s): " + ", ".join(leaked)
+        )
+    return projected
+
+
+def _project_external_deployment_plan(
+    plan: DeploymentCapabilityPlan,
+    *,
+    root_deployment_key: str,
+    replacements: Mapping[str, str],
+    runtime_to_provenance: Mapping[str, str],
+    runtime_tokens: frozenset[str],
+) -> DeploymentCapabilityPlan:
+    """Build a stable view of every persisted deployment-plan field."""
+
+    _validate_external_provenance_schema()
+    outcome_evidence: dict[CapabilityKey, Mapping[str, JSONValue]] = {}
+    for capability, evidence in plan.outcome_evidence.items():
+        plan_fingerprints = evidence.get("plan_fingerprints")
+        if evidence.get("source") == "external_runtime_plans":
+            if not isinstance(plan_fingerprints, list) or not all(
+                isinstance(fingerprint, str) for fingerprint in plan_fingerprints
+            ):
+                raise TypeError(
+                    "external runtime plan evidence must contain string "
+                    "plan_fingerprints"
+                )
+            typed_fingerprints = cast(list[str], plan_fingerprints)
+            missing = sorted(set(typed_fingerprints) - runtime_to_provenance.keys())
+            if missing:
+                raise ValueError(
+                    "external provenance projection cannot resolve runtime plan "
+                    "fingerprint(s): " + ", ".join(missing)
+                )
+
+        projected = _replace_provenance_tokens(evidence, replacements)
+        assert isinstance(projected, Mapping)
+        if evidence.get("source") == "external_runtime_plans":
+            projected_fingerprints = projected.get("plan_fingerprints")
+            assert isinstance(projected_fingerprints, list)
+            projected = {
+                **projected,
+                "plan_fingerprints": sorted(
+                    {cast(str, item) for item in projected_fingerprints}
+                ),
+            }
+        outcome_evidence[capability] = cast(Mapping[str, JSONValue], projected)
+
+    recipe_parameters = _replace_provenance_tokens(
+        cast(JSONValue, plan.recipe_parameters), replacements
+    )
+    explicit_parameters = _replace_provenance_tokens(
+        cast(JSONValue, plan.explicit_parameters), replacements
+    )
+    launch_patch = _replace_provenance_tokens(
+        cast(JSONValue, plan.launch_patch), replacements
+    )
+    assert isinstance(recipe_parameters, Mapping)
+    assert isinstance(explicit_parameters, Mapping)
+    assert isinstance(launch_patch, Mapping)
+    projected_plan = dataclasses.replace(
+        plan,
+        root_deployment_key=root_deployment_key,
+        engine_id=_replace_provenance_text(plan.engine_id, replacements),
+        desired_plan_fingerprint=(
+            None
+            if plan.desired_plan_fingerprint is None
+            else _replace_provenance_text(plan.desired_plan_fingerprint, replacements)
+        ),
+        recipe_parameters=cast(Mapping[str, JSONValue], recipe_parameters),
+        explicit_parameters=cast(Mapping[str, JSONValue], explicit_parameters),
+        serving_requirements=tuple(
+            _project_provenance_requirement(requirement, replacements)
+            for requirement in plan.serving_requirements
+        ),
+        launch_patch=cast(Mapping[str, JSONValue], launch_patch),
+        setup_checks=tuple(
+            _project_provenance_check(check, replacements)
+            for check in plan.setup_checks
+        ),
+        request_checks=tuple(
+            _project_provenance_check(check, replacements)
+            for check in plan.request_checks
+        ),
+        outcome_evidence=outcome_evidence,
+    )
+    leaked = sorted(
+        token
+        for token in runtime_tokens
+        if _contains_provenance_token(
+            cast(JSONValue, projected_plan.to_json_value()), token
+        )
+    )
+    if leaked:
+        raise ValueError(
+            "external provenance plan contains unresolved runtime identity "
+            "token(s): " + ", ".join(leaked)
+        )
+    return projected_plan
+
+
+@dataclasses.dataclass(frozen=True)
+class _ExternalProvenanceContext:
+    root_deployment_key: str
+    replacements: Mapping[str, str]
+    ambiguous_replacements: frozenset[str]
+    runtime_to_provenance: Mapping[str, str]
+
+    @property
+    def runtime_tokens(self) -> frozenset[str]:
+        return frozenset(self.replacements) | self.ambiguous_replacements
 
 
 class _PR1CompatibilityServingReconciler:
@@ -547,9 +882,14 @@ class _PR1CompositeServingReconciler:
         self,
         compatibility: _PR1CompatibilityServingReconciler,
         injected: ServingReconciler,
+        injected_inputs: Callable[
+            [tuple[ServingRequirement, ...], DeploymentReconcileInput],
+            tuple[tuple[ServingRequirement, ...], DeploymentReconcileInput],
+        ],
     ) -> None:
         self._compatibility = compatibility
         self._injected = injected
+        self._injected_inputs = injected_inputs
 
     def reconcile(
         self,
@@ -557,7 +897,12 @@ class _PR1CompositeServingReconciler:
         deployment: DeploymentReconcileInput,
     ) -> Mapping[CapabilityKey, ServingOutcome]:
         baseline_outcomes = self._compatibility.reconcile(requirements, deployment)
-        injected_outcomes = dict(self._injected.reconcile(requirements, deployment))
+        injected_requirements, injected_deployment = self._injected_inputs(
+            requirements, deployment
+        )
+        injected_outcomes = dict(
+            self._injected.reconcile(injected_requirements, injected_deployment)
+        )
         external_keys = {
             requirement.capability
             for requirement in requirements
@@ -1361,6 +1706,7 @@ class EvalSession:
             else _PR1CompositeServingReconciler(
                 compatibility_reconciler,
                 serving_reconciler,
+                self._external_reconciler_inputs,
             )
         )
         # Snapshot at init time so every audit file this session writes
@@ -1951,6 +2297,143 @@ class EvalSession:
                 found[plan.binding_id] = plan
         return tuple(found[key] for key in sorted(found))
 
+    def _external_provenance_context(
+        self,
+        root_deployment_key: str,
+    ) -> _ExternalProvenanceContext | None:
+        """Resolve the stable identity view for one external runtime root."""
+
+        found: dict[str, tuple[RuntimeBindingPlan, RuntimeBindingPlan]] = {}
+        has_projection = False
+        for sources in self._task_role_model_sources.values():
+            for source in sources.values():
+                if not isinstance(source, Model) or source.runtime_plan is None:
+                    continue
+                runtime_plan = source.runtime_plan
+                if runtime_plan.root_deployment_key != root_deployment_key:
+                    continue
+                if source._provenance_projector is None:
+                    provenance_plan = runtime_plan
+                else:
+                    provenance_plan = source._provenance_plan
+                    if provenance_plan is None:
+                        raise ValueError(
+                            "external legacy source has incomplete provenance: "
+                            f"{runtime_plan.binding_id}"
+                        )
+                    has_projection = True
+
+                previous = found.get(runtime_plan.binding_id)
+                current = (runtime_plan, provenance_plan)
+                if previous is not None and previous != current:
+                    raise ValueError(
+                        f"external binding {runtime_plan.binding_id!r} resolves to "
+                        "different runtime or provenance plans within deployment "
+                        f"root {root_deployment_key!r}"
+                    )
+                found[runtime_plan.binding_id] = current
+
+        if not has_projection:
+            return None
+
+        stable_roots = {
+            provenance.root_deployment_key for _, provenance in found.values()
+        }
+        if len(stable_roots) != 1:
+            raise ValueError(
+                "external deployment root mixes incompatible provenance policies: "
+                + ", ".join(sorted(stable_roots))
+            )
+        stable_root = next(iter(stable_roots))
+        replacements: dict[str, str] = {}
+        ambiguous_replacements: set[str] = set()
+        runtime_to_provenance: dict[str, str] = {}
+        for runtime_plan, provenance_plan in found.values():
+            previous_fingerprint = runtime_to_provenance.get(runtime_plan.fingerprint)
+            if (
+                previous_fingerprint is not None
+                and previous_fingerprint != provenance_plan.fingerprint
+            ):
+                raise ValueError(
+                    "external runtime plan has conflicting stable provenance "
+                    f"projections: {runtime_plan.fingerprint}"
+                )
+            runtime_to_provenance[runtime_plan.fingerprint] = (
+                provenance_plan.fingerprint
+            )
+            _record_plan_provenance_replacements(
+                replacements,
+                ambiguous_replacements,
+                runtime_plan,
+                provenance_plan,
+            )
+
+        return _ExternalProvenanceContext(
+            root_deployment_key=stable_root,
+            replacements=MappingProxyType(dict(replacements)),
+            ambiguous_replacements=frozenset(ambiguous_replacements),
+            runtime_to_provenance=MappingProxyType(dict(runtime_to_provenance)),
+        )
+
+    def _external_reconciler_inputs(
+        self,
+        requirements: tuple[ServingRequirement, ...],
+        deployment: DeploymentReconcileInput,
+    ) -> tuple[tuple[ServingRequirement, ...], DeploymentReconcileInput]:
+        """Hide wrapper-private ownership identity from injected reconcilers."""
+
+        _validate_external_provenance_schema()
+        context = self._external_provenance_context(deployment.root_deployment_key)
+        if context is None:
+            return requirements, deployment
+
+        projected_requirements = tuple(
+            _project_provenance_requirement(requirement, context.replacements)
+            for requirement in requirements
+        )
+
+        prelaunch_plan = deployment.prelaunch_plan
+        if prelaunch_plan is not None:
+            prelaunch_plan = _project_external_deployment_plan(
+                prelaunch_plan,
+                root_deployment_key=context.root_deployment_key,
+                replacements=context.replacements,
+                runtime_to_provenance=context.runtime_to_provenance,
+                runtime_tokens=context.runtime_tokens,
+            )
+        recipe_parameters = _replace_provenance_tokens(
+            cast(JSONValue, deployment.recipe_parameters), context.replacements
+        )
+        explicit_parameters = _replace_provenance_tokens(
+            cast(JSONValue, deployment.explicit_parameters), context.replacements
+        )
+        assert isinstance(recipe_parameters, Mapping)
+        assert isinstance(explicit_parameters, Mapping)
+        projected_deployment = dataclasses.replace(
+            deployment,
+            root_deployment_key=context.root_deployment_key,
+            recipe_parameters=cast(Mapping[str, JSONValue], recipe_parameters),
+            explicit_parameters=cast(Mapping[str, JSONValue], explicit_parameters),
+            prelaunch_plan=prelaunch_plan,
+        )
+        projected_input: JSONValue = {
+            "requirements": [
+                requirement.to_json_value() for requirement in projected_requirements
+            ],
+            "deployment": projected_deployment.to_json_value(),
+        }
+        leaked = sorted(
+            token
+            for token in context.runtime_tokens
+            if _contains_provenance_token(projected_input, token)
+        )
+        if leaked:
+            raise ValueError(
+                "external reconciler inputs contain unresolved runtime identity "
+                "token(s): " + ", ".join(leaked)
+            )
+        return projected_requirements, projected_deployment
+
     def _external_provenance_plan(
         self,
         model: Model,
@@ -1970,83 +2453,34 @@ class EvalSession:
         source_baseline = model.runtime_plan
         if source_baseline is None:
             raise ValueError(f"external binding {binding_id!r} has no runtime plan")
+        context = self._external_provenance_context(runtime_plan.root_deployment_key)
+        if context is None:
+            raise ValueError(
+                f"external binding {binding_id!r} has no stable provenance context"
+            )
+        if baseline.root_deployment_key != context.root_deployment_key:
+            raise ValueError(
+                f"external binding {binding_id!r} has a conflicting stable "
+                "deployment root"
+            )
         binding_plan = result.binding_plans[binding_id]
         stable_scope = ConnectionScope(
             credential_scope=baseline.connection_identity.credential_scope,
             retry_policy=baseline.connection_identity.retry_policy,
             quota_scope=baseline.connection_identity.quota_scope,
         )
-        provenance_binding_plan = dataclasses.replace(
+        provenance_binding_plan = _project_external_binding_plan(
             binding_plan,
             binding_id=baseline.binding_id,
             root_deployment_key=baseline.root_deployment_key,
             connection_scope=stable_scope,
+            replacements=context.replacements,
+            runtime_tokens=context.runtime_tokens,
         )
 
-        projector = model._provenance_projector
-        replacements: dict[str, str] = {}
-        ambiguous_replacements: set[str] = set()
-        runtime_to_provenance: dict[str, str] = {}
-        _record_plan_provenance_replacements(
-            replacements,
-            ambiguous_replacements,
-            source_baseline,
-            baseline,
-        )
-        runtime_to_provenance[source_baseline.fingerprint] = baseline.fingerprint
-
-        for sources in self._task_role_model_sources.values():
-            for source in sources.values():
-                if not isinstance(source, Model) or source.runtime_plan is None:
-                    continue
-                source_plan = source.runtime_plan
-                if source_plan.root_deployment_key != runtime_plan.root_deployment_key:
-                    continue
-                if (
-                    source_plan.connection_identity != runtime_plan.connection_identity
-                    and _is_uuid_scoped_legacy_plan(source_plan)
-                ):
-                    raise ValueError(
-                        "deployment root mixes different UUID-scoped legacy "
-                        "connection identities; use separate roots"
-                    )
-                if source._provenance_projector is not None:
-                    provenance_plan = source._provenance_plan
-                    if provenance_plan is None:
-                        raise ValueError(
-                            "external legacy source has incomplete provenance: "
-                            f"{source_plan.binding_id}"
-                        )
-                elif (
-                    source_plan.connection_identity == runtime_plan.connection_identity
-                ):
-                    provenance_plan = projector(source_plan)
-                    if provenance_plan is None:
-                        raise ValueError(
-                            "external canonical source cannot be projected into "
-                            "legacy provenance: "
-                            f"{source_plan.binding_id}"
-                        )
-                else:
-                    # A genuinely canonical identity is already stable and may
-                    # remain verbatim in this legacy model's aggregate proof.
-                    provenance_plan = source_plan
-
-                previous = runtime_to_provenance.get(source_plan.fingerprint)
-                if previous is not None and previous != provenance_plan.fingerprint:
-                    raise ValueError(
-                        "external runtime plan has conflicting stable provenance "
-                        f"projections: {source_plan.fingerprint}"
-                    )
-                runtime_to_provenance[source_plan.fingerprint] = (
-                    provenance_plan.fingerprint
-                )
-                _record_plan_provenance_replacements(
-                    replacements,
-                    ambiguous_replacements,
-                    source_plan,
-                    provenance_plan,
-                )
+        replacements = dict(context.replacements)
+        ambiguous_replacements = set(context.ambiguous_replacements)
+        runtime_to_provenance = dict(context.runtime_to_provenance)
 
         _record_provenance_replacement(
             replacements,
@@ -2079,69 +2513,45 @@ class EvalSession:
             stable_scope.quota_scope,
         )
 
-        unresolved_result_tokens = {
+        runtime_tokens = context.runtime_tokens | {
             runtime_plan.fingerprint,
             runtime_plan.verification_fingerprint,
             runtime_plan.deployment_plan_fingerprint,
-        } - replacements.keys()
-        unresolved_result_tokens.update(ambiguous_replacements)
+        }
 
         deployment_plan = result.deployment_plans[runtime_plan.root_deployment_key]
-        outcome_evidence: dict[CapabilityKey, Mapping[str, JSONValue]] = {}
-        for capability, evidence in deployment_plan.outcome_evidence.items():
-            plan_fingerprints = evidence.get("plan_fingerprints")
-            if evidence.get("source") == "external_runtime_plans":
-                if not isinstance(plan_fingerprints, list) or not all(
-                    isinstance(fingerprint, str) for fingerprint in plan_fingerprints
-                ):
-                    raise TypeError(
-                        "external runtime plan evidence must contain string "
-                        "plan_fingerprints"
-                    )
-                typed_fingerprints = cast(list[str], plan_fingerprints)
-                missing = sorted(set(typed_fingerprints) - runtime_to_provenance.keys())
-                if missing:
-                    raise ValueError(
-                        "external provenance projection cannot resolve runtime plan "
-                        "fingerprint(s): " + ", ".join(missing)
-                    )
-
-            projected = _replace_provenance_tokens(evidence, replacements)
-            assert isinstance(projected, Mapping)
-            if evidence.get("source") == "external_runtime_plans":
-                projected_fingerprints = projected.get("plan_fingerprints")
-                assert isinstance(projected_fingerprints, list)
-                projected = {
-                    **projected,
-                    "plan_fingerprints": sorted(
-                        {cast(str, item) for item in projected_fingerprints}
-                    ),
-                }
-            leaked = sorted(
-                token
-                for token in unresolved_result_tokens
-                if _contains_provenance_token(cast(JSONValue, projected), token)
-            )
-            if leaked:
-                raise ValueError(
-                    "external provenance evidence contains unresolved runtime "
-                    "fingerprint(s): " + ", ".join(leaked)
-                )
-            outcome_evidence[capability] = cast(Mapping[str, JSONValue], projected)
-        provenance_deployment_plan = dataclasses.replace(
+        provenance_deployment_plan = _project_external_deployment_plan(
             deployment_plan,
             root_deployment_key=baseline.root_deployment_key,
-            outcome_evidence=outcome_evidence,
+            replacements=replacements,
+            runtime_to_provenance=runtime_to_provenance,
+            runtime_tokens=frozenset(runtime_tokens),
         )
-
-        return dataclasses.replace(
+        provenance_plan = dataclasses.replace(
             runtime_plan,
             binding_id=baseline.binding_id,
             root_deployment_key=baseline.root_deployment_key,
+            request_checks=tuple(
+                _project_provenance_check(check, replacements)
+                for check in runtime_plan.request_checks
+            ),
             connection_identity=baseline.connection_identity,
             binding_plan_fingerprint=provenance_binding_plan.fingerprint,
             deployment_plan_fingerprint=provenance_deployment_plan.fingerprint,
         )
+        leaked = sorted(
+            token
+            for token in runtime_tokens
+            if _contains_provenance_token(
+                cast(JSONValue, provenance_plan.to_json_value()), token
+            )
+        )
+        if leaked:
+            raise ValueError(
+                "external provenance plan contains unresolved runtime identity "
+                "token(s): " + ", ".join(leaked)
+            )
+        return provenance_plan
 
     def _validate_external_runtime_obligations(self, result: ReconcileResult) -> None:
         """Reject a rebound external plan that weakens its existing guarantees."""

--- a/sieval/core/models/_legacy_binding.py
+++ b/sieval/core/models/_legacy_binding.py
@@ -9,7 +9,7 @@ canonical ``Model.bind`` path, so it goes when the wrappers do.
 AI-Generated Code - Claude Opus 5 (1M context) (Anthropic)
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any
 from uuid import uuid4
 
@@ -38,8 +38,117 @@ class _LegacyOpenAIBinding:
     deployment: Deployment
     pool: ConnectionPool[Any]
     runtime_plan: RuntimeBindingPlan
+    provenance_projector: "_LegacyProvenanceProjector"
     local_limiter: anyio.CapacityLimiter | None
     parent_limiter: anyio.CapacityLimiter | None
+
+
+@dataclass(frozen=True)
+class _LegacyProvenanceProjector:
+    """Project a UUID-scoped runtime plan into stable persisted evidence."""
+
+    connection_identity: ConnectionIdentity
+    runtime_binding_id: str
+    runtime_root_deployment_key: str
+    runtime_binding_plan_fingerprint: str
+    runtime_deployment_plan_fingerprint: str
+
+    def _identity_suffix(self) -> str:
+        identity_fingerprint = fingerprint_mapping(
+            {
+                "endpoint": self.connection_identity.endpoint,
+                "connection_family": self.connection_identity.connection_family,
+                "credential_scope": self.connection_identity.credential_scope,
+                "retry_policy": self.connection_identity.retry_policy,
+                "quota_scope": self.connection_identity.quota_scope,
+            }
+        )
+        return identity_fingerprint.removeprefix("sha256:")[:16]
+
+    def _stable_binding_id(
+        self,
+        runtime_plan: RuntimeBindingPlan,
+        stable_base_id: str,
+    ) -> str | None:
+        """Classify and project only wrapper-owned binding identities.
+
+        ``with_dialect`` accepts plans for sibling logical bindings.  Preserve
+        a sibling suffix in an injective, namespaced encoding.  An unrelated
+        binding ID is opaque: retaining it could persist a runtime UUID, while
+        treating it as the base binding could collapse two logical bindings.
+        """
+
+        if runtime_plan.binding_id == self.runtime_binding_id:
+            return stable_base_id
+        sibling_prefix = f"{self.runtime_binding_id}:"
+        if runtime_plan.binding_id.startswith(sibling_prefix):
+            suffix = runtime_plan.binding_id.removeprefix(sibling_prefix)
+            encoded_suffix = suffix.encode("utf-8").hex()
+            return f"{stable_base_id}:sibling:{encoded_suffix}"
+        return None
+
+    def _project_identity(
+        self, runtime_plan: RuntimeBindingPlan
+    ) -> RuntimeBindingPlan | None:
+        """Replace proven wrapper-owned identities without touching evidence."""
+
+        if runtime_plan.root_deployment_key != self.runtime_root_deployment_key:
+            return None
+        identity_suffix = self._identity_suffix()
+        stable_base_id = (
+            f"legacy:{runtime_plan.dialect_id}:"
+            f"{runtime_plan.requested_model_id}:{identity_suffix}"
+        )
+        binding_id = self._stable_binding_id(runtime_plan, stable_base_id)
+        if binding_id is None:
+            return None
+        root_deployment_key = (
+            f"legacy:{runtime_plan.deployment_fingerprint}:{identity_suffix}"
+        )
+        return replace(
+            runtime_plan,
+            binding_id=binding_id,
+            root_deployment_key=root_deployment_key,
+            connection_identity=self.connection_identity,
+        )
+
+    def __call__(self, runtime_plan: RuntimeBindingPlan) -> RuntimeBindingPlan | None:
+        """Return stable evidence only when no opaque proof was replaced.
+
+        Reconciliation owns binding/deployment plan fingerprints.  A bare
+        ``with_dialect`` call cannot interpret a changed opaque fingerprint,
+        so it must leave provenance incomplete for the composition layer to
+        fill rather than silently replacing that evidence.
+        """
+
+        if (
+            runtime_plan.binding_plan_fingerprint
+            != self.runtime_binding_plan_fingerprint
+            or runtime_plan.deployment_plan_fingerprint
+            != self.runtime_deployment_plan_fingerprint
+        ):
+            return None
+        projected_identity = self._project_identity(runtime_plan)
+        if projected_identity is None:
+            return None
+
+        semantic_plan = projected_identity.to_json_value()
+        for key in (
+            "binding_plan_fingerprint",
+            "deployment_plan_fingerprint",
+            "fingerprint",
+            "verification_fingerprint",
+        ):
+            semantic_plan.pop(key)
+        binding_plan_fingerprint = fingerprint_mapping(
+            {"legacy_provenance_plan": semantic_plan}
+        )
+        projected = replace(
+            projected_identity,
+            binding_plan_fingerprint=binding_plan_fingerprint,
+            deployment_plan_fingerprint="external:none",
+        )
+        return projected
 
 
 def _legacy_runtime_plan(
@@ -163,10 +272,33 @@ def build_legacy_openai_binding(
         deployment=deployment,
         identity=identity,
     )
+    # The UUID above is required runtime identity: independently constructed
+    # legacy wrappers must never share quota or credential ownership by
+    # accident.  Persisted provenance records the same semantic binding with
+    # only a credential category and a stable private-pool scope, so object
+    # allocation does not make equivalent run artifacts differ.
+    provenance_identity = ConnectionIdentity(
+        endpoint=endpoint,
+        connection_family="openai_sdk",
+        credential_scope=(
+            "legacy-private:explicit-credential"
+            if api_key is not None
+            else "legacy-private:environment-credential"
+        ),
+        retry_policy=f"openai-sdk:max-retries={max_retries}",
+        quota_scope="legacy-private",
+    )
     return _LegacyOpenAIBinding(
         deployment=deployment,
         pool=pool,
         runtime_plan=runtime_plan,
+        provenance_projector=_LegacyProvenanceProjector(
+            provenance_identity,
+            runtime_plan.binding_id,
+            runtime_plan.root_deployment_key,
+            runtime_plan.binding_plan_fingerprint,
+            runtime_plan.deployment_plan_fingerprint,
+        ),
         local_limiter=local_limiter,
         parent_limiter=parent_limiter,
     )

--- a/sieval/core/models/_legacy_binding.py
+++ b/sieval/core/models/_legacy_binding.py
@@ -3,8 +3,8 @@
 These wrappers accept a bare ``model=``/``api_base=`` pair and must still
 present a truthful :class:`RuntimeBindingPlan`, so this module fabricates one
 from an externally-owned connection rather than from a reconciled deployment.
-Kept apart from ``model`` by lifetime: nothing here is reachable from the
-canonical ``Model.bind`` path, so it goes when the wrappers do.
+The canonical ``Model.bind`` path also uses the narrow reconstruction helper
+below so converting a wrapper plan cannot discard its provenance policy.
 
 AI-Generated Code - Claude Opus 5 (1M context) (Anthropic)
 """
@@ -151,35 +151,74 @@ class _LegacyProvenanceProjector:
         return projected
 
 
-def _legacy_runtime_plan(
-    *,
-    dialect_id: str,
-    requested_model_id: str,
-    deployment: Deployment,
-    identity: ConnectionIdentity,
-) -> RuntimeBindingPlan:
-    """Build honest external-Python binding evidence for legacy wrappers."""
+def _legacy_private_credential_kind(
+    runtime_plan: RuntimeBindingPlan,
+) -> str | None:
+    """Return the stable credential category for a wrapper-private identity."""
 
-    spec = get_dialect_spec(dialect_id)
-    route = resolve_route(deployment, dialect_id, spec.connection_family)
+    identity = runtime_plan.connection_identity
+    quota_scope = identity.quota_scope
+    prefix = "legacy-private:"
+    credential_scope = identity.credential_scope
+    uses_legacy_namespace = (
+        quota_scope == "legacy-private"
+        or quota_scope.startswith(prefix)
+        or credential_scope == "legacy-private"
+        or credential_scope.startswith(prefix)
+    )
+    if not uses_legacy_namespace:
+        return None
+    if not quota_scope.startswith(prefix):
+        raise ValueError(
+            "legacy-private connection identity has an invalid quota scope"
+        )
+    private_scope = quota_scope.removeprefix(prefix)
+    if len(private_scope) != 32 or any(
+        character not in "0123456789abcdef" for character in private_scope
+    ):
+        raise ValueError(
+            "legacy-private connection identity has an invalid runtime UUID"
+        )
+    credential_prefix = f"{quota_scope}:"
+    if not credential_scope.startswith(credential_prefix):
+        raise ValueError(
+            "legacy-private connection identity has mismatched credential and "
+            "quota scopes"
+        )
+    credential_kind = credential_scope.removeprefix(credential_prefix)
+    if credential_kind not in {
+        "explicit-credential",
+        "environment-credential",
+    }:
+        raise ValueError(
+            "legacy-private connection identity has an invalid credential category"
+        )
+    return credential_kind
+
+
+def _legacy_capability_state(
+    dialect_id: str,
+) -> tuple[frozenset[str], dict[str, JSONValue]]:
     decisions = capability_decisions_for(dialect_id)
     available = frozenset(
         key for key, decision in decisions.items() if isinstance(decision, Supported)
     )
     effective: dict[str, JSONValue] = {key: {} for key in sorted(available)}
-    identity_fingerprint = fingerprint_mapping(
-        {
-            "endpoint": identity.endpoint,
-            "connection_family": identity.connection_family,
-            "credential_scope": identity.credential_scope,
-            "retry_policy": identity.retry_policy,
-            "quota_scope": identity.quota_scope,
-        }
-    )
-    identity_suffix = identity_fingerprint.removeprefix("sha256:")[:16]
-    binding_id = f"legacy:{dialect_id}:{requested_model_id}:{identity_suffix}"
-    root_deployment_key = f"legacy:{deployment.fingerprint}:{identity_suffix}"
-    binding_plan_fingerprint = fingerprint_mapping(
+    return available, effective
+
+
+def _legacy_initial_binding_plan_fingerprint(
+    *,
+    dialect_id: str,
+    requested_model_id: str,
+    binding_id: str,
+    root_deployment_key: str,
+    available: frozenset[str],
+    effective: dict[str, JSONValue],
+) -> str:
+    """Return the opaque proof emitted by the unreconciled wrapper plan."""
+
+    return fingerprint_mapping(
         {
             "available_capabilities": sorted(available),
             "binding_id": binding_id,
@@ -193,6 +232,116 @@ def _legacy_runtime_plan(
             "required_output_channels": [],
             "root_deployment_key": root_deployment_key,
         }
+    )
+
+
+def _legacy_provenance_projector_for_plan(
+    runtime_plan: RuntimeBindingPlan,
+) -> _LegacyProvenanceProjector | None:
+    """Recover the stable policy carried implicitly by a legacy runtime plan.
+
+    ``Model.bind`` is public and may be handed a plan obtained from a legacy
+    wrapper.  Reconstructing the projector here prevents that shape conversion
+    from silently turning private pool ownership into persisted provenance.
+    Malformed legacy-looking identities fail closed instead of being treated as
+    canonical plans.
+    """
+
+    credential_kind = _legacy_private_credential_kind(runtime_plan)
+    if credential_kind is None:
+        return None
+
+    runtime_identity = runtime_plan.connection_identity
+    identity_fingerprint = fingerprint_mapping(
+        {
+            "endpoint": runtime_identity.endpoint,
+            "connection_family": runtime_identity.connection_family,
+            "credential_scope": runtime_identity.credential_scope,
+            "retry_policy": runtime_identity.retry_policy,
+            "quota_scope": runtime_identity.quota_scope,
+        }
+    )
+    runtime_suffix = identity_fingerprint.removeprefix("sha256:")[:16]
+    runtime_binding_id = (
+        f"legacy:{runtime_plan.dialect_id}:"
+        f"{runtime_plan.requested_model_id}:{runtime_suffix}"
+    )
+    runtime_root_deployment_key = (
+        f"legacy:{runtime_plan.deployment_fingerprint}:{runtime_suffix}"
+    )
+    if (
+        runtime_plan.binding_id != runtime_binding_id
+        and not runtime_plan.binding_id.startswith(f"{runtime_binding_id}:")
+    ):
+        raise ValueError("UUID-scoped legacy plan has an inconsistent binding identity")
+    if runtime_plan.root_deployment_key != runtime_root_deployment_key:
+        raise ValueError("UUID-scoped legacy plan has an inconsistent deployment root")
+
+    available, effective = _legacy_capability_state(runtime_plan.dialect_id)
+    initial_binding_plan_fingerprint = _legacy_initial_binding_plan_fingerprint(
+        dialect_id=runtime_plan.dialect_id,
+        requested_model_id=runtime_plan.requested_model_id,
+        binding_id=runtime_binding_id,
+        root_deployment_key=runtime_root_deployment_key,
+        available=available,
+        effective=effective,
+    )
+    if (
+        runtime_plan.binding_plan_fingerprint != initial_binding_plan_fingerprint
+        or runtime_plan.deployment_plan_fingerprint != "external:none"
+    ):
+        raise ValueError(
+            "UUID-scoped legacy plan contains opaque reconciled provenance; "
+            "attach its stable provenance through the composition layer"
+        )
+
+    stable_identity = ConnectionIdentity(
+        endpoint=runtime_identity.endpoint,
+        connection_family=runtime_identity.connection_family,
+        credential_scope=f"legacy-private:{credential_kind}",
+        retry_policy=runtime_identity.retry_policy,
+        quota_scope="legacy-private",
+    )
+    return _LegacyProvenanceProjector(
+        stable_identity,
+        runtime_binding_id,
+        runtime_root_deployment_key,
+        runtime_plan.binding_plan_fingerprint,
+        runtime_plan.deployment_plan_fingerprint,
+    )
+
+
+def _legacy_runtime_plan(
+    *,
+    dialect_id: str,
+    requested_model_id: str,
+    deployment: Deployment,
+    identity: ConnectionIdentity,
+) -> RuntimeBindingPlan:
+    """Build honest external-Python binding evidence for legacy wrappers."""
+
+    spec = get_dialect_spec(dialect_id)
+    route = resolve_route(deployment, dialect_id, spec.connection_family)
+    available, effective = _legacy_capability_state(dialect_id)
+    identity_fingerprint = fingerprint_mapping(
+        {
+            "endpoint": identity.endpoint,
+            "connection_family": identity.connection_family,
+            "credential_scope": identity.credential_scope,
+            "retry_policy": identity.retry_policy,
+            "quota_scope": identity.quota_scope,
+        }
+    )
+    identity_suffix = identity_fingerprint.removeprefix("sha256:")[:16]
+    binding_id = f"legacy:{dialect_id}:{requested_model_id}:{identity_suffix}"
+    root_deployment_key = f"legacy:{deployment.fingerprint}:{identity_suffix}"
+    binding_plan_fingerprint = _legacy_initial_binding_plan_fingerprint(
+        dialect_id=dialect_id,
+        requested_model_id=requested_model_id,
+        binding_id=binding_id,
+        root_deployment_key=root_deployment_key,
+        available=available,
+        effective=effective,
     )
     return RuntimeBindingPlan(
         binding_id=binding_id,
@@ -277,28 +426,13 @@ def build_legacy_openai_binding(
     # accident.  Persisted provenance records the same semantic binding with
     # only a credential category and a stable private-pool scope, so object
     # allocation does not make equivalent run artifacts differ.
-    provenance_identity = ConnectionIdentity(
-        endpoint=endpoint,
-        connection_family="openai_sdk",
-        credential_scope=(
-            "legacy-private:explicit-credential"
-            if api_key is not None
-            else "legacy-private:environment-credential"
-        ),
-        retry_policy=f"openai-sdk:max-retries={max_retries}",
-        quota_scope="legacy-private",
-    )
+    provenance_projector = _legacy_provenance_projector_for_plan(runtime_plan)
+    assert provenance_projector is not None
     return _LegacyOpenAIBinding(
         deployment=deployment,
         pool=pool,
         runtime_plan=runtime_plan,
-        provenance_projector=_LegacyProvenanceProjector(
-            provenance_identity,
-            runtime_plan.binding_id,
-            runtime_plan.root_deployment_key,
-            runtime_plan.binding_plan_fingerprint,
-            runtime_plan.deployment_plan_fingerprint,
-        ),
+        provenance_projector=provenance_projector,
         local_limiter=local_limiter,
         parent_limiter=parent_limiter,
     )

--- a/sieval/core/models/_legacy_binding.py
+++ b/sieval/core/models/_legacy_binding.py
@@ -4,13 +4,16 @@ These wrappers accept a bare ``model=``/``api_base=`` pair and must still
 present a truthful :class:`RuntimeBindingPlan`, so this module fabricates one
 from an externally-owned connection rather than from a reconciled deployment.
 The canonical ``Model.bind`` path also uses the narrow reconstruction helper
-below so converting a wrapper plan cannot discard its provenance policy.
+below so converting a wrapper plan cannot discard its provenance policy.  That
+compatibility-only dependency can be removed together with support for passing
+legacy wrapper plans to ``Model.bind``; ordinary wrapper construction does not
+round-trip through the recovery path.
 
 AI-Generated Code - Claude Opus 5 (1M context) (Anthropic)
 """
 
 from dataclasses import dataclass, replace
-from typing import Any
+from typing import Any, Literal
 from uuid import uuid4
 
 import anyio
@@ -31,6 +34,11 @@ from .deployment import (
 )
 from .dialect_registry import capability_decisions_for, get_dialect_spec
 from .reconcile import RuntimeBindingPlan
+
+type _LegacyCredentialKind = Literal[
+    "explicit-credential",
+    "environment-credential",
+]
 
 
 @dataclass(frozen=True)
@@ -153,16 +161,25 @@ class _LegacyProvenanceProjector:
 
 def _legacy_private_credential_kind(
     runtime_plan: RuntimeBindingPlan,
-) -> str | None:
+) -> _LegacyCredentialKind | None:
     """Return the stable credential category for a wrapper-private identity."""
 
     identity = runtime_plan.connection_identity
     quota_scope = identity.quota_scope
     prefix = "legacy-private:"
     credential_scope = identity.credential_scope
+    stable_credential_scopes = {
+        "legacy-private:explicit-credential",
+        "legacy-private:environment-credential",
+    }
+    if quota_scope == "legacy-private":
+        if credential_scope in stable_credential_scopes:
+            return None
+        raise ValueError(
+            "projected legacy provenance identity has an invalid credential scope"
+        )
     uses_legacy_namespace = (
-        quota_scope == "legacy-private"
-        or quota_scope.startswith(prefix)
+        quota_scope.startswith(prefix)
         or credential_scope == "legacy-private"
         or credential_scope.startswith(prefix)
     )
@@ -186,14 +203,28 @@ def _legacy_private_credential_kind(
             "quota scopes"
         )
     credential_kind = credential_scope.removeprefix(credential_prefix)
-    if credential_kind not in {
-        "explicit-credential",
-        "environment-credential",
-    }:
-        raise ValueError(
-            "legacy-private connection identity has an invalid credential category"
-        )
-    return credential_kind
+    if credential_kind == "explicit-credential":
+        return "explicit-credential"
+    if credential_kind == "environment-credential":
+        return "environment-credential"
+    raise ValueError(
+        "legacy-private connection identity has an invalid credential category"
+    )
+
+
+def _legacy_stable_connection_identity(
+    runtime_identity: ConnectionIdentity,
+    credential_kind: _LegacyCredentialKind,
+) -> ConnectionIdentity:
+    """Return the stable semantic view of one wrapper-private connection."""
+
+    return ConnectionIdentity(
+        endpoint=runtime_identity.endpoint,
+        connection_family=runtime_identity.connection_family,
+        credential_scope=f"legacy-private:{credential_kind}",
+        retry_policy=runtime_identity.retry_policy,
+        quota_scope="legacy-private",
+    )
 
 
 def _legacy_capability_state(
@@ -295,12 +326,9 @@ def _legacy_provenance_projector_for_plan(
             "attach its stable provenance through the composition layer"
         )
 
-    stable_identity = ConnectionIdentity(
-        endpoint=runtime_identity.endpoint,
-        connection_family=runtime_identity.connection_family,
-        credential_scope=f"legacy-private:{credential_kind}",
-        retry_policy=runtime_identity.retry_policy,
-        quota_scope="legacy-private",
+    stable_identity = _legacy_stable_connection_identity(
+        runtime_identity,
+        credential_kind,
     )
     return _LegacyProvenanceProjector(
         stable_identity,
@@ -426,8 +454,20 @@ def build_legacy_openai_binding(
     # accident.  Persisted provenance records the same semantic binding with
     # only a credential category and a stable private-pool scope, so object
     # allocation does not make equivalent run artifacts differ.
-    provenance_projector = _legacy_provenance_projector_for_plan(runtime_plan)
-    assert provenance_projector is not None
+    credential_kind: _LegacyCredentialKind = (
+        "explicit-credential" if api_key is not None else "environment-credential"
+    )
+    provenance_identity = _legacy_stable_connection_identity(
+        identity,
+        credential_kind,
+    )
+    provenance_projector = _LegacyProvenanceProjector(
+        provenance_identity,
+        runtime_plan.binding_id,
+        runtime_plan.root_deployment_key,
+        runtime_plan.binding_plan_fingerprint,
+        runtime_plan.deployment_plan_fingerprint,
+    )
     return _LegacyOpenAIBinding(
         deployment=deployment,
         pool=pool,

--- a/sieval/core/models/_legacy_binding.py
+++ b/sieval/core/models/_legacy_binding.py
@@ -420,14 +420,16 @@ def build_legacy_openai_binding(
         shared_limiter = local_limiter
 
     private_scope = uuid4().hex
+    # One derivation feeds both the volatile runtime identity and the stable
+    # provenance identity below, so the two can never disagree about whether
+    # the credential was explicit or environment-derived.
+    credential_kind: _LegacyCredentialKind = (
+        "explicit-credential" if api_key is not None else "environment-credential"
+    )
     identity = ConnectionIdentity(
         endpoint=endpoint,
         connection_family="openai_sdk",
-        credential_scope=(
-            f"legacy-private:{private_scope}:explicit-credential"
-            if api_key is not None
-            else f"legacy-private:{private_scope}:environment-credential"
-        ),
+        credential_scope=f"legacy-private:{private_scope}:{credential_kind}",
         retry_policy=f"openai-sdk:max-retries={max_retries}",
         quota_scope=f"legacy-private:{private_scope}",
     )
@@ -454,9 +456,6 @@ def build_legacy_openai_binding(
     # accident.  Persisted provenance records the same semantic binding with
     # only a credential category and a stable private-pool scope, so object
     # allocation does not make equivalent run artifacts differ.
-    credential_kind: _LegacyCredentialKind = (
-        "explicit-credential" if api_key is not None else "environment-credential"
-    )
     provenance_identity = _legacy_stable_connection_identity(
         identity,
         credential_kind,

--- a/sieval/core/models/_legacy_binding.py
+++ b/sieval/core/models/_legacy_binding.py
@@ -420,9 +420,8 @@ def build_legacy_openai_binding(
         shared_limiter = local_limiter
 
     private_scope = uuid4().hex
-    # One derivation feeds both the volatile runtime identity and the stable
-    # provenance identity below, so the two can never disagree about whether
-    # the credential was explicit or environment-derived.
+    # Derived once for both the runtime identity and the stable provenance
+    # identity below, so the two cannot disagree.
     credential_kind: _LegacyCredentialKind = (
         "explicit-credential" if api_key is not None else "environment-credential"
     )

--- a/sieval/core/models/chat_model.py
+++ b/sieval/core/models/chat_model.py
@@ -70,6 +70,7 @@ class ChatModel(Model):
             extra=extra,
             api_base=api_base,
             lifecycle_owner=self,
+            provenance_projector=binding.provenance_projector,
         )
 
     def _build_default_transport(self) -> Dialect:

--- a/sieval/core/models/gen_model.py
+++ b/sieval/core/models/gen_model.py
@@ -65,6 +65,7 @@ class GenModel(Model):
             extra=extra,
             api_base=api_base,
             lifecycle_owner=self,
+            provenance_projector=binding.provenance_projector,
         )
 
     def _build_default_transport(self) -> Dialect:

--- a/sieval/core/models/model.py
+++ b/sieval/core/models/model.py
@@ -15,6 +15,7 @@ AI-Generated Code - GPT-5.6 (OpenAI)
 """
 
 import copy
+import json
 from collections.abc import Mapping
 from dataclasses import fields, replace
 from types import TracebackType
@@ -24,6 +25,7 @@ import anyio
 
 from sieval.core.types import JSONValue
 
+from ._legacy_binding import _legacy_provenance_projector_for_plan
 from ._legacy_bridge import (
     ModelMeta,
     ModelOutput,
@@ -38,6 +40,7 @@ from .capabilities import (
 )
 from .deployment import (
     BINDING_RESOURCE_KEYS,
+    ConnectionIdentity,
     ConnectionPool,
     Deployment,
 )
@@ -66,7 +69,7 @@ from .ir import (
     Request,
     Response,
 )
-from .reconcile import RuntimeBindingPlan
+from .reconcile import CheckStage, DeferredCheck, RuntimeBindingPlan
 
 
 class ModelQuotaSnapshot(TypedDict):
@@ -121,13 +124,16 @@ class _ProvenanceProjector(Protocol):
     ) -> RuntimeBindingPlan | None: ...
 
 
-def _validate_provenance_plan(
-    runtime_plan: RuntimeBindingPlan,
-    provenance_plan: RuntimeBindingPlan,
-) -> None:
-    """Reject projections that change request or capability semantics."""
-
-    semantic_fields = (
+_PROVENANCE_PROJECTABLE_PLAN_FIELDS = frozenset(
+    {
+        "binding_id",
+        "root_deployment_key",
+        "binding_plan_fingerprint",
+        "deployment_plan_fingerprint",
+    }
+)
+_PROVENANCE_SEMANTIC_PLAN_FIELDS = frozenset(
+    {
         "requested_model_id",
         "dialect_id",
         "declared_capabilities",
@@ -136,18 +142,112 @@ def _validate_provenance_plan(
         "capability_minimums",
         "request_defaults",
         "required_output_channels",
-        "request_checks",
         "deployment_fingerprint",
         "resolved_route",
+    }
+)
+_PROVENANCE_SPECIAL_PLAN_FIELDS = frozenset({"request_checks", "connection_identity"})
+_PROVENANCE_COMPUTED_PLAN_FIELDS = frozenset(
+    {"fingerprint", "verification_fingerprint"}
+)
+_PROVENANCE_PROJECTABLE_CONNECTION_FIELDS = frozenset(
+    {"credential_scope", "quota_scope"}
+)
+_PROVENANCE_SEMANTIC_CONNECTION_FIELDS = frozenset(
+    {"endpoint", "connection_family", "retry_policy"}
+)
+_PROVENANCE_PROJECTABLE_CHECK_FIELDS = frozenset({"reason"})
+_PROVENANCE_SEMANTIC_CHECK_FIELDS = frozenset({"capability", "stage", "verifier"})
+
+
+def _validate_provenance_schema() -> None:
+    """Fail when a plan field has no explicit provenance policy."""
+
+    plan_fields = {item.name for item in fields(RuntimeBindingPlan)}
+    classified_plan_fields = (
+        _PROVENANCE_PROJECTABLE_PLAN_FIELDS
+        | _PROVENANCE_SEMANTIC_PLAN_FIELDS
+        | _PROVENANCE_SPECIAL_PLAN_FIELDS
+        | _PROVENANCE_COMPUTED_PLAN_FIELDS
     )
+    if plan_fields != classified_plan_fields:
+        missing = sorted(plan_fields - classified_plan_fields)
+        stale = sorted(classified_plan_fields - plan_fields)
+        raise RuntimeError(
+            "RuntimeBindingPlan provenance policy is incomplete; "
+            f"missing={missing!r}, stale={stale!r}"
+        )
+
+    identity_fields = {item.name for item in fields(ConnectionIdentity)}
+    classified_identity_fields = (
+        _PROVENANCE_PROJECTABLE_CONNECTION_FIELDS
+        | _PROVENANCE_SEMANTIC_CONNECTION_FIELDS
+    )
+    if identity_fields != classified_identity_fields:
+        missing = sorted(identity_fields - classified_identity_fields)
+        stale = sorted(classified_identity_fields - identity_fields)
+        raise RuntimeError(
+            "ConnectionIdentity provenance policy is incomplete; "
+            f"missing={missing!r}, stale={stale!r}"
+        )
+
+    check_fields = {item.name for item in fields(DeferredCheck)}
+    classified_check_fields = (
+        _PROVENANCE_PROJECTABLE_CHECK_FIELDS | _PROVENANCE_SEMANTIC_CHECK_FIELDS
+    )
+    if check_fields != classified_check_fields:
+        missing = sorted(check_fields - classified_check_fields)
+        stale = sorted(classified_check_fields - check_fields)
+        raise RuntimeError(
+            "DeferredCheck provenance policy is incomplete; "
+            f"missing={missing!r}, stale={stale!r}"
+        )
+
+
+def _request_check_semantics(
+    checks: tuple[DeferredCheck, ...],
+) -> tuple[tuple[str, CheckStage, str], ...]:
+    """Return the executable part of checks; reasons are diagnostic evidence."""
+
+    return tuple((check.capability, check.stage, check.verifier) for check in checks)
+
+
+def _same_json_value(left: JSONValue, right: JSONValue) -> bool:
+    """Compare JSON values with the same type-sensitive rules as fingerprints."""
+
+    def encode(value: JSONValue) -> str:
+        return json.dumps(
+            value,
+            allow_nan=False,
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+
+    return encode(left) == encode(right)
+
+
+def _validate_provenance_plan(
+    runtime_plan: RuntimeBindingPlan,
+    provenance_plan: RuntimeBindingPlan,
+) -> None:
+    """Reject projections that change request or capability semantics."""
+
+    _validate_provenance_schema()
+    runtime_value = runtime_plan.to_json_value()
+    provenance_value = provenance_plan.to_json_value()
     changed = [
         name
-        for name in semantic_fields
-        if getattr(provenance_plan, name) != getattr(runtime_plan, name)
+        for name in sorted(_PROVENANCE_SEMANTIC_PLAN_FIELDS)
+        if not _same_json_value(runtime_value[name], provenance_value[name])
     ]
+    if _request_check_semantics(provenance_plan.request_checks) != (
+        _request_check_semantics(runtime_plan.request_checks)
+    ):
+        changed.append("request_checks")
     changed.extend(
         f"connection_identity.{name}"
-        for name in ("endpoint", "connection_family", "retry_policy")
+        for name in sorted(_PROVENANCE_SEMANTIC_CONNECTION_FIELDS)
         if getattr(provenance_plan.connection_identity, name)
         != getattr(runtime_plan.connection_identity, name)
     )
@@ -291,6 +391,8 @@ class Model:
             raise ValueError("bound dialect does not match the runtime plan")
         if dialect.connection_family != runtime_plan.resolved_route.connection_family:
             raise ValueError("bound dialect does not match the connection family")
+        if provenance_projector is None:
+            provenance_projector = _legacy_provenance_projector_for_plan(runtime_plan)
         self._deployment = deployment
         self._pool = pool
         self._runtime_plan = runtime_plan

--- a/sieval/core/models/model.py
+++ b/sieval/core/models/model.py
@@ -18,7 +18,7 @@ import copy
 from collections.abc import Mapping
 from dataclasses import fields, replace
 from types import TracebackType
-from typing import Any, Self, TypedDict, cast
+from typing import Any, Protocol, Self, TypedDict, cast
 
 import anyio
 
@@ -111,6 +111,50 @@ _RESPONSE_CHANNEL_BY_CAPABILITY: Mapping[str, str] = {
 
 _REQUEST_CHECK_VERIFIERS = frozenset({"validate_response_channel"})
 _REMOVED_SUBCLASS_HOOKS = frozenset({"_agenerate_impl", "_alogprobs_impl"})
+
+
+class _ProvenanceProjector(Protocol):
+    """Legacy seam for deriving stable evidence from a runtime plan."""
+
+    def __call__(
+        self, runtime_plan: RuntimeBindingPlan
+    ) -> RuntimeBindingPlan | None: ...
+
+
+def _validate_provenance_plan(
+    runtime_plan: RuntimeBindingPlan,
+    provenance_plan: RuntimeBindingPlan,
+) -> None:
+    """Reject projections that change request or capability semantics."""
+
+    semantic_fields = (
+        "requested_model_id",
+        "dialect_id",
+        "declared_capabilities",
+        "effective_capabilities",
+        "available_capabilities",
+        "capability_minimums",
+        "request_defaults",
+        "required_output_channels",
+        "request_checks",
+        "deployment_fingerprint",
+        "resolved_route",
+    )
+    changed = [
+        name
+        for name in semantic_fields
+        if getattr(provenance_plan, name) != getattr(runtime_plan, name)
+    ]
+    changed.extend(
+        f"connection_identity.{name}"
+        for name in ("endpoint", "connection_family", "retry_policy")
+        if getattr(provenance_plan.connection_identity, name)
+        != getattr(runtime_plan.connection_identity, name)
+    )
+    if changed:
+        raise ValueError(
+            "provenance plan changes runtime semantics: " + ", ".join(changed)
+        )
 
 
 def _checked_builder_defaults(values: Mapping[str, object]) -> dict[str, object]:
@@ -240,6 +284,8 @@ class Model:
         extra: Mapping[str, JSONValue] | None,
         api_base: str | None,
         lifecycle_owner: "Model | None",
+        provenance_projector: _ProvenanceProjector | None = None,
+        provenance_plan: RuntimeBindingPlan | None = None,
     ) -> None:
         if dialect.dialect_id != runtime_plan.dialect_id:
             raise ValueError("bound dialect does not match the runtime plan")
@@ -258,6 +304,19 @@ class Model:
         self._parent_limiter = parent_limiter
         self._lifecycle_owner = lifecycle_owner
         self._client = pool.connection  # borrowed compatibility view; never owned here
+        # Canonical bindings persist their runtime plan verbatim. Legacy
+        # wrappers retain volatile pool ownership at runtime while projecting
+        # every derived/reconciled plan into stable persisted evidence.
+        self._provenance_projector = provenance_projector
+        if provenance_plan is None:
+            provenance_plan = (
+                runtime_plan
+                if provenance_projector is None
+                else provenance_projector(runtime_plan)
+            )
+        if provenance_plan is not None:
+            _validate_provenance_plan(runtime_plan, provenance_plan)
+        self._provenance_plan = provenance_plan
 
     @property
     def dialect_id(self) -> str:
@@ -357,6 +416,9 @@ class Model:
             self._pool,
             runtime_plan,
         )
+        provenance_plan = (
+            self._provenance_plan if runtime_plan == self._runtime_plan else None
+        )
         result = object.__new__(Model)
         result._initialize(
             deployment=self._deployment,
@@ -369,8 +431,38 @@ class Model:
             extra=self._extra,
             api_base=self._api_base,
             lifecycle_owner=self._lifecycle_owner,
+            provenance_projector=self._provenance_projector,
+            provenance_plan=provenance_plan,
         )
         return result
+
+    def _with_provenance_plan(
+        self,
+        provenance_plan: RuntimeBindingPlan,
+    ) -> Self:
+        """Return a copy carrying trusted composition-layer provenance."""
+
+        if self._provenance_projector is None and provenance_plan != self._runtime_plan:
+            raise ValueError(
+                "canonical models must persist their runtime plan verbatim"
+            )
+        _validate_provenance_plan(self._runtime_plan, provenance_plan)
+        if provenance_plan == self._provenance_plan:
+            return self
+        result = copy.copy(self)
+        result._provenance_plan = provenance_plan
+        return result
+
+    def _require_provenance_plan(self) -> RuntimeBindingPlan:
+        """Return complete persisted evidence or fail before request I/O."""
+
+        provenance_plan = self._provenance_plan
+        if provenance_plan is None:
+            raise RuntimeError(
+                "model provenance is incomplete: the reconciled binding and "
+                "deployment evidence must be attached by the composition layer"
+            )
+        return provenance_plan
 
     def as_compat_type(self, model_type: type["Model"]) -> "Model":
         """Expose a truthful one-cycle wrapper over this exact binding.
@@ -405,6 +497,8 @@ class Model:
             extra=self._extra,
             api_base=self._api_base,
             lifecycle_owner=None,
+            provenance_projector=self._provenance_projector,
+            provenance_plan=self._provenance_plan,
         )
         return result
 
@@ -496,6 +590,7 @@ class Model:
 
         if not isinstance(req, Request):
             raise TypeError(f"arun requires Request, got {type(req).__name__}")
+        self._require_provenance_plan()
         projected = _apply_request_defaults(req, self._runtime_plan.request_defaults)
         validate_request_invariants(projected)
         validate_runtime_binding_plan(self._runtime_plan, projected)
@@ -562,6 +657,7 @@ class Model:
 
     def _provenance(self, response: Response) -> ModelProvenance:
         plan = self._runtime_plan
+        provenance_plan = self._require_provenance_plan()
         deployment = self._deployment
         return ModelProvenance(
             dialect_id=plan.dialect_id,
@@ -577,8 +673,8 @@ class Model:
             capabilities=CapabilityEvidence(
                 declared=plan.declared_capabilities,
                 effective=plan.effective_capabilities,
-                plan_fingerprint=plan.fingerprint,
-                verification_fingerprint=plan.verification_fingerprint,
+                plan_fingerprint=provenance_plan.fingerprint,
+                verification_fingerprint=provenance_plan.verification_fingerprint,
             ),
         )
 

--- a/sieval/core/models/model.py
+++ b/sieval/core/models/model.py
@@ -25,6 +25,8 @@ import anyio
 
 from sieval.core.types import JSONValue
 
+# Compatibility-only recovery for public ``Model.bind(..., legacy_plan)``.
+# Remove this dependency when wrapper runtime plans stop being bindable.
 from ._legacy_binding import _legacy_provenance_projector_for_plan
 from ._legacy_bridge import (
     ModelMeta,
@@ -40,7 +42,6 @@ from .capabilities import (
 )
 from .deployment import (
     BINDING_RESOURCE_KEYS,
-    ConnectionIdentity,
     ConnectionPool,
     Deployment,
 )
@@ -160,50 +161,6 @@ _PROVENANCE_PROJECTABLE_CHECK_FIELDS = frozenset({"reason"})
 _PROVENANCE_SEMANTIC_CHECK_FIELDS = frozenset({"capability", "stage", "verifier"})
 
 
-def _validate_provenance_schema() -> None:
-    """Fail when a plan field has no explicit provenance policy."""
-
-    plan_fields = {item.name for item in fields(RuntimeBindingPlan)}
-    classified_plan_fields = (
-        _PROVENANCE_PROJECTABLE_PLAN_FIELDS
-        | _PROVENANCE_SEMANTIC_PLAN_FIELDS
-        | _PROVENANCE_SPECIAL_PLAN_FIELDS
-        | _PROVENANCE_COMPUTED_PLAN_FIELDS
-    )
-    if plan_fields != classified_plan_fields:
-        missing = sorted(plan_fields - classified_plan_fields)
-        stale = sorted(classified_plan_fields - plan_fields)
-        raise RuntimeError(
-            "RuntimeBindingPlan provenance policy is incomplete; "
-            f"missing={missing!r}, stale={stale!r}"
-        )
-
-    identity_fields = {item.name for item in fields(ConnectionIdentity)}
-    classified_identity_fields = (
-        _PROVENANCE_PROJECTABLE_CONNECTION_FIELDS
-        | _PROVENANCE_SEMANTIC_CONNECTION_FIELDS
-    )
-    if identity_fields != classified_identity_fields:
-        missing = sorted(identity_fields - classified_identity_fields)
-        stale = sorted(classified_identity_fields - identity_fields)
-        raise RuntimeError(
-            "ConnectionIdentity provenance policy is incomplete; "
-            f"missing={missing!r}, stale={stale!r}"
-        )
-
-    check_fields = {item.name for item in fields(DeferredCheck)}
-    classified_check_fields = (
-        _PROVENANCE_PROJECTABLE_CHECK_FIELDS | _PROVENANCE_SEMANTIC_CHECK_FIELDS
-    )
-    if check_fields != classified_check_fields:
-        missing = sorted(check_fields - classified_check_fields)
-        stale = sorted(classified_check_fields - check_fields)
-        raise RuntimeError(
-            "DeferredCheck provenance policy is incomplete; "
-            f"missing={missing!r}, stale={stale!r}"
-        )
-
-
 def _request_check_semantics(
     checks: tuple[DeferredCheck, ...],
 ) -> tuple[tuple[str, CheckStage, str], ...]:
@@ -233,7 +190,8 @@ def _validate_provenance_plan(
 ) -> None:
     """Reject projections that change request or capability semantics."""
 
-    _validate_provenance_schema()
+    if provenance_plan is runtime_plan:
+        return
     runtime_value = runtime_plan.to_json_value()
     provenance_value = provenance_plan.to_json_value()
     changed = [
@@ -348,6 +306,7 @@ class Model:
             pool,
             runtime_plan,
         )
+        provenance_projector = _legacy_provenance_projector_for_plan(runtime_plan)
         model = object.__new__(Model)
         model._initialize(
             deployment=deployment,
@@ -368,6 +327,7 @@ class Model:
             extra=extra,
             api_base=deployment.api_base,
             lifecycle_owner=None,
+            provenance_projector=provenance_projector,
         )
         return model
 
@@ -391,8 +351,6 @@ class Model:
             raise ValueError("bound dialect does not match the runtime plan")
         if dialect.connection_family != runtime_plan.resolved_route.connection_family:
             raise ValueError("bound dialect does not match the connection family")
-        if provenance_projector is None:
-            provenance_projector = _legacy_provenance_projector_for_plan(runtime_plan)
         self._deployment = deployment
         self._pool = pool
         self._runtime_plan = runtime_plan
@@ -417,6 +375,10 @@ class Model:
                 else provenance_projector(runtime_plan)
             )
         if provenance_plan is not None:
+            if provenance_projector is None and provenance_plan != runtime_plan:
+                raise ValueError(
+                    "canonical models must persist their runtime plan verbatim"
+                )
             _validate_provenance_plan(runtime_plan, provenance_plan)
         self._provenance_plan = provenance_plan
 
@@ -427,6 +389,12 @@ class Model:
     @property
     def runtime_plan(self) -> RuntimeBindingPlan | None:
         return self._runtime_plan
+
+    @property
+    def provenance_plan(self) -> RuntimeBindingPlan | None:
+        """Return the immutable plan used for persisted model evidence."""
+
+        return self._provenance_plan
 
     @property
     def deployment(self) -> Deployment:
@@ -538,7 +506,17 @@ class Model:
         )
         return result
 
-    def _with_provenance_plan(
+    def with_reconciled_plan(
+        self,
+        runtime_plan: RuntimeBindingPlan,
+        provenance_plan: RuntimeBindingPlan,
+    ) -> "Model":
+        """Atomically rebind runtime behavior and composition-owned provenance."""
+
+        rebound = self.with_dialect(runtime_plan.dialect_id, runtime_plan)
+        return rebound.with_provenance_plan(provenance_plan)
+
+    def with_provenance_plan(
         self,
         provenance_plan: RuntimeBindingPlan,
     ) -> Self:

--- a/sieval/core/models/sglang_gen_model.py
+++ b/sieval/core/models/sglang_gen_model.py
@@ -206,6 +206,10 @@ class SglangGenModel(Model):
         return None
 
     @property
+    def provenance_plan(self) -> None:
+        return None
+
+    @property
     def capabilities(self) -> frozenset[Capability]:
         return self._legacy_transport.capabilities
 
@@ -228,6 +232,13 @@ class SglangGenModel(Model):
         del dialect_id, runtime_plan
         raise RuntimeError(
             "sglang_legacy cannot rebind before the sglang_native PR-5 binder"
+        )
+
+    def with_provenance_plan(self, provenance_plan: Any) -> Self:
+        del provenance_plan
+        raise RuntimeError(
+            "sglang_legacy has no runtime plan for provenance before the "
+            "sglang_native PR-5 binder"
         )
 
     def _legacy_lifecycle_owner(self) -> "SglangGenModel":

--- a/sieval/core/models/sglang_gen_model.py
+++ b/sieval/core/models/sglang_gen_model.py
@@ -35,6 +35,7 @@ from .dialect import (
 from .dialect_registry import compatibility_factory_for
 from .ir import CompletionInput, ModelInput, Request, Response
 from .model import Model
+from .reconcile import RuntimeBindingPlan
 from .transports.sglang import (
     SGLANG_LEGACY_DIALECT_OPTION_KEYS,
     SglangTransport,
@@ -228,13 +229,13 @@ class SglangGenModel(Model):
         async with self._pool.acquire(self._limiter):
             return await self._legacy_transport.arun(req)
 
-    def with_dialect(self, dialect_id: str, runtime_plan: Any) -> Model:
+    def with_dialect(self, dialect_id: str, runtime_plan: RuntimeBindingPlan) -> Model:
         del dialect_id, runtime_plan
         raise RuntimeError(
             "sglang_legacy cannot rebind before the sglang_native PR-5 binder"
         )
 
-    def with_provenance_plan(self, provenance_plan: Any) -> Self:
+    def with_provenance_plan(self, provenance_plan: RuntimeBindingPlan) -> Self:
         del provenance_plan
         raise RuntimeError(
             "sglang_legacy has no runtime plan for provenance before the "

--- a/tests/unit/cli/leaderboard/test_session.py
+++ b/tests/unit/cli/leaderboard/test_session.py
@@ -1764,12 +1764,10 @@ class TestPrelaunchReconciliation:
             )
 
     def test_check_reason_leak_is_named_before_the_whole_plan_backstop(self) -> None:
-        """Pin the per-check rejection, not just the plan-wide one.
+        """Pin the per-check rejection, not the plan-wide backstop.
 
-        The whole-plan leak check at the end of the projection would also catch
-        a token in a check reason, so asserting only that *something* raises
-        passes with the per-check pass deleted.  The context string is what
-        distinguishes the layers, so that is what this asserts.
+        Both catch the same token, so matching the context string is the only
+        way to fail when the per-check pass is deleted.
         """
 
         runtime_token = "legacy-private:" + "b" * 32
@@ -1806,11 +1804,9 @@ class TestPrelaunchReconciliation:
     def test_projection_changes_only_the_fields_labelled_projected(self) -> None:
         """Make the PROJECTED/SEMANTIC labels load-bearing.
 
-        The completeness test above only proves every field was *named*; the
-        projection functions route fields by hand and never read these sets, so
-        a field could be labelled SEMANTIC while being rewritten (or the
-        reverse) with nothing failing.  This pins each label against what the
-        projection actually does.
+        The test above only proves every field was *named*.  The projection
+        functions route fields by hand and never read these sets, so a
+        mislabelled field would otherwise fail nothing.
         """
 
         for case in _projection_label_cases():
@@ -1828,8 +1824,7 @@ class TestPrelaunchReconciliation:
                 f"{case.label}: {sorted(changed & case.semantic_fields)} is "
                 "labelled semantic but was rewritten"
             )
-            # A label is only meaningful if the projection actually moved
-            # something, otherwise the assertions above hold vacuously.
+            # Without this the two assertions above hold vacuously.
             assert changed, f"{case.label}: projection changed nothing"
 
     def test_external_provenance_rejects_runtime_tokens_in_semantic_json(self) -> None:

--- a/tests/unit/cli/leaderboard/test_session.py
+++ b/tests/unit/cli/leaderboard/test_session.py
@@ -22,7 +22,15 @@ import yaml
 from sieval.cli._filter_spec import VALUES_DIGEST_KEY, compute_values_digest
 from sieval.cli.leaderboard.session import (
     _DETERMINISTIC_SEED_CONTRACT_KEY,
+    _EXTERNAL_PROVENANCE_COMPUTED_BINDING_PLAN_FIELDS,
     _EXTERNAL_PROVENANCE_POLICIES,
+    _EXTERNAL_PROVENANCE_PROJECTED_BINDING_PLAN_FIELDS,
+    _EXTERNAL_PROVENANCE_PROJECTED_INTENT_FIELDS,
+    _EXTERNAL_PROVENANCE_PROJECTED_REQUIREMENT_FIELDS,
+    _EXTERNAL_PROVENANCE_SEMANTIC_BINDING_PLAN_FIELDS,
+    _EXTERNAL_PROVENANCE_SEMANTIC_INTENT_FIELDS,
+    _EXTERNAL_PROVENANCE_SEMANTIC_REQUIREMENT_FIELDS,
+    _EXTERNAL_PROVENANCE_SPECIAL_BINDING_PLAN_FIELDS,
     _NONMATCH_KEYS_STRIPPED_IN_BLOCKS,
     _NONMATCH_RUNNER_KEYS,
     _STRICT_RUNNER_KEYS,
@@ -40,6 +48,10 @@ from sieval.cli.leaderboard.session import (
     _diff_key_shape,
     _diff_lines,
     _format_comment_header,
+    _project_external_binding_plan,
+    _project_external_deployment_plan,
+    _project_provenance_intent,
+    _project_provenance_requirement,
     _reify_cli_overrides,
     _reject_unprojected_provenance_tokens,
     _replace_provenance_reference_text,
@@ -55,14 +67,20 @@ from sieval.cli.leaderboard.session import (
 )
 from sieval.cli.resolution import derive_model_type
 from sieval.cli.validation import _VALID_OPERATIONS
+from sieval.core.models.capabilities import CapabilityIntent, RequestDefaults
 from sieval.core.models.connection_factory import DEFAULT_REQUEST_TIMEOUT
+from sieval.core.models.deployment import RouteIntent
 from sieval.core.models.dialect_registry import RequestSeedSupport
 from sieval.core.models.model import Model
 from sieval.core.models.reconcile import (
+    BindingCapabilityPlan,
     CannotVerify,
     CheckStage,
     Configured,
+    ConnectionScope,
     DeferredCheck,
+    DeploymentCapabilityPlan,
+    ServingRequirement,
 )
 from sieval.core.models.requirements import (
     AggregatedTaskRequirements,
@@ -1634,6 +1652,105 @@ class TestSetupDatasetsErrors:
         assert "mock_ds" in runner.datasets
 
 
+@dataclasses.dataclass(frozen=True)
+class _ProjectionLabelCase:
+    """One record put through its real projection, with its declared labels."""
+
+    label: str
+    original: ServingRequirement | CapabilityIntent | BindingCapabilityPlan
+    projected: ServingRequirement | CapabilityIntent | BindingCapabilityPlan
+    projected_fields: frozenset[str]
+    semantic_fields: frozenset[str]
+    special_fields: frozenset[str] = frozenset()
+
+
+def _projection_label_cases() -> tuple[_ProjectionLabelCase, ...]:
+    """Drive each pure projection function once with a rewritable token."""
+
+    runtime_token = "legacy-private:" + "a" * 32
+    replacements = {runtime_token: "legacy-private"}
+    runtime_tokens = frozenset({runtime_token})
+
+    requirement = ServingRequirement(
+        capability="reasoning",
+        minimums={"depth": 1},
+        sources=(f"binding {runtime_token}",),
+        verifier="external_runtime_plan",
+        reason="guarded by the response contract",
+    )
+    intent = CapabilityIntent(
+        key="reasoning",
+        required=True,
+        minimums={"depth": 1},
+        sources=(f"binding {runtime_token}",),
+    )
+    binding_plan = BindingCapabilityPlan(
+        binding_id=f"binding:{runtime_token}",
+        root_deployment_key=f"root:{runtime_token}",
+        requested_model_id="m",
+        dialect_id="openai_chat",
+        declared_capabilities={},
+        intents={"reasoning": intent},
+        required_capabilities=frozenset({"reasoning"}),
+        available_capabilities=frozenset({"reasoning"}),
+        pending_capabilities=frozenset(),
+        unavailable_capabilities={},
+        capability_minimums={},
+        request_defaults=RequestDefaults(),
+        output_channels=frozenset({"text"}),
+        required_output_channels=frozenset(),
+        serving_requirements=(requirement,),
+        route_intent=RouteIntent(),
+        connection_scope=ConnectionScope(
+            credential_scope=f"{runtime_token}:explicit-credential",
+            retry_policy="openai-sdk:max-retries=4",
+            quota_scope=runtime_token,
+        ),
+    )
+    stable_scope = ConnectionScope(
+        credential_scope="legacy-private:explicit-credential",
+        retry_policy="openai-sdk:max-retries=4",
+        quota_scope="legacy-private",
+    )
+
+    return (
+        _ProjectionLabelCase(
+            label="ServingRequirement",
+            original=requirement,
+            projected=_project_provenance_requirement(
+                requirement, replacements, runtime_tokens
+            ),
+            projected_fields=_EXTERNAL_PROVENANCE_PROJECTED_REQUIREMENT_FIELDS,
+            semantic_fields=_EXTERNAL_PROVENANCE_SEMANTIC_REQUIREMENT_FIELDS,
+        ),
+        _ProjectionLabelCase(
+            label="CapabilityIntent",
+            original=intent,
+            projected=_project_provenance_intent(intent, replacements, runtime_tokens),
+            projected_fields=_EXTERNAL_PROVENANCE_PROJECTED_INTENT_FIELDS,
+            semantic_fields=_EXTERNAL_PROVENANCE_SEMANTIC_INTENT_FIELDS,
+        ),
+        _ProjectionLabelCase(
+            label="BindingCapabilityPlan",
+            original=binding_plan,
+            projected=_project_external_binding_plan(
+                binding_plan,
+                binding_id="binding:legacy-private",
+                root_deployment_key="root:legacy-private",
+                connection_scope=stable_scope,
+                replacements=replacements,
+                runtime_tokens=runtime_tokens,
+            ),
+            projected_fields=_EXTERNAL_PROVENANCE_PROJECTED_BINDING_PLAN_FIELDS,
+            semantic_fields=_EXTERNAL_PROVENANCE_SEMANTIC_BINDING_PLAN_FIELDS,
+            special_fields=(
+                _EXTERNAL_PROVENANCE_SPECIAL_BINDING_PLAN_FIELDS
+                | _EXTERNAL_PROVENANCE_COMPUTED_BINDING_PLAN_FIELDS
+            ),
+        ),
+    )
+
+
 # ===================================================================
 # RFC #25 pre-launch requirement composition and reconciliation
 # ===================================================================
@@ -1645,6 +1762,75 @@ class TestPrelaunchReconciliation:
             assert {item.name for item in dataclasses.fields(record_type)} == (
                 classified_fields
             )
+
+    def test_check_reason_leak_is_named_before_the_whole_plan_backstop(self) -> None:
+        """Pin the per-check rejection, not just the plan-wide one.
+
+        The whole-plan leak check at the end of the projection would also catch
+        a token in a check reason, so asserting only that *something* raises
+        passes with the per-check pass deleted.  The context string is what
+        distinguishes the layers, so that is what this asserts.
+        """
+
+        runtime_token = "legacy-private:" + "b" * 32
+        plan = DeploymentCapabilityPlan(
+            root_deployment_key=f"root:{runtime_token}",
+            engine_id="vllm",
+            desired_plan_fingerprint=None,
+            recipe_parameters={},
+            explicit_parameters={},
+            serving_requirements=(),
+            launch_patch={},
+            setup_checks=(
+                DeferredCheck(
+                    "reasoning",
+                    CheckStage.SETUP,
+                    "external_runtime_plan",
+                    f"guarded for {runtime_token}",
+                ),
+            ),
+            request_checks=(),
+            outcome_kinds={},
+            outcome_evidence={},
+        )
+
+        with pytest.raises(ValueError, match="external provenance check reason"):
+            _project_external_deployment_plan(
+                plan,
+                root_deployment_key="root:legacy-private",
+                replacements={runtime_token: "legacy-private"},
+                runtime_to_provenance={},
+                runtime_tokens=frozenset({runtime_token}),
+            )
+
+    def test_projection_changes_only_the_fields_labelled_projected(self) -> None:
+        """Make the PROJECTED/SEMANTIC labels load-bearing.
+
+        The completeness test above only proves every field was *named*; the
+        projection functions route fields by hand and never read these sets, so
+        a field could be labelled SEMANTIC while being rewritten (or the
+        reverse) with nothing failing.  This pins each label against what the
+        projection actually does.
+        """
+
+        for case in _projection_label_cases():
+            before = case.original.to_json_value()
+            after = case.projected.to_json_value()
+            changed = {
+                name for name in before if before[name] != after.get(name, object())
+            }
+            rewritable = case.projected_fields | case.special_fields
+            assert changed <= rewritable, (
+                f"{case.label}: {sorted(changed - rewritable)} changed but is "
+                "not labelled projected/special"
+            )
+            assert not (changed & case.semantic_fields), (
+                f"{case.label}: {sorted(changed & case.semantic_fields)} is "
+                "labelled semantic but was rewritten"
+            )
+            # A label is only meaningful if the projection actually moved
+            # something, otherwise the assertions above hold vacuously.
+            assert changed, f"{case.label}: projection changed nothing"
 
     def test_external_provenance_rejects_runtime_tokens_in_semantic_json(self) -> None:
         original = {

--- a/tests/unit/cli/leaderboard/test_session.py
+++ b/tests/unit/cli/leaderboard/test_session.py
@@ -22,6 +22,7 @@ import yaml
 from sieval.cli._filter_spec import VALUES_DIGEST_KEY, compute_values_digest
 from sieval.cli.leaderboard.session import (
     _DETERMINISTIC_SEED_CONTRACT_KEY,
+    _EXTERNAL_PROVENANCE_POLICIES,
     _NONMATCH_KEYS_STRIPPED_IN_BLOCKS,
     _NONMATCH_RUNNER_KEYS,
     _STRICT_RUNNER_KEYS,
@@ -40,13 +41,13 @@ from sieval.cli.leaderboard.session import (
     _diff_lines,
     _format_comment_header,
     _reify_cli_overrides,
-    _replace_provenance_tokens,
+    _reject_unprojected_provenance_tokens,
+    _replace_provenance_reference_text,
     _resolve_deterministic_request_seed,
     _sort_versions,
     _split_header,
     _strip_header,
     _strip_noncomparable_fields,
-    _validate_external_provenance_schema,
     arun_session,
     resolve_deterministic,
     run_session,
@@ -74,6 +75,7 @@ from sieval.core.models.requirements import (
 )
 from sieval.core.runners import TaskRunnerConfig
 from sieval.core.runners.multi_runner import MultiTaskRunner
+from sieval.core.types import JSONValue
 from tests.conftest import MockChatModel
 
 
@@ -1639,30 +1641,42 @@ class TestPrelaunchReconciliation:
     def test_external_provenance_policy_classifies_every_projected_field(
         self,
     ) -> None:
-        _validate_external_provenance_schema()
-
-    def test_external_provenance_projection_rejects_key_collisions(self) -> None:
-        with pytest.raises(
-            ValueError,
-            match="external provenance projection collapses evidence key 'stable'",
-        ):
-            _replace_provenance_tokens(
-                {"runtime": "first", "stable": "second"},
-                {"runtime": "stable"},
+        for record_type, classified_fields in _EXTERNAL_PROVENANCE_POLICIES:
+            assert {item.name for item in dataclasses.fields(record_type)} == (
+                classified_fields
             )
 
-    def test_external_provenance_projection_does_not_cascade_replacements(
+    def test_external_provenance_rejects_runtime_tokens_in_semantic_json(self) -> None:
+        original = {
+            "runtime-key": "user-data::runtime-long::literal",
+            "stable": "unchanged",
+        }
+        with pytest.raises(
+            ValueError,
+            match="test semantic field contains runtime identity token.*runtime-long",
+        ):
+            _reject_unprojected_provenance_tokens(
+                cast(JSONValue, original),
+                frozenset({"runtime-long"}),
+                context="test semantic field",
+            )
+        assert original == {
+            "runtime-key": "user-data::runtime-long::literal",
+            "stable": "unchanged",
+        }
+
+    def test_external_provenance_reference_projection_does_not_cascade(
         self,
     ) -> None:
         assert (
-            _replace_provenance_tokens(
-                "runtime-long",
+            _replace_provenance_reference_text(
+                "runtime-source:runtime-long",
                 {
                     "runtime-long": "runtime-short",
                     "runtime-short": "stable",
                 },
             )
-            == "runtime-short"
+            == "runtime-source:runtime-short"
         )
 
     class ChatTask:
@@ -4742,7 +4756,7 @@ tasks:
         candidate_close.assert_awaited_once()
 
     @pytest.mark.anyio
-    async def test_external_grader_pool_is_borrowed_not_closed(
+    async def test_external_grader_rebind_attaches_provenance_and_borrows_pool(
         self, tmp_path: Path, loguru_caplog
     ) -> None:
         from sieval.core.models import ChatModel
@@ -4817,6 +4831,7 @@ tasks:
             )
             assert external.pool not in session._owned_pools.values()
             assert TrackingChatModel.rebind_calls == 1
+            assert rebound.provenance_plan is not None
             session._stamp_deterministic_seed_contract()
             contract = session._reified_config[_DETERMINISTIC_SEED_CONTRACT_KEY]
             external_contract = contract["external_roles"]["judged.grader"]
@@ -4993,8 +5008,8 @@ tasks:
             assert first_rebound_plan is not first.runtime_plan
             assert second_rebound_plan is not second.runtime_plan
             assert first_rebound_plan.fingerprint != second_rebound_plan.fingerprint
-            first_source_provenance = first._provenance_plan
-            second_source_provenance = second._provenance_plan
+            first_source_provenance = first.provenance_plan
+            second_source_provenance = second.provenance_plan
             assert first_source_provenance is not None
             assert second_source_provenance is not None
             postlaunch = session.postlaunch_reconcile_result
@@ -5010,9 +5025,9 @@ tasks:
                     if "injected_reconciler" in evidence
                 ]
                 assert injected
-                assert source._provenance_plan is not None
+                assert source.provenance_plan is not None
                 assert any(
-                    source._provenance_plan.root_deployment_key in repr(evidence)
+                    source.provenance_plan.root_deployment_key in repr(evidence)
                     for evidence in injected
                 )
                 assert all(
@@ -5033,8 +5048,8 @@ tasks:
                 )
                 is None
             )
-            assert first_rebound._provenance_plan is not None
-            assert second_rebound._provenance_plan is not None
+            assert first_rebound.provenance_plan is not None
+            assert second_rebound.provenance_plan is not None
             assert first_evidence == second_evidence
             assert set(reconciler_roots) == {
                 first_source_provenance.root_deployment_key,
@@ -5499,13 +5514,41 @@ tasks:
             )
             with pytest.raises(
                 ValueError,
-                match="external provenance plan contains unresolved runtime identity",
+                match=(
+                    "external provenance plan contains runtime identity token.*"
+                    "semantic data"
+                ),
             ):
                 session._external_provenance_plan(
                     guarded_external,
                     leaked_result,
                     guarded_plan.binding_id,
                 )
+
+            semantic_recipe = {"note": f"user-data::{runtime_plan.binding_id}::literal"}
+            semantic_deployment_plan = dataclasses.replace(
+                deployment_plan,
+                recipe_parameters=semantic_recipe,
+            )
+            semantic_result = dataclasses.replace(
+                result,
+                deployment_plans={
+                    guarded_plan.root_deployment_key: semantic_deployment_plan
+                },
+            )
+            with pytest.raises(
+                ValueError,
+                match=(
+                    "external provenance plan contains runtime identity token.*"
+                    "semantic data"
+                ),
+            ):
+                session._external_provenance_plan(
+                    guarded_external,
+                    semantic_result,
+                    guarded_plan.binding_id,
+                )
+            assert semantic_deployment_plan.recipe_parameters == semantic_recipe
 
             assert (
                 changed_projected.verification_fingerprint

--- a/tests/unit/cli/leaderboard/test_session.py
+++ b/tests/unit/cli/leaderboard/test_session.py
@@ -4710,6 +4710,13 @@ tasks:
     ) -> None:
         from sieval.core.models import ChatModel
 
+        class TrackingChatModel(ChatModel):
+            rebind_calls = 0
+
+            def with_dialect(self, dialect_id, runtime_plan):
+                type(self).rebind_calls += 1
+                return super().with_dialect(dialect_id, runtime_plan)
+
         config_path = self._config(
             tmp_path,
             """
@@ -4728,7 +4735,7 @@ tasks:
     args: {}
 """,
         )
-        external = ChatModel(
+        external = TrackingChatModel(
             model="org/external-grader",
             api_base="https://external.example/v1",
             api_key="external-key",
@@ -4772,6 +4779,7 @@ tasks:
                 is postlaunch.runtime_plans[external.runtime_plan.binding_id]
             )
             assert external.pool not in session._owned_pools.values()
+            assert TrackingChatModel.rebind_calls == 1
             session._stamp_deterministic_seed_contract()
             contract = session._reified_config[_DETERMINISTIC_SEED_CONTRACT_KEY]
             external_contract = contract["external_roles"]["judged.grader"]
@@ -4788,6 +4796,369 @@ tasks:
         candidate_close.assert_awaited_once()
         external_close.assert_not_awaited()
         await external._client.close()
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize("model_type_name", ["chat", "gen"])
+    async def test_equivalent_external_legacy_models_keep_stable_provenance(
+        self, tmp_path: Path, model_type_name: str
+    ) -> None:
+        from sieval.core.models import ChatModel, GenModel, Response
+
+        runtime_by_root: dict[str, Any] = {}
+
+        class RootEchoReconciler:
+            def reconcile(self, requirements, deployment):
+                if (
+                    not requirements
+                    or deployment.root_deployment_key not in runtime_by_root
+                ):
+                    return {}
+                runtime_plan = runtime_by_root[deployment.root_deployment_key]
+                return {
+                    requirement.capability: Configured(
+                        evidence={
+                            "runtime_root": deployment.root_deployment_key,
+                            "runtime_binding": runtime_plan.binding_id,
+                            "fingerprints": {
+                                "plan": runtime_plan.fingerprint,
+                                "verification": runtime_plan.verification_fingerprint,
+                                "binding": runtime_plan.binding_plan_fingerprint,
+                                "deployment": (
+                                    runtime_plan.deployment_plan_fingerprint
+                                ),
+                            },
+                            "connection_scopes": [
+                                runtime_plan.connection_identity.credential_scope,
+                                runtime_plan.connection_identity.quota_scope,
+                            ],
+                            "nested": [
+                                {
+                                    "embedded": (
+                                        f"root={deployment.root_deployment_key};"
+                                        f"binding={runtime_plan.binding_id}"
+                                    )
+                                }
+                            ],
+                        }
+                    )
+                    for requirement in requirements
+                }
+
+        model_type = ChatModel if model_type_name == "chat" else GenModel
+
+        config_path = self._config(
+            tmp_path,
+            """
+models:
+  candidate:
+    name: org/candidate
+tasks:
+  judged_a:
+    class: fake.Task
+    dataset:
+      class: fake.Dataset
+    model: candidate
+    args: {}
+  judged_b:
+    class: fake.Task
+    dataset:
+      class: fake.Dataset
+    model: candidate
+    args: {}
+""",
+        )
+        first = model_type(
+            model="org/external-grader",
+            api_base="https://external.example/v1",
+            api_key="external-key",
+            concurrency_limit=2,
+        )
+        second = model_type(
+            model="org/external-grader",
+            api_base="https://external.example/v1",
+            api_key="external-key",
+            concurrency_limit=2,
+        )
+        assert first.runtime_plan is not None
+        assert second.runtime_plan is not None
+        runtime_by_root.update(
+            {
+                first.runtime_plan.root_deployment_key: first.runtime_plan,
+                second.runtime_plan.root_deployment_key: second.runtime_plan,
+            }
+        )
+        session = EvalSession(
+            config_path,
+            serving_reconciler=RootEchoReconciler(),
+        )
+        tasks = cast(dict, session.config["tasks"])
+        cast(dict, cast(dict, tasks["judged_a"])["args"])["grader"] = first
+        cast(dict, cast(dict, tasks["judged_b"])["args"])["grader"] = second
+        task_type = self.JudgeTask if model_type is ChatModel else self.ScoringJudgeTask
+        candidate_close = AsyncMock()
+
+        try:
+            with (
+                patch(
+                    "sieval.cli.leaderboard.session.resolve_task_class",
+                    return_value=task_type,
+                ),
+                patch(
+                    "sieval.core.models.connection_factory.AsyncOpenAI",
+                    return_value=types.SimpleNamespace(close=candidate_close),
+                ),
+            ):
+                session._setup_prelaunch_reconciliation()
+                session._setup_postlaunch_reconciliation()
+                session._setup_models()
+
+            first_rebound = session._bound_task_role_models["judged_a"]["grader"]
+            second_rebound = session._bound_task_role_models["judged_b"]["grader"]
+            first_evidence = first_rebound._provenance(
+                Response(texts=("first",))
+            ).capabilities
+            second_evidence = second_rebound._provenance(
+                Response(texts=("second",))
+            ).capabilities
+            first_rebound_plan = first_rebound.runtime_plan
+            second_rebound_plan = second_rebound.runtime_plan
+
+            assert first.runtime_plan is not None
+            assert second.runtime_plan is not None
+            assert first_rebound_plan is not None
+            assert second_rebound_plan is not None
+            assert first_rebound_plan is not first.runtime_plan
+            assert second_rebound_plan is not second.runtime_plan
+            assert first_rebound_plan.fingerprint != second_rebound_plan.fingerprint
+            postlaunch = session.postlaunch_reconcile_result
+            assert postlaunch is not None
+            for source in (first, second):
+                assert source.runtime_plan is not None
+                raw_deployment = postlaunch.deployment_plans[
+                    source.runtime_plan.root_deployment_key
+                ]
+                injected = [
+                    evidence["injected_reconciler"]
+                    for evidence in raw_deployment.outcome_evidence.values()
+                    if "injected_reconciler" in evidence
+                ]
+                assert injected
+                assert any(
+                    source.runtime_plan.root_deployment_key in repr(evidence)
+                    for evidence in injected
+                )
+            assert first._provenance_projector is not None
+            assert second._provenance_projector is not None
+            assert (
+                first._provenance_projector(
+                    postlaunch.runtime_plans[first.runtime_plan.binding_id]
+                )
+                is None
+            )
+            assert (
+                second._provenance_projector(
+                    postlaunch.runtime_plans[second.runtime_plan.binding_id]
+                )
+                is None
+            )
+            assert first_rebound._provenance_plan is not None
+            assert second_rebound._provenance_plan is not None
+            assert first_evidence == second_evidence
+            assert first_evidence is not None
+            assert first_evidence.plan_fingerprint != first_rebound_plan.fingerprint
+            assert second_evidence is not None
+            assert second_evidence.plan_fingerprint != second_rebound_plan.fingerprint
+            assert first_rebound.pool is first.pool
+            assert second_rebound.pool is second.pool
+            assert first_rebound.pool is not second_rebound.pool
+
+            await session._close_owned_model_resources()
+        finally:
+            await first.aclose()
+            await second.aclose()
+
+        candidate_close.assert_awaited_once()
+
+    @pytest.mark.anyio
+    async def test_mixed_external_models_keep_provenance_policy_and_order(
+        self, tmp_path: Path
+    ) -> None:
+        from sieval.core.models import ChatModel, Model, Response
+
+        legacy_fingerprints: dict[str, list[str]] = {"shared": [], "sibling": []}
+        for variant, suffix in (("shared", ""), ("sibling", ":canonical")):
+            for order in (("legacy", "canonical"), ("canonical", "legacy")):
+                task_blocks = "\n".join(
+                    f"""  {name}:
+    class: fake.JudgeTask
+    dataset:
+      class: fake.Dataset
+    model: candidate
+    args: {{}}"""
+                    for name in order
+                )
+                config_path = self._config(
+                    tmp_path,
+                    f"""
+models:
+  candidate:
+    name: org/candidate
+tasks:
+{task_blocks}
+""",
+                )
+                legacy = ChatModel(
+                    model="org/external-grader",
+                    api_base="https://external.example/v1",
+                    api_key="external-key",
+                )
+                assert legacy.runtime_plan is not None
+                canonical_plan = dataclasses.replace(
+                    legacy.runtime_plan,
+                    binding_id=f"{legacy.runtime_plan.binding_id}{suffix}",
+                )
+                canonical = Model.bind(
+                    legacy.deployment,
+                    legacy.pool,
+                    canonical_plan,
+                )
+                session = EvalSession(config_path)
+                tasks = cast(dict, session.config["tasks"])
+                sources = {"legacy": legacy, "canonical": canonical}
+                for name in order:
+                    cast(dict, cast(dict, tasks[name])["args"])["grader"] = sources[
+                        name
+                    ]
+                candidate_close = AsyncMock()
+
+                try:
+                    with (
+                        patch(
+                            "sieval.cli.leaderboard.session.resolve_task_class",
+                            return_value=self.JudgeTask,
+                        ),
+                        patch(
+                            "sieval.core.models.connection_factory.AsyncOpenAI",
+                            return_value=types.SimpleNamespace(close=candidate_close),
+                        ),
+                    ):
+                        session._setup_prelaunch_reconciliation()
+                        session._setup_postlaunch_reconciliation()
+                        session._setup_models()
+
+                    legacy_rebound = session._bound_task_role_models["legacy"]["grader"]
+                    canonical_rebound = session._bound_task_role_models["canonical"][
+                        "grader"
+                    ]
+                    legacy_plan = legacy_rebound.runtime_plan
+                    canonical_runtime = canonical_rebound.runtime_plan
+                    assert legacy_plan is not None
+                    assert canonical_runtime is not None
+                    canonical_evidence = canonical_rebound._provenance(
+                        Response(texts=("canonical",))
+                    ).capabilities
+                    legacy_evidence = legacy_rebound._provenance(
+                        Response(texts=("legacy",))
+                    ).capabilities
+                    assert canonical_evidence is not None
+                    assert legacy_evidence is not None
+                    assert (
+                        canonical_evidence.plan_fingerprint
+                        == canonical_runtime.fingerprint
+                    )
+                    assert legacy_evidence.plan_fingerprint != legacy_plan.fingerprint
+                    legacy_fingerprints[variant].append(
+                        legacy_evidence.plan_fingerprint
+                    )
+
+                    await session._close_owned_model_resources()
+                finally:
+                    await legacy.aclose()
+
+                candidate_close.assert_awaited_once()
+
+        assert len(set(legacy_fingerprints["shared"])) == 1
+        assert len(set(legacy_fingerprints["sibling"])) == 1
+        assert legacy_fingerprints["shared"][0] != legacy_fingerprints["sibling"][0]
+
+    @pytest.mark.anyio
+    async def test_same_root_rejects_a_different_legacy_private_pool(
+        self, tmp_path: Path
+    ) -> None:
+        from sieval.core.models import ChatModel, Model
+
+        config_path = self._config(
+            tmp_path,
+            """
+models:
+  candidate:
+    name: org/candidate
+tasks:
+  legacy:
+    class: fake.JudgeTask
+    dataset:
+      class: fake.Dataset
+    model: candidate
+    args: {}
+  canonical:
+    class: fake.JudgeTask
+    dataset:
+      class: fake.Dataset
+    model: candidate
+    args: {}
+""",
+        )
+        legacy = ChatModel(
+            model="org/external-grader",
+            api_base="https://external.example/v1",
+            api_key="external-key",
+        )
+        other_pool = ChatModel(
+            model="org/external-grader",
+            api_base="https://external.example/v1",
+            api_key="external-key",
+        )
+        assert legacy.runtime_plan is not None
+        assert other_pool.runtime_plan is not None
+        forced_plan = dataclasses.replace(
+            other_pool.runtime_plan,
+            root_deployment_key=legacy.runtime_plan.root_deployment_key,
+        )
+        canonical = Model.bind(
+            other_pool.deployment,
+            other_pool.pool,
+            forced_plan,
+        )
+        session = EvalSession(config_path)
+        tasks = cast(dict, session.config["tasks"])
+        cast(dict, cast(dict, tasks["legacy"])["args"])["grader"] = legacy
+        cast(dict, cast(dict, tasks["canonical"])["args"])["grader"] = canonical
+        candidate_close = AsyncMock()
+
+        try:
+            with (
+                patch(
+                    "sieval.cli.leaderboard.session.resolve_task_class",
+                    return_value=self.JudgeTask,
+                ),
+                patch(
+                    "sieval.core.models.connection_factory.AsyncOpenAI",
+                    return_value=types.SimpleNamespace(close=candidate_close),
+                ),
+            ):
+                session._setup_prelaunch_reconciliation()
+                session._setup_postlaunch_reconciliation()
+                with pytest.raises(
+                    ValueError,
+                    match="mixes different UUID-scoped legacy connection identities",
+                ):
+                    session._setup_models()
+                await session._close_owned_model_resources()
+        finally:
+            await legacy.aclose()
+            await other_pool.aclose()
+
+        candidate_close.assert_awaited_once()
 
     @pytest.mark.anyio
     @pytest.mark.parametrize("order", [("a", "b"), ("b", "a")])
@@ -4969,7 +5340,7 @@ tasks:
     async def test_custom_reconciler_cannot_erase_external_baseline(
         self, tmp_path: Path
     ) -> None:
-        from sieval.core.models import GenModel
+        from sieval.core.models import GenModel, Response
 
         class BlindReconciler:
             def reconcile(self, requirements, deployment):
@@ -5015,23 +5386,80 @@ tasks:
         session = EvalSession(config_path, serving_reconciler=BlindReconciler())
         task = cast(dict, cast(dict, session.config["tasks"])["judged"])
         cast(dict, task["args"])["grader"] = guarded_external
+        candidate_close = AsyncMock()
 
         try:
-            with patch(
-                "sieval.cli.leaderboard.session.resolve_task_class",
-                return_value=self.ScoringJudgeTask,
+            with (
+                patch(
+                    "sieval.cli.leaderboard.session.resolve_task_class",
+                    return_value=self.ScoringJudgeTask,
+                ),
+                patch(
+                    "sieval.core.models.connection_factory.AsyncOpenAI",
+                    return_value=types.SimpleNamespace(close=candidate_close),
+                ),
             ):
-                result = session.prepare_prelaunch()
+                session._setup_prelaunch_reconciliation()
+                session._setup_postlaunch_reconciliation()
+                session._setup_models()
 
-            rebound = result.runtime_plans[guarded_plan.binding_id]
-            assert guarded_plan.request_checks[0] in rebound.request_checks
+            result = session.postlaunch_reconcile_result
+            assert result is not None
+            runtime_plan = result.runtime_plans[guarded_plan.binding_id]
+            assert guarded_plan.request_checks[0] in runtime_plan.request_checks
             evidence = result.deployment_plans[
                 guarded_plan.root_deployment_key
             ].outcome_evidence["top_logprobs"]
             assert evidence["plan_fingerprints"] == [guarded_plan.fingerprint]
             assert evidence["injected_reconciler"] == {"probe": "ok"}
+
+            projected = session._external_provenance_plan(
+                guarded_external,
+                result,
+                guarded_plan.binding_id,
+            )
+            deployment_plan = result.deployment_plans[guarded_plan.root_deployment_key]
+            changed_evidence = {
+                capability: dict(value)
+                for capability, value in deployment_plan.outcome_evidence.items()
+            }
+            changed_evidence["top_logprobs"]["injected_reconciler"] = {
+                "probe": "changed"
+            }
+            changed_deployment_plan = dataclasses.replace(
+                deployment_plan,
+                outcome_evidence=changed_evidence,
+            )
+            changed_result = dataclasses.replace(
+                result,
+                deployment_plans={
+                    guarded_plan.root_deployment_key: changed_deployment_plan
+                },
+            )
+            changed_projected = session._external_provenance_plan(
+                guarded_external,
+                changed_result,
+                guarded_plan.binding_id,
+            )
+
+            assert (
+                changed_projected.verification_fingerprint
+                != projected.verification_fingerprint
+            )
+            assert changed_projected.fingerprint != projected.fingerprint
+
+            rebound = session._bound_task_role_models["judged"]["grader"]
+            persisted = rebound._provenance(Response(texts=("graded",))).capabilities
+            assert persisted is not None
+            assert persisted.plan_fingerprint == projected.fingerprint
+            assert (
+                persisted.verification_fingerprint == projected.verification_fingerprint
+            )
+            await session._close_owned_model_resources()
         finally:
             await external.aclose()
+
+        candidate_close.assert_awaited_once()
 
     @pytest.mark.anyio
     async def test_external_bindings_can_share_root_with_distinct_plans(

--- a/tests/unit/cli/leaderboard/test_session.py
+++ b/tests/unit/cli/leaderboard/test_session.py
@@ -6,6 +6,7 @@ AI-Generated Code - Claude Opus 4.6 (Anthropic)
 """
 
 import dataclasses
+import hashlib
 import json
 import re
 import types
@@ -39,11 +40,13 @@ from sieval.cli.leaderboard.session import (
     _diff_lines,
     _format_comment_header,
     _reify_cli_overrides,
+    _replace_provenance_tokens,
     _resolve_deterministic_request_seed,
     _sort_versions,
     _split_header,
     _strip_header,
     _strip_noncomparable_fields,
+    _validate_external_provenance_schema,
     arun_session,
     resolve_deterministic,
     run_session,
@@ -54,7 +57,12 @@ from sieval.cli.validation import _VALID_OPERATIONS
 from sieval.core.models.connection_factory import DEFAULT_REQUEST_TIMEOUT
 from sieval.core.models.dialect_registry import RequestSeedSupport
 from sieval.core.models.model import Model
-from sieval.core.models.reconcile import CheckStage, Configured, DeferredCheck
+from sieval.core.models.reconcile import (
+    CannotVerify,
+    CheckStage,
+    Configured,
+    DeferredCheck,
+)
 from sieval.core.models.requirements import (
     AggregatedTaskRequirements,
     InlineModelBinding,
@@ -1628,6 +1636,35 @@ class TestSetupDatasetsErrors:
 # RFC #25 pre-launch requirement composition and reconciliation
 # ===================================================================
 class TestPrelaunchReconciliation:
+    def test_external_provenance_policy_classifies_every_projected_field(
+        self,
+    ) -> None:
+        _validate_external_provenance_schema()
+
+    def test_external_provenance_projection_rejects_key_collisions(self) -> None:
+        with pytest.raises(
+            ValueError,
+            match="external provenance projection collapses evidence key 'stable'",
+        ):
+            _replace_provenance_tokens(
+                {"runtime": "first", "stable": "second"},
+                {"runtime": "stable"},
+            )
+
+    def test_external_provenance_projection_does_not_cascade_replacements(
+        self,
+    ) -> None:
+        assert (
+            _replace_provenance_tokens(
+                "runtime-long",
+                {
+                    "runtime-long": "runtime-short",
+                    "runtime-short": "stable",
+                },
+            )
+            == "runtime-short"
+        )
+
     class ChatTask:
         model_type = "chat"
 
@@ -4804,45 +4841,44 @@ tasks:
     ) -> None:
         from sieval.core.models import ChatModel, GenModel, Response
 
-        runtime_by_root: dict[str, Any] = {}
+        reconciler_roots: list[str] = []
+        reconciler_requirement_sources: list[tuple[str, ...]] = []
 
-        class RootEchoReconciler:
+        class StableInputReconciler:
             def reconcile(self, requirements, deployment):
-                if (
-                    not requirements
-                    or deployment.root_deployment_key not in runtime_by_root
-                ):
+                root = deployment.root_deployment_key
+                if not requirements or not root.startswith("legacy:"):
                     return {}
-                runtime_plan = runtime_by_root[deployment.root_deployment_key]
-                return {
-                    requirement.capability: Configured(
-                        evidence={
-                            "runtime_root": deployment.root_deployment_key,
-                            "runtime_binding": runtime_plan.binding_id,
-                            "fingerprints": {
-                                "plan": runtime_plan.fingerprint,
-                                "verification": runtime_plan.verification_fingerprint,
-                                "binding": runtime_plan.binding_plan_fingerprint,
-                                "deployment": (
-                                    runtime_plan.deployment_plan_fingerprint
-                                ),
-                            },
-                            "connection_scopes": [
-                                runtime_plan.connection_identity.credential_scope,
-                                runtime_plan.connection_identity.quota_scope,
-                            ],
-                            "nested": [
-                                {
-                                    "embedded": (
-                                        f"root={deployment.root_deployment_key};"
-                                        f"binding={runtime_plan.binding_id}"
-                                    )
-                                }
-                            ],
-                        }
-                    )
+                reconciler_roots.append(root)
+                sources = tuple(
+                    source
                     for requirement in requirements
-                }
+                    for source in requirement.sources
+                )
+                reconciler_requirement_sources.append(sources)
+                suffix = root.rsplit(":", 1)[-1]
+                payload = json.dumps(
+                    [requirement.to_json_value() for requirement in requirements],
+                    sort_keys=True,
+                )
+                digest = hashlib.sha256(f"{root}:{payload}".encode()).hexdigest()
+                outcomes = {}
+                for requirement in requirements:
+                    if requirement.capability == "top_logprobs":
+                        outcomes[requirement.capability] = CannotVerify(
+                            CheckStage.REQUEST,
+                            "validate_response_channel",
+                            f"stable-root-suffix={suffix};digest={digest}",
+                        )
+                    else:
+                        outcomes[requirement.capability] = Configured(
+                            evidence={
+                                "semantic_root": root,
+                                "derived_suffix": suffix,
+                                "derived_digest": digest,
+                            }
+                        )
+                return outcomes
 
         model_type = ChatModel if model_type_name == "chat" else GenModel
 
@@ -4881,27 +4917,54 @@ tasks:
         )
         assert first.runtime_plan is not None
         assert second.runtime_plan is not None
-        runtime_by_root.update(
-            {
-                first.runtime_plan.root_deployment_key: first.runtime_plan,
-                second.runtime_plan.root_deployment_key: second.runtime_plan,
-            }
+
+        external_input = (
+            InputKind.CHAT if model_type is ChatModel else InputKind.COMPLETION
         )
+
+        class RuntimeIdentitySourceTask:
+            model_type = "chat"
+
+            def __init__(self, *, grader=None, models_by_role=None):
+                del grader, models_by_role
+
+            @classmethod
+            def model_requirements_for(cls, context):
+                grader_binding = context.model_bindings["grader"]
+                return (
+                    TaskModelRequirement(
+                        role="candidate",
+                        binding=context.model_bindings["candidate"],
+                        requires=TaskRequirements(input=InputKind.CHAT),
+                        source_task="candidate",
+                    ),
+                    TaskModelRequirement(
+                        role="grader",
+                        binding=grader_binding,
+                        requires=TaskRequirements(
+                            input=external_input,
+                            sampled_logprobs=True,
+                        ),
+                        source_task=(
+                            f"runtime-source:{grader_binding.root_deployment_key}"
+                        ),
+                    ),
+                )
+
         session = EvalSession(
             config_path,
-            serving_reconciler=RootEchoReconciler(),
+            serving_reconciler=StableInputReconciler(),
         )
         tasks = cast(dict, session.config["tasks"])
         cast(dict, cast(dict, tasks["judged_a"])["args"])["grader"] = first
         cast(dict, cast(dict, tasks["judged_b"])["args"])["grader"] = second
-        task_type = self.JudgeTask if model_type is ChatModel else self.ScoringJudgeTask
         candidate_close = AsyncMock()
 
         try:
             with (
                 patch(
                     "sieval.cli.leaderboard.session.resolve_task_class",
-                    return_value=task_type,
+                    return_value=RuntimeIdentitySourceTask,
                 ),
                 patch(
                     "sieval.core.models.connection_factory.AsyncOpenAI",
@@ -4930,6 +4993,10 @@ tasks:
             assert first_rebound_plan is not first.runtime_plan
             assert second_rebound_plan is not second.runtime_plan
             assert first_rebound_plan.fingerprint != second_rebound_plan.fingerprint
+            first_source_provenance = first._provenance_plan
+            second_source_provenance = second._provenance_plan
+            assert first_source_provenance is not None
+            assert second_source_provenance is not None
             postlaunch = session.postlaunch_reconcile_result
             assert postlaunch is not None
             for source in (first, second):
@@ -4943,8 +5010,13 @@ tasks:
                     if "injected_reconciler" in evidence
                 ]
                 assert injected
+                assert source._provenance_plan is not None
                 assert any(
-                    source.runtime_plan.root_deployment_key in repr(evidence)
+                    source._provenance_plan.root_deployment_key in repr(evidence)
+                    for evidence in injected
+                )
+                assert all(
+                    source.runtime_plan.root_deployment_key not in repr(evidence)
                     for evidence in injected
                 )
             assert first._provenance_projector is not None
@@ -4964,6 +5036,19 @@ tasks:
             assert first_rebound._provenance_plan is not None
             assert second_rebound._provenance_plan is not None
             assert first_evidence == second_evidence
+            assert set(reconciler_roots) == {
+                first_source_provenance.root_deployment_key,
+                second_source_provenance.root_deployment_key,
+            }
+            assert {
+                source
+                for sources in reconciler_requirement_sources
+                for source in sources
+                if source.startswith("runtime-source:")
+            } == {
+                f"runtime-source:{first_source_provenance.root_deployment_key}",
+                f"runtime-source:{second_source_provenance.root_deployment_key}",
+            }
             assert first_evidence is not None
             assert first_evidence.plan_fingerprint != first_rebound_plan.fingerprint
             assert second_evidence is not None
@@ -4980,7 +5065,7 @@ tasks:
         candidate_close.assert_awaited_once()
 
     @pytest.mark.anyio
-    async def test_mixed_external_models_keep_provenance_policy_and_order(
+    async def test_model_bind_preserves_external_provenance_policy_and_order(
         self, tmp_path: Path
     ) -> None:
         from sieval.core.models import ChatModel, Model, Response
@@ -5064,7 +5149,7 @@ tasks:
                     assert legacy_evidence is not None
                     assert (
                         canonical_evidence.plan_fingerprint
-                        == canonical_runtime.fingerprint
+                        != canonical_runtime.fingerprint
                     )
                     assert legacy_evidence.plan_fingerprint != legacy_plan.fingerprint
                     legacy_fingerprints[variant].append(
@@ -5082,32 +5167,9 @@ tasks:
         assert legacy_fingerprints["shared"][0] != legacy_fingerprints["sibling"][0]
 
     @pytest.mark.anyio
-    async def test_same_root_rejects_a_different_legacy_private_pool(
-        self, tmp_path: Path
-    ) -> None:
+    async def test_model_bind_rejects_a_mismatched_legacy_private_root(self) -> None:
         from sieval.core.models import ChatModel, Model
 
-        config_path = self._config(
-            tmp_path,
-            """
-models:
-  candidate:
-    name: org/candidate
-tasks:
-  legacy:
-    class: fake.JudgeTask
-    dataset:
-      class: fake.Dataset
-    model: candidate
-    args: {}
-  canonical:
-    class: fake.JudgeTask
-    dataset:
-      class: fake.Dataset
-    model: candidate
-    args: {}
-""",
-        )
         legacy = ChatModel(
             model="org/external-grader",
             api_base="https://external.example/v1",
@@ -5124,41 +5186,17 @@ tasks:
             other_pool.runtime_plan,
             root_deployment_key=legacy.runtime_plan.root_deployment_key,
         )
-        canonical = Model.bind(
-            other_pool.deployment,
-            other_pool.pool,
-            forced_plan,
-        )
-        session = EvalSession(config_path)
-        tasks = cast(dict, session.config["tasks"])
-        cast(dict, cast(dict, tasks["legacy"])["args"])["grader"] = legacy
-        cast(dict, cast(dict, tasks["canonical"])["args"])["grader"] = canonical
-        candidate_close = AsyncMock()
 
         try:
-            with (
-                patch(
-                    "sieval.cli.leaderboard.session.resolve_task_class",
-                    return_value=self.JudgeTask,
-                ),
-                patch(
-                    "sieval.core.models.connection_factory.AsyncOpenAI",
-                    return_value=types.SimpleNamespace(close=candidate_close),
-                ),
-            ):
-                session._setup_prelaunch_reconciliation()
-                session._setup_postlaunch_reconciliation()
-                with pytest.raises(
-                    ValueError,
-                    match="mixes different UUID-scoped legacy connection identities",
-                ):
-                    session._setup_models()
-                await session._close_owned_model_resources()
+            with pytest.raises(ValueError, match="inconsistent deployment root"):
+                Model.bind(
+                    other_pool.deployment,
+                    other_pool.pool,
+                    forced_plan,
+                )
         finally:
             await legacy.aclose()
             await other_pool.aclose()
-
-        candidate_close.assert_awaited_once()
 
     @pytest.mark.anyio
     @pytest.mark.parametrize("order", [("a", "b"), ("b", "a")])
@@ -5441,6 +5479,33 @@ tasks:
                 changed_result,
                 guarded_plan.binding_id,
             )
+
+            leaked_evidence = {
+                capability: dict(value)
+                for capability, value in deployment_plan.outcome_evidence.items()
+            }
+            leaked_evidence["top_logprobs"]["injected_reconciler"] = {
+                "probe": runtime_plan.deployment_plan_fingerprint
+            }
+            leaked_deployment_plan = dataclasses.replace(
+                deployment_plan,
+                outcome_evidence=leaked_evidence,
+            )
+            leaked_result = dataclasses.replace(
+                result,
+                deployment_plans={
+                    guarded_plan.root_deployment_key: leaked_deployment_plan
+                },
+            )
+            with pytest.raises(
+                ValueError,
+                match="external provenance plan contains unresolved runtime identity",
+            ):
+                session._external_provenance_plan(
+                    guarded_external,
+                    leaked_result,
+                    guarded_plan.binding_id,
+                )
 
             assert (
                 changed_projected.verification_fingerprint

--- a/tests/unit/core/models/test__legacy_binding.py
+++ b/tests/unit/core/models/test__legacy_binding.py
@@ -6,6 +6,7 @@ bypasses.
 AI-Generated Code - Claude Opus 5 (1M context) (Anthropic)
 """
 
+from dataclasses import replace
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
@@ -44,4 +45,235 @@ class TestLegacyBindingClient:
             api_key="sk-runtime-only",
             max_retries=4,
             timeout=DEFAULT_REQUEST_TIMEOUT,
+        )
+
+    def test_persisted_fingerprints_exclude_the_private_runtime_scope(self) -> None:
+        client = SimpleNamespace(
+            base_url="https://legacy.example/v1/",
+            close=AsyncMock(),
+        )
+        with (
+            patch(
+                "sieval.core.models._legacy_binding.AsyncOpenAI",
+                return_value=client,
+            ),
+            patch(
+                "sieval.core.models._legacy_binding.uuid4",
+                side_effect=[
+                    SimpleNamespace(hex="first-runtime-scope"),
+                    SimpleNamespace(hex="second-runtime-scope"),
+                ],
+            ),
+        ):
+            first = build_legacy_openai_binding(
+                dialect_id="openai_chat",
+                model="m",
+                api_base="https://legacy.example/v1",
+                api_key="sk-runtime-only",
+                max_retries=4,
+                concurrency_limit=None,
+                parent_limiter=None,
+            )
+            second = build_legacy_openai_binding(
+                dialect_id="openai_chat",
+                model="m",
+                api_base="https://legacy.example/v1",
+                api_key="sk-runtime-only",
+                max_retries=4,
+                concurrency_limit=None,
+                parent_limiter=None,
+            )
+
+        assert first.pool.identity != second.pool.identity
+        assert first.runtime_plan.fingerprint != second.runtime_plan.fingerprint
+        first_provenance = first.provenance_projector(first.runtime_plan)
+        second_provenance = second.provenance_projector(second.runtime_plan)
+        assert first_provenance is not None
+        assert second_provenance is not None
+        assert first_provenance.fingerprint == second_provenance.fingerprint
+        assert (
+            first_provenance.verification_fingerprint
+            == second_provenance.verification_fingerprint
+        )
+
+    def test_projection_preserves_distinct_sibling_binding_identity(self) -> None:
+        client = SimpleNamespace(
+            base_url="https://legacy.example/v1/",
+            close=AsyncMock(),
+        )
+        with patch(
+            "sieval.core.models._legacy_binding.AsyncOpenAI",
+            return_value=client,
+        ):
+            binding = build_legacy_openai_binding(
+                dialect_id="openai_chat",
+                model="m",
+                api_base="https://legacy.example/v1",
+                api_key="sk-runtime-only",
+                max_retries=4,
+                concurrency_limit=None,
+                parent_limiter=None,
+            )
+
+        base = binding.provenance_projector(binding.runtime_plan)
+        assert base is not None
+        sibling_runtime = replace(
+            binding.runtime_plan,
+            binding_id=f"{binding.runtime_plan.binding_id}:sibling",
+        )
+        sibling = binding.provenance_projector(sibling_runtime)
+        assert sibling is not None
+
+        assert sibling.binding_id.startswith(f"{base.binding_id}:sibling:")
+        assert sibling.root_deployment_key == base.root_deployment_key
+        assert sibling.fingerprint != base.fingerprint
+        assert sibling.verification_fingerprint != base.verification_fingerprint
+
+    def test_projection_rejects_foreign_binding_that_matches_stable_base(self) -> None:
+        client = SimpleNamespace(
+            base_url="https://legacy.example/v1/",
+            close=AsyncMock(),
+        )
+        with patch(
+            "sieval.core.models._legacy_binding.AsyncOpenAI",
+            return_value=client,
+        ):
+            binding = build_legacy_openai_binding(
+                dialect_id="openai_chat",
+                model="m",
+                api_base="https://legacy.example/v1",
+                api_key="sk-runtime-only",
+                max_retries=4,
+                concurrency_limit=None,
+                parent_limiter=None,
+            )
+
+        base = binding.provenance_projector(binding.runtime_plan)
+        assert base is not None
+        foreign = replace(binding.runtime_plan, binding_id=base.binding_id)
+
+        assert binding.provenance_projector(foreign) is None
+
+    def test_projection_rejects_changed_opaque_plan_evidence(self) -> None:
+        client = SimpleNamespace(
+            base_url="https://legacy.example/v1/",
+            close=AsyncMock(),
+        )
+        with patch(
+            "sieval.core.models._legacy_binding.AsyncOpenAI",
+            return_value=client,
+        ):
+            binding = build_legacy_openai_binding(
+                dialect_id="openai_chat",
+                model="m",
+                api_base="https://legacy.example/v1",
+                api_key="sk-runtime-only",
+                max_retries=4,
+                concurrency_limit=None,
+                parent_limiter=None,
+            )
+
+        assert (
+            binding.provenance_projector(
+                replace(
+                    binding.runtime_plan,
+                    binding_plan_fingerprint="opaque:binding-proof",
+                )
+            )
+            is None
+        )
+        assert (
+            binding.provenance_projector(
+                replace(
+                    binding.runtime_plan,
+                    deployment_plan_fingerprint="opaque:deployment-proof",
+                )
+            )
+            is None
+        )
+
+    def test_persisted_fingerprints_record_credential_category_not_secret(self) -> None:
+        def build(api_key: str):
+            client = SimpleNamespace(
+                base_url="https://legacy.example/v1/",
+                close=AsyncMock(),
+            )
+            with patch(
+                "sieval.core.models._legacy_binding.AsyncOpenAI",
+                return_value=client,
+            ):
+                return build_legacy_openai_binding(
+                    dialect_id="openai_chat",
+                    model="m",
+                    api_base="https://legacy.example/v1",
+                    api_key=api_key,
+                    max_retries=4,
+                    concurrency_limit=None,
+                    parent_limiter=None,
+                )
+
+        first = build("first-secret")
+        second = build("second-secret")
+
+        assert first.runtime_plan.fingerprint != second.runtime_plan.fingerprint
+        first_provenance = first.provenance_projector(first.runtime_plan)
+        second_provenance = second.provenance_projector(second.runtime_plan)
+        assert first_provenance is not None
+        assert second_provenance is not None
+        assert first_provenance.fingerprint == second_provenance.fingerprint
+        assert "first-secret" not in repr(first)
+        assert "second-secret" not in repr(second)
+
+    def test_persisted_fingerprint_changes_with_semantic_binding_inputs(self) -> None:
+        def build(
+            *,
+            dialect_id: str = "openai_chat",
+            model: str = "m",
+            api_base: str = "https://legacy.example/v1",
+            api_key: str | None = "sk-runtime-only",
+            max_retries: int = 4,
+        ):
+            client = SimpleNamespace(
+                base_url=f"{api_base.rstrip('/')}/",
+                close=AsyncMock(),
+            )
+            with patch(
+                "sieval.core.models._legacy_binding.AsyncOpenAI",
+                return_value=client,
+            ):
+                return build_legacy_openai_binding(
+                    dialect_id=dialect_id,
+                    model=model,
+                    api_base=api_base,
+                    api_key=api_key,
+                    max_retries=max_retries,
+                    concurrency_limit=None,
+                    parent_limiter=None,
+                )
+
+        baseline = build()
+        variants = (
+            build(model="another-model"),
+            build(max_retries=5),
+            build(api_base="https://other.example/v1"),
+            build(dialect_id="openai_completions"),
+            build(api_key=None),
+        )
+
+        baseline_provenance = baseline.provenance_projector(baseline.runtime_plan)
+        variant_provenance = [
+            variant.provenance_projector(variant.runtime_plan) for variant in variants
+        ]
+        assert baseline_provenance is not None
+        assert all(projected is not None for projected in variant_provenance)
+        assert all(
+            projected.fingerprint != baseline_provenance.fingerprint
+            for projected in variant_provenance
+            if projected is not None
+        )
+        assert all(
+            projected.verification_fingerprint
+            != baseline_provenance.verification_fingerprint
+            for projected in variant_provenance
+            if projected is not None
         )

--- a/tests/unit/core/models/test__legacy_binding.py
+++ b/tests/unit/core/models/test__legacy_binding.py
@@ -60,8 +60,8 @@ class TestLegacyBindingClient:
             patch(
                 "sieval.core.models._legacy_binding.uuid4",
                 side_effect=[
-                    SimpleNamespace(hex="first-runtime-scope"),
-                    SimpleNamespace(hex="second-runtime-scope"),
+                    SimpleNamespace(hex="0" * 32),
+                    SimpleNamespace(hex="1" * 32),
                 ],
             ),
         ):
@@ -153,6 +153,32 @@ class TestLegacyBindingClient:
         foreign = replace(binding.runtime_plan, binding_id=base.binding_id)
 
         assert binding.provenance_projector(foreign) is None
+
+    def test_projection_rejects_a_plan_from_another_runtime_root(self) -> None:
+        client = SimpleNamespace(
+            base_url="https://legacy.example/v1/",
+            close=AsyncMock(),
+        )
+        with patch(
+            "sieval.core.models._legacy_binding.AsyncOpenAI",
+            return_value=client,
+        ):
+            binding = build_legacy_openai_binding(
+                dialect_id="openai_chat",
+                model="m",
+                api_base="https://legacy.example/v1",
+                api_key="sk-runtime-only",
+                max_retries=4,
+                concurrency_limit=None,
+                parent_limiter=None,
+            )
+
+        foreign_root = replace(
+            binding.runtime_plan,
+            root_deployment_key="legacy:foreign-runtime-root",
+        )
+
+        assert binding.provenance_projector(foreign_root) is None
 
     def test_projection_rejects_changed_opaque_plan_evidence(self) -> None:
         client = SimpleNamespace(

--- a/tests/unit/core/models/test__legacy_binding.py
+++ b/tests/unit/core/models/test__legacy_binding.py
@@ -399,10 +399,7 @@ class TestLegacyBindingClient:
     ) -> None:
         """A stable quota scope does not license an arbitrary credential scope.
 
-        The stable-form arm returns ``None`` so a projected plan falls through
-        as non-legacy.  If it were reached with a credential scope this module
-        never mints, treating it as canonical would persist forged evidence
-        verbatim, so it must fail closed instead.
+        Falling through as canonical would persist forged evidence verbatim.
         """
 
         projected = _projected_plan()

--- a/tests/unit/core/models/test__legacy_binding.py
+++ b/tests/unit/core/models/test__legacy_binding.py
@@ -10,11 +10,44 @@ from dataclasses import replace
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
-from sieval.core.models._legacy_binding import build_legacy_openai_binding
+from sieval.core.models._legacy_binding import (
+    _legacy_provenance_projector_for_plan,
+    build_legacy_openai_binding,
+)
 from sieval.core.models.connection_factory import DEFAULT_REQUEST_TIMEOUT
 
 
 class TestLegacyBindingClient:
+    def test_constructor_builds_provenance_without_recovering_its_own_plan(
+        self,
+    ) -> None:
+        client = SimpleNamespace(
+            base_url="https://legacy.example/v1/",
+            close=AsyncMock(),
+        )
+        with (
+            patch(
+                "sieval.core.models._legacy_binding.AsyncOpenAI",
+                return_value=client,
+            ),
+            patch(
+                "sieval.core.models._legacy_binding."
+                "_legacy_provenance_projector_for_plan",
+                side_effect=AssertionError("constructor must not use recovery"),
+            ),
+        ):
+            binding = build_legacy_openai_binding(
+                dialect_id="openai_chat",
+                model="m",
+                api_base="https://legacy.example/v1",
+                api_key="sk-runtime-only",
+                max_retries=4,
+                concurrency_limit=None,
+                parent_limiter=None,
+            )
+
+        assert binding.provenance_projector(binding.runtime_plan) is not None
+
     def test_client_declares_the_shared_request_timeout(self) -> None:
         """The wrapper path owes the same declared bound as the factory.
 
@@ -303,3 +336,28 @@ class TestLegacyBindingClient:
             for projected in variant_provenance
             if projected is not None
         )
+
+    def test_projected_plan_is_not_reported_as_a_malformed_runtime_identity(
+        self,
+    ) -> None:
+        client = SimpleNamespace(
+            base_url="https://legacy.example/v1/",
+            close=AsyncMock(),
+        )
+        with patch(
+            "sieval.core.models._legacy_binding.AsyncOpenAI",
+            return_value=client,
+        ):
+            binding = build_legacy_openai_binding(
+                dialect_id="openai_chat",
+                model="m",
+                api_base="https://legacy.example/v1",
+                api_key="sk-runtime-only",
+                max_retries=4,
+                concurrency_limit=None,
+                parent_limiter=None,
+            )
+
+        projected = binding.provenance_projector(binding.runtime_plan)
+        assert projected is not None
+        assert _legacy_provenance_projector_for_plan(projected) is None

--- a/tests/unit/core/models/test__legacy_binding.py
+++ b/tests/unit/core/models/test__legacy_binding.py
@@ -10,11 +10,43 @@ from dataclasses import replace
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
+import pytest
+
 from sieval.core.models._legacy_binding import (
     _legacy_provenance_projector_for_plan,
+    _LegacyOpenAIBinding,
     build_legacy_openai_binding,
 )
 from sieval.core.models.connection_factory import DEFAULT_REQUEST_TIMEOUT
+from sieval.core.models.reconcile import RuntimeBindingPlan
+
+
+def _a_binding(*, api_key: str | None = "sk-runtime-only") -> _LegacyOpenAIBinding:
+    """Build a wrapper binding without opening a client."""
+
+    client = SimpleNamespace(base_url="https://legacy.example/v1/", close=AsyncMock())
+    with patch(
+        "sieval.core.models._legacy_binding.AsyncOpenAI",
+        return_value=client,
+    ):
+        return build_legacy_openai_binding(
+            dialect_id="openai_chat",
+            model="m",
+            api_base="https://legacy.example/v1",
+            api_key=api_key,
+            max_retries=4,
+            concurrency_limit=None,
+            parent_limiter=None,
+        )
+
+
+def _projected_plan() -> RuntimeBindingPlan:
+    """Return the stable provenance plan a wrapper persists."""
+
+    binding = _a_binding()
+    projected = binding.provenance_projector(binding.runtime_plan)
+    assert projected is not None
+    return projected
 
 
 class TestLegacyBindingClient:
@@ -361,3 +393,72 @@ class TestLegacyBindingClient:
         projected = binding.provenance_projector(binding.runtime_plan)
         assert projected is not None
         assert _legacy_provenance_projector_for_plan(projected) is None
+
+    def test_projected_plan_with_a_tampered_credential_scope_fails_closed(
+        self,
+    ) -> None:
+        """A stable quota scope does not license an arbitrary credential scope.
+
+        The stable-form arm returns ``None`` so a projected plan falls through
+        as non-legacy.  If it were reached with a credential scope this module
+        never mints, treating it as canonical would persist forged evidence
+        verbatim, so it must fail closed instead.
+        """
+
+        projected = _projected_plan()
+        forged = replace(
+            projected,
+            connection_identity=replace(
+                projected.connection_identity,
+                credential_scope="legacy-private:forged-credential",
+            ),
+        )
+
+        with pytest.raises(ValueError, match="invalid credential scope"):
+            _legacy_provenance_projector_for_plan(forged)
+
+    def test_legacy_credential_scope_without_a_legacy_quota_scope_fails_closed(
+        self,
+    ) -> None:
+        """A half-legacy identity is malformed, not canonical."""
+
+        plan = _a_binding().runtime_plan
+        mismatched = replace(
+            plan,
+            connection_identity=replace(
+                plan.connection_identity,
+                quota_scope="shared-pool",
+            ),
+        )
+
+        with pytest.raises(ValueError, match="invalid quota scope"):
+            _legacy_provenance_projector_for_plan(mismatched)
+
+    def test_recovery_rejects_a_plan_whose_binding_identity_was_rewritten(
+        self,
+    ) -> None:
+        """Recovery re-derives the binding id and will not adopt a foreign one."""
+
+        plan = _a_binding().runtime_plan
+        rewritten = replace(plan, binding_id="legacy:someone-elses:binding:0000")
+
+        with pytest.raises(ValueError, match="inconsistent binding identity"):
+            _legacy_provenance_projector_for_plan(rewritten)
+
+    def test_environment_credential_plans_recover_their_stable_identity(self) -> None:
+        """The environment-credential category survives a ``Model.bind`` round-trip."""
+
+        binding = _a_binding(api_key=None)
+        runtime_scope = binding.runtime_plan.connection_identity.credential_scope
+        assert runtime_scope.endswith(":environment-credential")
+
+        projector = _legacy_provenance_projector_for_plan(binding.runtime_plan)
+        assert projector is not None
+        assert (
+            projector.connection_identity.credential_scope
+            == "legacy-private:environment-credential"
+        )
+        # Recovery must land on exactly what the constructor already built.
+        assert projector.connection_identity == (
+            binding.provenance_projector.connection_identity
+        )

--- a/tests/unit/core/models/test_model.py
+++ b/tests/unit/core/models/test_model.py
@@ -12,6 +12,7 @@ AI-Generated Code - Claude Fable 5 (Anthropic)
 
 from dataclasses import replace
 from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -95,6 +96,205 @@ class TestModelUnique:
         assert first.runtime_plan.fingerprint != second.runtime_plan.fingerprint
         assert "first-secret" not in repr(first.pool.identity)
         assert "second-secret" not in repr(second.pool.identity)
+
+    @pytest.mark.parametrize("model_type", [ChatModel, GenModel])
+    def test_equivalent_legacy_models_persist_stable_provenance(self, model_type):
+        first = model_type(
+            model="same-model",
+            api_base="https://same.example/v1",
+            api_key="same-secret",
+            max_retries=4,
+        )
+        second = model_type(
+            model="same-model",
+            api_base="https://same.example/v1",
+            api_key="same-secret",
+            max_retries=4,
+        )
+
+        assert first.pool.identity != second.pool.identity
+        assert first.runtime_plan is not None
+        assert second.runtime_plan is not None
+        assert first.runtime_plan.fingerprint != second.runtime_plan.fingerprint
+
+        first_provenance = first._provenance(Response(texts=("first",)))
+        second_provenance = second._provenance(Response(texts=("second",)))
+
+        assert first_provenance == second_provenance
+        assert (
+            first_provenance.capabilities.plan_fingerprint
+            != first.runtime_plan.fingerprint
+        )
+
+    def test_legacy_provenance_projection_survives_shape_derivation(self, gen_model):
+        plan = gen_model.runtime_plan
+        assert plan is not None
+        expected = gen_model._provenance(Response(texts=("base",))).capabilities
+        assert expected is not None
+
+        derived = gen_model.with_args(temperature=0.25)
+        rebound = gen_model.with_dialect(gen_model.dialect_id, plan)
+        compat = rebound.as_compat_type(GenModel)
+
+        for model in (derived, rebound, compat):
+            actual = model._provenance(Response(texts=("derived",))).capabilities
+            assert actual == expected
+
+    def test_canonical_bind_uses_the_runtime_plan_fingerprints(self, gen_model):
+        plan = gen_model.runtime_plan
+        assert plan is not None
+        canonical = Model.bind(gen_model.deployment, gen_model.pool, plan)
+
+        evidence = canonical._provenance(Response(texts=("canonical",))).capabilities
+
+        assert evidence is not None
+        assert evidence.plan_fingerprint == plan.fingerprint
+        assert evidence.verification_fingerprint == plan.verification_fingerprint
+
+    @pytest.mark.parametrize(
+        "field",
+        [
+            "requested_model_id",
+            "dialect_id",
+            "declared_capabilities",
+            "effective_capabilities",
+            "available_capabilities",
+            "capability_minimums",
+            "request_defaults",
+            "required_output_channels",
+            "request_checks",
+            "deployment_fingerprint",
+            "resolved_route",
+            "connection_identity.endpoint",
+            "connection_identity.connection_family",
+            "connection_identity.retry_policy",
+        ],
+    )
+    def test_rebind_rejects_provenance_projection_semantic_drift(
+        self, gen_model, field
+    ):
+        plan = gen_model.runtime_plan
+        assert plan is not None
+        check = DeferredCheck(
+            "sampled_logprobs",
+            CheckStage.REQUEST,
+            "validate_response_channel",
+            "changed provenance guard",
+        )
+        variants = {
+            "requested_model_id": replace(plan, requested_model_id="other-model"),
+            "dialect_id": replace(plan, dialect_id="other-dialect"),
+            "declared_capabilities": replace(
+                plan, declared_capabilities={"sampled_logprobs": {}}
+            ),
+            "effective_capabilities": replace(
+                plan, effective_capabilities={"sampled_logprobs": {}}
+            ),
+            "available_capabilities": replace(plan, available_capabilities=frozenset()),
+            "capability_minimums": replace(
+                plan, capability_minimums={"top_logprobs": {"minimum": 2}}
+            ),
+            "request_defaults": replace(
+                plan,
+                request_defaults=RequestDefaults({"sampling.temperature": 0.25}),
+            ),
+            "required_output_channels": replace(
+                plan, required_output_channels=frozenset({"reasoning"})
+            ),
+            "request_checks": replace(plan, request_checks=(check,)),
+            "deployment_fingerprint": replace(
+                plan, deployment_fingerprint="sha256:other"
+            ),
+            "resolved_route": replace(
+                plan,
+                resolved_route=replace(plan.resolved_route, service_role="other"),
+            ),
+            "connection_identity.endpoint": replace(
+                plan,
+                connection_identity=replace(
+                    plan.connection_identity,
+                    endpoint="https://other.example/v1",
+                ),
+            ),
+            "connection_identity.connection_family": replace(
+                plan,
+                connection_identity=replace(
+                    plan.connection_identity,
+                    connection_family="async_http_json",
+                ),
+            ),
+            "connection_identity.retry_policy": replace(
+                plan,
+                connection_identity=replace(
+                    plan.connection_identity,
+                    retry_policy="other-retry-policy",
+                ),
+            ),
+        }
+
+        with pytest.raises(ValueError, match=field.replace(".", r"\.")):
+            gen_model._with_provenance_plan(variants[field])
+
+    def test_noop_rebind_preserves_full_projected_provenance(self, gen_model):
+        plan = gen_model.runtime_plan
+        assert plan is not None
+        current_provenance = gen_model._provenance_plan
+        assert current_provenance is not None
+        full_projection = replace(
+            current_provenance,
+            binding_plan_fingerprint="stable:reconciled-binding",
+            deployment_plan_fingerprint="stable:reconciled-deployment",
+        )
+        rebound = gen_model._with_provenance_plan(full_projection)
+
+        repeated = rebound.with_dialect(plan.dialect_id, plan)
+
+        assert repeated._provenance_plan == full_projection
+        assert (
+            repeated._provenance(Response(texts=("repeated",))).capabilities
+            == rebound._provenance(Response(texts=("rebound",))).capabilities
+        )
+
+    def test_canonical_rebind_rejects_non_runtime_provenance(self, gen_model):
+        plan = gen_model.runtime_plan
+        assert plan is not None
+        canonical = Model.bind(gen_model.deployment, gen_model.pool, plan)
+        projected = replace(
+            plan,
+            connection_identity=replace(
+                plan.connection_identity,
+                credential_scope="stable:credential",
+                quota_scope="stable:quota",
+            ),
+        )
+
+        with pytest.raises(ValueError, match="persist their runtime plan verbatim"):
+            canonical._with_provenance_plan(projected)
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize(
+        "field",
+        ["binding_plan_fingerprint", "deployment_plan_fingerprint"],
+    )
+    async def test_opaque_rebind_requires_provenance_before_io(self, gen_model, field):
+        plan = gen_model.runtime_plan
+        assert plan is not None
+        rebound = gen_model.with_dialect(
+            plan.dialect_id,
+            replace(plan, **{field: f"opaque:{field}"}),
+        )
+        execute = AsyncMock(return_value=Response(texts=("unexpected",)))
+
+        assert rebound._provenance_plan is None
+        with pytest.raises(RuntimeError, match="provenance is incomplete"):
+            rebound._provenance(Response(texts=("not persisted",)))
+        with (
+            patch.object(rebound._dialect, "execute", execute),
+            pytest.raises(RuntimeError, match="provenance is incomplete"),
+        ):
+            await rebound.arun(Request(input=CompletionInput("prompt")))
+
+        execute.assert_not_awaited()
 
     def test_legacy_runtime_fingerprint_covers_every_plan_field(self, gen_model):
         plan = gen_model.runtime_plan

--- a/tests/unit/core/models/test_model.py
+++ b/tests/unit/core/models/test_model.py
@@ -10,7 +10,7 @@ Response -> ModelOutput bridge.
 AI-Generated Code - Claude Fable 5 (Anthropic)
 """
 
-from dataclasses import replace
+from dataclasses import fields, replace
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
@@ -20,6 +20,8 @@ from sieval.core.models import (
     ChatInput,
     ChatModel,
     CompletionInput,
+    ConnectionIdentity,
+    ConnectionPool,
     DialectOptions,
     GenModel,
     InputScoringResult,
@@ -39,8 +41,18 @@ from sieval.core.models import (
 )
 from sieval.core.models._legacy_bridge import response_to_model_output
 from sieval.core.models.dialect import DialectError
-from sieval.core.models.model import _apply_request_defaults
-from sieval.core.models.reconcile import CheckStage, DeferredCheck
+from sieval.core.models.model import (
+    _PROVENANCE_COMPUTED_PLAN_FIELDS,
+    _PROVENANCE_PROJECTABLE_CHECK_FIELDS,
+    _PROVENANCE_PROJECTABLE_CONNECTION_FIELDS,
+    _PROVENANCE_PROJECTABLE_PLAN_FIELDS,
+    _PROVENANCE_SEMANTIC_CHECK_FIELDS,
+    _PROVENANCE_SEMANTIC_CONNECTION_FIELDS,
+    _PROVENANCE_SEMANTIC_PLAN_FIELDS,
+    _PROVENANCE_SPECIAL_PLAN_FIELDS,
+    _apply_request_defaults,
+)
+from sieval.core.models.reconcile import CheckStage, DeferredCheck, RuntimeBindingPlan
 
 
 # ---------------------------------------------------------------------------
@@ -140,16 +152,90 @@ class TestModelUnique:
             actual = model._provenance(Response(texts=("derived",))).capabilities
             assert actual == expected
 
-    def test_canonical_bind_uses_the_runtime_plan_fingerprints(self, gen_model):
+    def test_bind_preserves_uuid_scoped_legacy_provenance_policy(self, gen_model):
         plan = gen_model.runtime_plan
         assert plan is not None
-        canonical = Model.bind(gen_model.deployment, gen_model.pool, plan)
+        rebound = Model.bind(gen_model.deployment, gen_model.pool, plan)
 
-        evidence = canonical._provenance(Response(texts=("canonical",))).capabilities
+        evidence = rebound._provenance(Response(texts=("rebound",))).capabilities
+        expected = gen_model._provenance(Response(texts=("legacy",))).capabilities
 
         assert evidence is not None
-        assert evidence.plan_fingerprint == plan.fingerprint
-        assert evidence.verification_fingerprint == plan.verification_fingerprint
+        assert evidence == expected
+        assert evidence.plan_fingerprint != plan.fingerprint
+        assert rebound._provenance_projector is not None
+
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [
+            ("binding_plan_fingerprint", "opaque:reconciled-binding"),
+            ("deployment_plan_fingerprint", "opaque:reconciled-deployment"),
+        ],
+    )
+    def test_bind_rejects_reconciled_legacy_plan_without_stable_provenance(
+        self, gen_model, field, value
+    ):
+        plan = gen_model.runtime_plan
+        assert plan is not None
+        reconciled = replace(plan, **{field: value})
+
+        with pytest.raises(ValueError, match="opaque reconciled provenance"):
+            Model.bind(gen_model.deployment, gen_model.pool, reconciled)
+
+    @pytest.mark.parametrize(
+        ("quota_scope", "credential_scope", "message"),
+        [
+            (
+                "legacy-private:not-a-uuid",
+                "legacy-private:not-a-uuid:explicit-credential",
+                "invalid runtime UUID",
+            ),
+            (
+                "legacy-private:" + "0" * 32,
+                "legacy-private:" + "1" * 32 + ":explicit-credential",
+                "mismatched credential and quota scopes",
+            ),
+            (
+                "legacy-private:" + "0" * 32,
+                "legacy-private:" + "0" * 32 + ":unknown-credential",
+                "invalid credential category",
+            ),
+        ],
+    )
+    def test_bind_rejects_malformed_legacy_private_identity(
+        self, gen_model, quota_scope, credential_scope, message
+    ):
+        plan = gen_model.runtime_plan
+        assert plan is not None
+        malformed_identity = replace(
+            plan.connection_identity,
+            quota_scope=quota_scope,
+            credential_scope=credential_scope,
+        )
+        malformed_plan = replace(plan, connection_identity=malformed_identity)
+        malformed_pool = ConnectionPool(
+            gen_model.pool.connection,
+            malformed_identity,
+            gen_model.pool.shared_limiter,
+        )
+
+        with pytest.raises(ValueError, match=message):
+            Model.bind(gen_model.deployment, malformed_pool, malformed_plan)
+
+    def test_provenance_policy_classifies_every_runtime_plan_field(self) -> None:
+        assert {item.name for item in fields(RuntimeBindingPlan)} == (
+            _PROVENANCE_PROJECTABLE_PLAN_FIELDS
+            | _PROVENANCE_SEMANTIC_PLAN_FIELDS
+            | _PROVENANCE_SPECIAL_PLAN_FIELDS
+            | _PROVENANCE_COMPUTED_PLAN_FIELDS
+        )
+        assert {item.name for item in fields(ConnectionIdentity)} == (
+            _PROVENANCE_PROJECTABLE_CONNECTION_FIELDS
+            | _PROVENANCE_SEMANTIC_CONNECTION_FIELDS
+        )
+        assert {item.name for item in fields(DeferredCheck)} == (
+            _PROVENANCE_PROJECTABLE_CHECK_FIELDS | _PROVENANCE_SEMANTIC_CHECK_FIELDS
+        )
 
     @pytest.mark.parametrize(
         "field",
@@ -235,6 +321,30 @@ class TestModelUnique:
         with pytest.raises(ValueError, match=field.replace(".", r"\.")):
             gen_model._with_provenance_plan(variants[field])
 
+    @pytest.mark.parametrize("projected_value", [True, 1.0])
+    def test_rebind_compares_json_semantics_without_numeric_coercion(
+        self, gen_model, projected_value
+    ):
+        plan = gen_model.runtime_plan
+        assert plan is not None
+        runtime_plan = replace(
+            plan,
+            request_defaults=RequestDefaults({"sampling.temperature": 1}),
+        )
+        rebound = gen_model.with_dialect(plan.dialect_id, runtime_plan)
+        provenance_plan = rebound._provenance_plan
+        assert provenance_plan is not None
+
+        with pytest.raises(ValueError, match="request_defaults"):
+            rebound._with_provenance_plan(
+                replace(
+                    provenance_plan,
+                    request_defaults=RequestDefaults(
+                        {"sampling.temperature": projected_value}
+                    ),
+                )
+            )
+
     def test_noop_rebind_preserves_full_projected_provenance(self, gen_model):
         plan = gen_model.runtime_plan
         assert plan is not None
@@ -255,10 +365,53 @@ class TestModelUnique:
             == rebound._provenance(Response(texts=("rebound",))).capabilities
         )
 
-    def test_canonical_rebind_rejects_non_runtime_provenance(self, gen_model):
+    def test_provenance_projection_may_stabilize_only_check_reason(self, gen_model):
         plan = gen_model.runtime_plan
         assert plan is not None
-        canonical = Model.bind(gen_model.deployment, gen_model.pool, plan)
+        runtime_check = DeferredCheck(
+            "sampled_logprobs",
+            CheckStage.REQUEST,
+            "validate_response_channel",
+            f"runtime root {plan.root_deployment_key}",
+        )
+        runtime_plan = replace(plan, request_checks=(runtime_check,))
+        rebound = gen_model.with_dialect(plan.dialect_id, runtime_plan)
+        provenance_plan = rebound._provenance_plan
+        assert provenance_plan is not None
+        stable_check = replace(
+            provenance_plan.request_checks[0],
+            reason=f"stable root {provenance_plan.root_deployment_key}",
+        )
+
+        projected = rebound._with_provenance_plan(
+            replace(provenance_plan, request_checks=(stable_check,))
+        )
+
+        assert projected._provenance_plan is not None
+        assert projected._provenance_plan.request_checks == (stable_check,)
+
+    def test_canonical_rebind_rejects_non_runtime_provenance(self, gen_model):
+        legacy_plan = gen_model.runtime_plan
+        assert legacy_plan is not None
+        canonical_identity = ConnectionIdentity(
+            endpoint=legacy_plan.connection_identity.endpoint,
+            connection_family=legacy_plan.connection_identity.connection_family,
+            credential_scope="canonical:explicit-credential",
+            retry_policy=legacy_plan.connection_identity.retry_policy,
+            quota_scope="canonical:quota",
+        )
+        plan = replace(
+            legacy_plan,
+            binding_id="model:canonical",
+            root_deployment_key="model:canonical",
+            connection_identity=canonical_identity,
+        )
+        pool = ConnectionPool(
+            gen_model.pool.connection,
+            canonical_identity,
+            gen_model.pool.shared_limiter,
+        )
+        canonical = Model.bind(gen_model.deployment, pool, plan)
         projected = replace(
             plan,
             connection_identity=replace(
@@ -299,24 +452,32 @@ class TestModelUnique:
     def test_legacy_runtime_fingerprint_covers_every_plan_field(self, gen_model):
         plan = gen_model.runtime_plan
         assert plan is not None
-        variants = (
-            replace(plan, binding_id=f"{plan.binding_id}:changed"),
-            replace(plan, root_deployment_key=f"{plan.root_deployment_key}:changed"),
-            replace(plan, requested_model_id="changed-model"),
-            replace(plan, dialect_id="changed-dialect"),
-            replace(plan, declared_capabilities={"sampled_logprobs": {}}),
-            replace(plan, effective_capabilities={"sampled_logprobs": {}}),
-            replace(plan, available_capabilities=frozenset()),
-            replace(
+        variants = {
+            "binding_id": replace(plan, binding_id=f"{plan.binding_id}:changed"),
+            "root_deployment_key": replace(
+                plan, root_deployment_key=f"{plan.root_deployment_key}:changed"
+            ),
+            "requested_model_id": replace(plan, requested_model_id="changed-model"),
+            "dialect_id": replace(plan, dialect_id="changed-dialect"),
+            "declared_capabilities": replace(
+                plan, declared_capabilities={"sampled_logprobs": {}}
+            ),
+            "effective_capabilities": replace(
+                plan, effective_capabilities={"sampled_logprobs": {}}
+            ),
+            "available_capabilities": replace(plan, available_capabilities=frozenset()),
+            "capability_minimums": replace(
                 plan,
                 capability_minimums={"top_logprobs": {"minimum": 2}},
             ),
-            replace(
+            "request_defaults": replace(
                 plan,
                 request_defaults=RequestDefaults({"sampling.temperature": 0.25}),
             ),
-            replace(plan, required_output_channels=frozenset({"reasoning"})),
-            replace(
+            "required_output_channels": replace(
+                plan, required_output_channels=frozenset({"reasoning"})
+            ),
+            "request_checks": replace(
                 plan,
                 request_checks=(
                     DeferredCheck(
@@ -327,30 +488,72 @@ class TestModelUnique:
                     ),
                 ),
             ),
-            replace(plan, deployment_fingerprint="sha256:changed-deployment"),
-            replace(
+            "deployment_fingerprint": replace(
+                plan, deployment_fingerprint="sha256:changed-deployment"
+            ),
+            "resolved_route": replace(
                 plan,
                 resolved_route=replace(
                     plan.resolved_route,
                     service_role="changed-role",
                 ),
             ),
-            replace(
+            "connection_identity": replace(
                 plan,
                 connection_identity=replace(
                     plan.connection_identity,
                     quota_scope="changed-quota",
                 ),
             ),
-            replace(plan, binding_plan_fingerprint="sha256:changed-binding-plan"),
-            replace(
+            "binding_plan_fingerprint": replace(
+                plan, binding_plan_fingerprint="sha256:changed-binding-plan"
+            ),
+            "deployment_plan_fingerprint": replace(
                 plan,
                 deployment_plan_fingerprint="sha256:changed-deployment-plan",
             ),
-        )
+        }
 
-        fingerprints = {plan.fingerprint, *(item.fingerprint for item in variants)}
+        assert set(variants) == {
+            item.name for item in fields(RuntimeBindingPlan) if item.init
+        }
+
+        fingerprints = {
+            plan.fingerprint,
+            *(item.fingerprint for item in variants.values()),
+        }
         assert len(fingerprints) == len(variants) + 1
+
+        identity_variants = {
+            "endpoint": replace(
+                plan.connection_identity,
+                endpoint="https://changed.example/v1",
+            ),
+            "connection_family": replace(
+                plan.connection_identity,
+                connection_family="async_http_json",
+            ),
+            "credential_scope": replace(
+                plan.connection_identity,
+                credential_scope="changed-credential",
+            ),
+            "retry_policy": replace(
+                plan.connection_identity,
+                retry_policy="changed-retry",
+            ),
+            "quota_scope": replace(
+                plan.connection_identity,
+                quota_scope="changed-quota",
+            ),
+        }
+        assert set(identity_variants) == {
+            item.name for item in fields(ConnectionIdentity) if item.init
+        }
+        identity_fingerprints = {
+            replace(plan, connection_identity=identity).fingerprint
+            for identity in identity_variants.values()
+        }
+        assert len(identity_fingerprints) == len(identity_variants)
 
     def test_as_compat_type_rebuilds_truthful_non_owning_wrapper(self, gen_model):
         plan = gen_model.runtime_plan

--- a/tests/unit/core/models/test_model.py
+++ b/tests/unit/core/models/test_model.py
@@ -51,6 +51,7 @@ from sieval.core.models.model import (
     _PROVENANCE_SEMANTIC_PLAN_FIELDS,
     _PROVENANCE_SPECIAL_PLAN_FIELDS,
     _apply_request_defaults,
+    _validate_provenance_plan,
 )
 from sieval.core.models.reconcile import CheckStage, DeferredCheck, RuntimeBindingPlan
 
@@ -237,6 +238,17 @@ class TestModelUnique:
             _PROVENANCE_PROJECTABLE_CHECK_FIELDS | _PROVENANCE_SEMANTIC_CHECK_FIELDS
         )
 
+    def test_identical_provenance_plan_skips_serialization(self, gen_model) -> None:
+        plan = gen_model.runtime_plan
+        assert plan is not None
+
+        with patch.object(
+            RuntimeBindingPlan,
+            "to_json_value",
+            side_effect=AssertionError("identical plans need no comparison"),
+        ):
+            _validate_provenance_plan(plan, plan)
+
     @pytest.mark.parametrize(
         "field",
         [
@@ -319,7 +331,7 @@ class TestModelUnique:
         }
 
         with pytest.raises(ValueError, match=field.replace(".", r"\.")):
-            gen_model._with_provenance_plan(variants[field])
+            gen_model.with_provenance_plan(variants[field])
 
     @pytest.mark.parametrize("projected_value", [True, 1.0])
     def test_rebind_compares_json_semantics_without_numeric_coercion(
@@ -332,11 +344,11 @@ class TestModelUnique:
             request_defaults=RequestDefaults({"sampling.temperature": 1}),
         )
         rebound = gen_model.with_dialect(plan.dialect_id, runtime_plan)
-        provenance_plan = rebound._provenance_plan
+        provenance_plan = rebound.provenance_plan
         assert provenance_plan is not None
 
         with pytest.raises(ValueError, match="request_defaults"):
-            rebound._with_provenance_plan(
+            rebound.with_provenance_plan(
                 replace(
                     provenance_plan,
                     request_defaults=RequestDefaults(
@@ -348,18 +360,18 @@ class TestModelUnique:
     def test_noop_rebind_preserves_full_projected_provenance(self, gen_model):
         plan = gen_model.runtime_plan
         assert plan is not None
-        current_provenance = gen_model._provenance_plan
+        current_provenance = gen_model.provenance_plan
         assert current_provenance is not None
         full_projection = replace(
             current_provenance,
             binding_plan_fingerprint="stable:reconciled-binding",
             deployment_plan_fingerprint="stable:reconciled-deployment",
         )
-        rebound = gen_model._with_provenance_plan(full_projection)
+        rebound = gen_model.with_provenance_plan(full_projection)
 
         repeated = rebound.with_dialect(plan.dialect_id, plan)
 
-        assert repeated._provenance_plan == full_projection
+        assert repeated.provenance_plan == full_projection
         assert (
             repeated._provenance(Response(texts=("repeated",))).capabilities
             == rebound._provenance(Response(texts=("rebound",))).capabilities
@@ -376,19 +388,19 @@ class TestModelUnique:
         )
         runtime_plan = replace(plan, request_checks=(runtime_check,))
         rebound = gen_model.with_dialect(plan.dialect_id, runtime_plan)
-        provenance_plan = rebound._provenance_plan
+        provenance_plan = rebound.provenance_plan
         assert provenance_plan is not None
         stable_check = replace(
             provenance_plan.request_checks[0],
             reason=f"stable root {provenance_plan.root_deployment_key}",
         )
 
-        projected = rebound._with_provenance_plan(
+        projected = rebound.with_provenance_plan(
             replace(provenance_plan, request_checks=(stable_check,))
         )
 
-        assert projected._provenance_plan is not None
-        assert projected._provenance_plan.request_checks == (stable_check,)
+        assert projected.provenance_plan is not None
+        assert projected.provenance_plan.request_checks == (stable_check,)
 
     def test_canonical_rebind_rejects_non_runtime_provenance(self, gen_model):
         legacy_plan = gen_model.runtime_plan
@@ -422,7 +434,12 @@ class TestModelUnique:
         )
 
         with pytest.raises(ValueError, match="persist their runtime plan verbatim"):
-            canonical._with_provenance_plan(projected)
+            canonical.with_provenance_plan(projected)
+        with pytest.raises(ValueError, match="persist their runtime plan verbatim"):
+            canonical.with_reconciled_plan(
+                plan,
+                projected,
+            )
 
     @pytest.mark.anyio
     @pytest.mark.parametrize(
@@ -438,7 +455,7 @@ class TestModelUnique:
         )
         execute = AsyncMock(return_value=Response(texts=("unexpected",)))
 
-        assert rebound._provenance_plan is None
+        assert rebound.provenance_plan is None
         with pytest.raises(RuntimeError, match="provenance is incomplete"):
             rebound._provenance(Response(texts=("not persisted",)))
         with (
@@ -448,6 +465,29 @@ class TestModelUnique:
             await rebound.arun(Request(input=CompletionInput("prompt")))
 
         execute.assert_not_awaited()
+
+    def test_rebind_can_attach_composition_provenance_atomically(self, gen_model):
+        runtime_plan = gen_model.runtime_plan
+        provenance_plan = gen_model.provenance_plan
+        assert runtime_plan is not None
+        assert provenance_plan is not None
+        reconciled_runtime = replace(
+            runtime_plan,
+            binding_plan_fingerprint="opaque:reconciled-binding",
+            deployment_plan_fingerprint="opaque:reconciled-deployment",
+        )
+        reconciled_provenance = replace(
+            provenance_plan,
+            binding_plan_fingerprint="stable:reconciled-binding",
+            deployment_plan_fingerprint="stable:reconciled-deployment",
+        )
+
+        rebound = gen_model.with_reconciled_plan(
+            reconciled_runtime,
+            reconciled_provenance,
+        )
+
+        assert rebound.provenance_plan == reconciled_provenance
 
     def test_legacy_runtime_fingerprint_covers_every_plan_field(self, gen_model):
         plan = gen_model.runtime_plan

--- a/tests/unit/core/models/test_model.py
+++ b/tests/unit/core/models/test_model.py
@@ -238,6 +238,52 @@ class TestModelUnique:
             _PROVENANCE_PROJECTABLE_CHECK_FIELDS | _PROVENANCE_SEMANTIC_CHECK_FIELDS
         )
 
+    def test_initialize_rejects_foreign_provenance_on_a_canonical_binding(
+        self, gen_model
+    ) -> None:
+        """Pin the canonical-verbatim invariant inside the private constructor.
+
+        No current ``_initialize`` caller can pair ``provenance_projector=None``
+        with a differing provenance plan, so this drives the constructor
+        directly.  Unlike a schema check over fixed dataclass fields, this
+        branch is reachable by any future caller — and the callers grow with
+        each new binder — so the invariant is pinned rather than deleted.
+        """
+
+        plan = gen_model.runtime_plan
+        assert plan is not None
+        foreign = replace(plan, requested_model_id="somebody-elses-model")
+        model = object.__new__(Model)
+
+        with pytest.raises(ValueError, match="persist their runtime plan verbatim"):
+            model._initialize(
+                deployment=gen_model.deployment,
+                pool=gen_model.pool,
+                runtime_plan=plan,
+                dialect=gen_model._dialect,
+                local_limiter=None,
+                parent_limiter=None,
+                builder_defaults={},
+                extra=None,
+                api_base=gen_model.deployment.api_base,
+                lifecycle_owner=None,
+                provenance_projector=None,
+                provenance_plan=foreign,
+            )
+
+    def test_reattaching_the_same_provenance_plan_returns_the_same_model(
+        self, gen_model
+    ) -> None:
+        plan = gen_model.runtime_plan
+        assert plan is not None
+        assert gen_model.provenance_plan is not None
+
+        # A canonical model persists its runtime plan, so re-attaching it is a
+        # no-op that must not allocate a second model.
+        rebound = Model.bind(gen_model.deployment, gen_model.pool, plan)
+        assert rebound.provenance_plan is not None
+        assert rebound.with_provenance_plan(rebound.provenance_plan) is rebound
+
     def test_identical_provenance_plan_skips_serialization(self, gen_model) -> None:
         plan = gen_model.runtime_plan
         assert plan is not None

--- a/tests/unit/core/models/test_model.py
+++ b/tests/unit/core/models/test_model.py
@@ -243,11 +243,9 @@ class TestModelUnique:
     ) -> None:
         """Pin the canonical-verbatim invariant inside the private constructor.
 
-        No current ``_initialize`` caller can pair ``provenance_projector=None``
-        with a differing provenance plan, so this drives the constructor
-        directly.  Unlike a schema check over fixed dataclass fields, this
-        branch is reachable by any future caller — and the callers grow with
-        each new binder — so the invariant is pinned rather than deleted.
+        No current caller can pair a null projector with a differing plan, so
+        this drives ``_initialize`` directly.  The branch is still reachable by
+        any future caller, so the invariant is pinned rather than deleted.
         """
 
         plan = gen_model.runtime_plan
@@ -278,8 +276,7 @@ class TestModelUnique:
         assert plan is not None
         assert gen_model.provenance_plan is not None
 
-        # A canonical model persists its runtime plan, so re-attaching it is a
-        # no-op that must not allocate a second model.
+        # Re-attaching what the model already persists must not allocate.
         rebound = Model.bind(gen_model.deployment, gen_model.pool, plan)
         assert rebound.provenance_plan is not None
         assert rebound.with_provenance_plan(rebound.provenance_plan) is rebound

--- a/tests/unit/core/models/test_sglang_gen_model.py
+++ b/tests/unit/core/models/test_sglang_gen_model.py
@@ -127,8 +127,12 @@ class TestDefaultTransport:
     def test_legacy_facade_cannot_rebind_or_lose_its_owner(self):
         model = SglangGenModel(model="m", api_key="local")
 
+        assert model.runtime_plan is None
+        assert model.provenance_plan is None
         with pytest.raises(RuntimeError, match="cannot rebind"):
             model.with_dialect("sglang_native", object())
+        with pytest.raises(RuntimeError, match="no runtime plan for provenance"):
+            model.with_provenance_plan(object())
         model._lifecycle_owner = None
         with pytest.raises(RuntimeError, match="no lifecycle owner"):
             model._legacy_lifecycle_owner()

--- a/tests/unit/core/models/test_sglang_gen_model.py
+++ b/tests/unit/core/models/test_sglang_gen_model.py
@@ -36,8 +36,29 @@ from sieval.core.models import (
     SglangGenModel,
     ToolParams,
 )
+from sieval.core.models._legacy_binding import build_legacy_openai_binding
 from sieval.core.models.dialect import RequestAuditError
+from sieval.core.models.reconcile import RuntimeBindingPlan
 from sieval.core.models.transports.sglang import SglangTransport
+
+
+def _a_runtime_plan() -> RuntimeBindingPlan:
+    """Build a genuine plan without opening a client, for refusal tests."""
+
+    client = SimpleNamespace(base_url="https://legacy.example/v1/", close=AsyncMock())
+    with patch(
+        "sieval.core.models._legacy_binding.AsyncOpenAI",
+        return_value=client,
+    ):
+        return build_legacy_openai_binding(
+            dialect_id="openai_completions",
+            model="m",
+            api_base="https://legacy.example/v1",
+            api_key="sk-test",
+            max_retries=2,
+            concurrency_limit=None,
+            parent_limiter=None,
+        ).runtime_plan
 
 
 class TestDefaultTransport:
@@ -126,13 +147,15 @@ class TestDefaultTransport:
 
     def test_legacy_facade_cannot_rebind_or_lose_its_owner(self):
         model = SglangGenModel(model="m", api_key="local")
+        # A real plan, so the refusal is not an artifact of a bogus argument.
+        plan = _a_runtime_plan()
 
         assert model.runtime_plan is None
         assert model.provenance_plan is None
         with pytest.raises(RuntimeError, match="cannot rebind"):
-            model.with_dialect("sglang_native", object())
+            model.with_dialect("sglang_native", plan)
         with pytest.raises(RuntimeError, match="no runtime plan for provenance"):
-            model.with_provenance_plan(object())
+            model.with_provenance_plan(plan)
         model._lifecycle_owner = None
         with pytest.raises(RuntimeError, match="no lifecycle owner"):
             model._legacy_lifecycle_owner()


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Type

<!-- Choose ONE, delete the rest -->

- fix — bug fix or alignment correction

## Summary

- Legacy `ChatModel`/`GenModel` keep a UUID-scoped runtime identity for pool/quota
  isolation, but persist a stable semantic provenance plan — equivalent configs now
  produce identical run artifacts instead of UUID-randomized ones.
- `Model` carries provenance explicitly: a read-only `provenance_plan` property, an
  atomic `with_reconciled_plan(runtime_plan, provenance_plan)` for the composition
  layer, and a completeness gate in `arun` that fails before provider I/O.
- External-model reconciliation projects persisted evidence structurally: each record
  type has a field-classification policy (pinned by tests), identity references are
  replaced only in declared `sources` fields, and a runtime token found anywhere in
  semantic data fails loud — it is never rewritten.
- Malformed legacy identities, runtime/provenance semantic drift, opaque reconciled
  evidence, and unresolved runtime tokens are all rejected before anything persists.

## Related Issues

Fixes #128

## Test Plan

### Automated

- [x] Lint/format clean (`ruff check && ruff format --check`)
- [x] Type check clean (`ty check` or `mypy --strict`)
- [x] Unit tests pass (`pdm run pytest`) <!-- delete if benchmark-only PR -->

### Manual

- [x] Equivalent models retain separate runtime identities and produce identical
      persisted provenance (also verified under `python -O`)
- [x] Semantic configuration changes still change persisted provenance
- [x] Incomplete provenance fails before provider I/O

## Checklist

### Required (all PRs)

- [x] PR title follows conventional format (`type(scope): description`)
- [x] No internal paths, credentials, or personal info in committed files
- [x] AI-generated code has `AI-Generated Code - <model> (<provider>)` in module docstring
- [x] No new upper-layer dependencies added to `core/`
- [x] Deleted code verified — no remaining call sites depend on it