### PR TITLE
fix(infer): a deploy that never becomes ready must say why

### DIFF
--- a/sieval/infer/deployer.py
+++ b/sieval/infer/deployer.py
@@ -43,10 +43,9 @@ _HEALTH_CHECK_TIMEOUT = 2.0
 _GRACEFUL_SHUTDOWN_TIMEOUT = 10.0
 _LOG_DIR = Path.home() / ".sieval" / "logs"
 _FAILURE_LOG_TAIL = 30
-# Bytes read back from the end of a log before taking its trailing lines.
-# Sized in bytes rather than lines × bytes-per-line: collapsing carriage-return
-# redraws (see _tail_lines) turns tens of kilobytes of progress bar into one
-# line, so a window derived from the line count comes back nearly empty.
+# Bytes read back from the end of a log before taking its trailing lines. In
+# bytes, not lines × bytes-per-line: collapsing carriage-return redraws (see
+# _tail_lines) can turn tens of kilobytes into one line, emptying such a window.
 _LOG_TAIL_WINDOW_BYTES = 256 * 1024
 
 ProgressCallback = Callable[[float, str], None]
@@ -56,15 +55,12 @@ def _tail_lines(text: str) -> list[str]:
     """Split *text* into log lines, one per line the engine actually wrote.
 
     ``str.splitlines`` splits on ``\\r`` as well as ``\\n``, so a progress bar
-    redrawn with carriage returns costs one "line" per frame. Engines redraw
-    weight-loading bars this way even when stdout is a redirected file, which
-    is enough to spend a whole tail window on redraws of a single bar and bury
-    the traceback the log was read for. Split on ``\\n`` only and keep each
-    line's last frame — what a terminal would have shown.
+    redrawn with carriage returns costs one "line" per frame — enough to spend
+    a whole tail window on one bar and bury the traceback it was read for.
+    Split on ``\\n`` only and keep each line's last frame, as a terminal would.
 
-    The trailing ``\\r`` of a CRLF line is stripped first; taking the last
-    frame of ``"line1\\r"`` would otherwise yield ``""`` and drop every line
-    of a CRLF log.
+    The trailing ``\\r`` of a CRLF line is stripped first, or the last frame of
+    ``"line1\\r"`` is ``""`` and every line of a CRLF log drops.
     """
     return [line.rstrip("\r").rsplit("\r", 1)[-1] for line in text.split("\n")]
 
@@ -150,17 +146,12 @@ class LocalDeployer:
         if cmd.env:
             env = {**os.environ, **cmd.env}
 
-        # Resolve the executable before spawning. Without this the failure is a
-        # bare FileNotFoundError from Popen that names neither the role nor the
-        # command, and it is indistinguishable from a missing working_dir.
-        # Resolve it exactly the way Popen will, or the check rejects commands
-        # that would have launched: a bare name is looked up in the *child's*
-        # PATH (subprocess uses os.get_exec_path(env), so cmd.env wins), and a
-        # name carrying a directory is relative to cwd — cmd.working_dir, not
-        # this process's.
-        # This runs before the log directory and the "Logging to" line, so a
-        # rejected launch neither creates a directory for a process that never
-        # starts nor names a log path that will never exist.
+        # Popen would raise a bare FileNotFoundError naming neither the role nor
+        # the command. Resolve exactly as it does, or this rejects launches that
+        # would have worked: a bare name against the *child's* PATH
+        # (os.get_exec_path(env)), anything else against cmd.working_dir.
+        # Runs before the log dir and the "Logging to" line, so a rejected
+        # launch creates no directory and names no path that will never exist.
         executable = cmd.cli_args[0] if cmd.cli_args else ""
         search_path = (env or os.environ).get("PATH")
         probe = executable
@@ -168,15 +159,14 @@ class LocalDeployer:
             probe = os.path.join(cmd.working_dir, executable)
 
         if not shutil.which(probe, path=search_path):
-            # which() also rejects a file that exists but is not executable,
-            # where Popen raises PermissionError, not FileNotFoundError.
+            # which() also rejects a present but non-executable file, where
+            # Popen raises PermissionError — a different finding.
             if shutil.which(probe, mode=os.F_OK, path=search_path):
                 problem = "is not executable"
             elif os.path.dirname(probe) and os.path.isdir(probe):
-                # which() rejects a directory under F_OK too, so without this
-                # branch a directory reads as absent while Popen would raise
-                # PermissionError. Guarded on dirname: for a bare name this
-                # path is not what Popen would have run anyway.
+                # which() rejects a directory under F_OK too, so it would read
+                # as absent though Popen raises PermissionError. Guarded on
+                # dirname: for a bare name this is not what Popen would run.
                 problem = f"is a directory, not an executable: {probe!r}"
             elif os.path.dirname(probe):
                 problem = f"does not exist at {probe!r}"
@@ -391,18 +381,16 @@ class LocalDeployer:
                 if ready and ready.status:
                     ready_str = "ready"
                 else:
-                    # The reason separates "still loading" (connection_refused)
-                    # from "up but unhealthy" (health_check_failed) — the one
-                    # bit that decides whether waiting longer can help.
+                    # connection_refused (still loading) vs health_check_failed
+                    # (up, unhealthy) decides whether waiting longer can help.
                     ready_str = phase.value
                     if ready and ready.reason:
                         ready_str += f"({ready.reason})"
                 summary_parts.append(f"{role}={ready_str}")
 
                 if phase in (InferPhase.FAILED, InferPhase.STOPPED):
-                    # Same quoting as the timeout path: a crash needs the log
-                    # path and the launch command for the same reason a hang
-                    # does — the log is written outside the run directory.
+                    # Same block as the timeout path — the log sits outside the
+                    # run directory either way.
                     msg = f"Process {handle.handle_id} ({role}) {phase.value}"
                     msg += await self._quote_logs([handle])
                     raise DeployError(msg)
@@ -421,22 +409,19 @@ class LocalDeployer:
             if anyio.current_time() >= deadline:
                 summary = ", ".join(summary_parts)
                 msg = f"Not all processes ready within {timeout}s ({summary})"
-                # A timeout is the common failure and used to be the only one
-                # that discarded the engine's own log. The process is about to
-                # be killed and its log lives outside the run directory, so if
-                # we do not quote it here it is usually gone for good.
+                # The process is about to be killed and its log lives outside
+                # the run directory, so not quoting it here usually loses it.
                 msg += await self._quote_logs(not_ready)
                 raise DeployTimeoutError(msg)
 
             await anyio.sleep(poll_interval)
 
     async def _quote_logs(self, handles: list[InferHandle]) -> str:
-        """Quote the log of each of *handles* for an error message.
+        """Quote each handle's log tail, path and launch command.
 
-        Returns a block to append, empty when *handles* is. Always names the
-        log path: an empty tail is itself a finding (the engine wrote nothing),
-        and the path is the only way to reach a log that is written outside the
-        run directory.
+        Returns a block to append, empty when *handles* is. The path prints even
+        with no tail: an engine that logged nothing is itself a finding, and the
+        log sits outside the run directory.
         """
         blocks: list[str] = []
         for handle in handles:
@@ -444,8 +429,7 @@ class LocalDeployer:
             log_file = handle.metadata.get("log_file", "")
             launched = handle.metadata.get("cmd")
             header = f"--- {role} (pid {handle.handle_id})"
-            # metadata values are not typed as sequences; a str would join
-            # character by character, so narrow rather than truth-test.
+            # MetadataValue admits str, which would join character by character.
             if isinstance(launched, list):
                 header += f" cmd: {' '.join(str(a) for a in launched)}"
             header += f"\n    log: {log_file or '?'}"

--- a/sieval/infer/deployer.py
+++ b/sieval/infer/deployer.py
@@ -12,6 +12,7 @@ import importlib
 import json
 import os
 import platform
+import shutil
 import signal
 import subprocess
 from collections.abc import AsyncIterator, Callable
@@ -129,6 +130,17 @@ class LocalDeployer:
 
         logger.info("Launching [{}]: {}", cmd.role, " ".join(cmd.cli_args))
         logger.info("Logging to {}", log_file)
+
+        # Resolve the executable before spawning. Without this the failure is a
+        # bare FileNotFoundError from Popen that names neither the role nor the
+        # command, and it is indistinguishable from a missing working_dir.
+        executable = cmd.cli_args[0] if cmd.cli_args else ""
+        if not shutil.which(executable):
+            raise DeployError(
+                f"Engine executable {executable!r} for role {cmd.role!r} was not "
+                f"found on PATH, so the process was never started and no log "
+                f"exists to inspect. Command: {' '.join(cmd.cli_args)}"
+            )
 
         env = None
         if cmd.env:
@@ -318,12 +330,21 @@ class LocalDeployer:
         while True:
             all_ready = True
             summary_parts: list[str] = []
+            not_ready: list[InferHandle] = []
 
             for handle in handles:
                 phase, conditions = await self.status(handle)
                 role = handle.metadata.get("role", "?")
                 ready = conditions.get("ready")
-                ready_str = "ready" if ready and ready.status else phase.value
+                if ready and ready.status:
+                    ready_str = "ready"
+                else:
+                    # The reason separates "still loading" (connection_refused)
+                    # from "up but unhealthy" (health_check_failed) — the one
+                    # bit that decides whether waiting longer can help.
+                    ready_str = phase.value
+                    if ready and ready.reason:
+                        ready_str += f"({ready.reason})"
                 summary_parts.append(f"{role}={ready_str}")
 
                 if phase in (InferPhase.FAILED, InferPhase.STOPPED):
@@ -335,6 +356,7 @@ class LocalDeployer:
 
                 if not (ready and ready.status):
                     all_ready = False
+                    not_ready.append(handle)
 
             elapsed = anyio.current_time() - start
             if on_progress:
@@ -346,9 +368,38 @@ class LocalDeployer:
             if anyio.current_time() >= deadline:
                 summary = ", ".join(summary_parts)
                 msg = f"Not all processes ready within {timeout}s ({summary})"
+                # A timeout is the common failure and used to be the only one
+                # that discarded the engine's own log. The process is about to
+                # be killed and its log lives outside the run directory, so if
+                # we do not quote it here it is usually gone for good.
+                msg += await self._quote_logs(not_ready)
                 raise DeployTimeoutError(msg)
 
             await anyio.sleep(poll_interval)
+
+    async def _quote_logs(self, handles: list[InferHandle]) -> str:
+        """Quote the log of each of *handles* for an error message.
+
+        Returns a block to append, empty when *handles* is. Always names the
+        log path: an empty tail is itself a finding (the engine wrote nothing),
+        and the path is the only way to reach a log that is written outside the
+        run directory.
+        """
+        blocks: list[str] = []
+        for handle in handles:
+            role = handle.metadata.get("role", "?")
+            log_file = handle.metadata.get("log_file", "")
+            launched = handle.metadata.get("cmd") or []
+            header = f"--- {role} (pid {handle.handle_id})"
+            if launched:
+                header += f" cmd: {' '.join(str(a) for a in launched)}"
+            header += f"\n    log: {log_file or '?'}"
+            tail = await self._read_tail(handle)
+            if tail:
+                blocks.append(header + " ---\n" + "\n".join(tail))
+            else:
+                blocks.append(header + " --- (empty)")
+        return "\n" + "\n".join(blocks) if blocks else ""
 
     async def _read_tail(
         self, handle: InferHandle, n: int = _FAILURE_LOG_TAIL

--- a/sieval/infer/deployer.py
+++ b/sieval/infer/deployer.py
@@ -131,20 +131,38 @@ class LocalDeployer:
         logger.info("Launching [{}]: {}", cmd.role, " ".join(cmd.cli_args))
         logger.info("Logging to {}", log_file)
 
-        # Resolve the executable before spawning. Without this the failure is a
-        # bare FileNotFoundError from Popen that names neither the role nor the
-        # command, and it is indistinguishable from a missing working_dir.
-        executable = cmd.cli_args[0] if cmd.cli_args else ""
-        if not shutil.which(executable):
-            raise DeployError(
-                f"Engine executable {executable!r} for role {cmd.role!r} was not "
-                f"found on PATH, so the process was never started and no log "
-                f"exists to inspect. Command: {' '.join(cmd.cli_args)}"
-            )
-
         env = None
         if cmd.env:
             env = {**os.environ, **cmd.env}
+
+        # Resolve the executable before spawning. Without this the failure is a
+        # bare FileNotFoundError from Popen that names neither the role nor the
+        # command, and it is indistinguishable from a missing working_dir.
+        # Resolve it exactly the way Popen will, or the check rejects commands
+        # that would have launched: a bare name is looked up in the *child's*
+        # PATH (subprocess uses os.get_exec_path(env), so cmd.env wins), and a
+        # name carrying a directory is relative to cwd — cmd.working_dir, not
+        # this process's.
+        executable = cmd.cli_args[0] if cmd.cli_args else ""
+        search_path = (env or os.environ).get("PATH")
+        probe = executable
+        if cmd.working_dir and os.path.dirname(executable):
+            probe = os.path.join(cmd.working_dir, executable)
+
+        if not shutil.which(probe, path=search_path):
+            # which() also rejects a file that exists but is not executable,
+            # where Popen raises PermissionError, not FileNotFoundError.
+            if shutil.which(probe, mode=os.F_OK, path=search_path):
+                problem = "is not executable"
+            elif os.path.dirname(probe):
+                problem = f"does not exist at {probe!r}"
+            else:
+                problem = "was not found on PATH"
+            raise DeployError(
+                f"Engine executable {executable!r} for role {cmd.role!r} "
+                f"{problem}, so the process was never started and no log "
+                f"exists to inspect. Command: {' '.join(cmd.cli_args)}"
+            )
 
         with open(log_file, "a") as fh:
             process = subprocess.Popen(
@@ -348,10 +366,11 @@ class LocalDeployer:
                 summary_parts.append(f"{role}={ready_str}")
 
                 if phase in (InferPhase.FAILED, InferPhase.STOPPED):
-                    tail = await self._read_tail(handle)
+                    # Same quoting as the timeout path: a crash needs the log
+                    # path and the launch command for the same reason a hang
+                    # does — the log is written outside the run directory.
                     msg = f"Process {handle.handle_id} ({role}) {phase.value}"
-                    if tail:
-                        msg += f"\n--- last {len(tail)} lines ---\n" + "\n".join(tail)
+                    msg += await self._quote_logs([handle])
                     raise DeployError(msg)
 
                 if not (ready and ready.status):

--- a/sieval/infer/deployer.py
+++ b/sieval/infer/deployer.py
@@ -389,9 +389,11 @@ class LocalDeployer:
         for handle in handles:
             role = handle.metadata.get("role", "?")
             log_file = handle.metadata.get("log_file", "")
-            launched = handle.metadata.get("cmd") or []
+            launched = handle.metadata.get("cmd")
             header = f"--- {role} (pid {handle.handle_id})"
-            if launched:
+            # metadata values are not typed as sequences; a str would join
+            # character by character, so narrow rather than truth-test.
+            if isinstance(launched, list):
                 header += f" cmd: {' '.join(str(a) for a in launched)}"
             header += f"\n    log: {log_file or '?'}"
             tail = await self._read_tail(handle)

--- a/sieval/infer/deployer.py
+++ b/sieval/infer/deployer.py
@@ -43,8 +43,30 @@ _HEALTH_CHECK_TIMEOUT = 2.0
 _GRACEFUL_SHUTDOWN_TIMEOUT = 10.0
 _LOG_DIR = Path.home() / ".sieval" / "logs"
 _FAILURE_LOG_TAIL = 30
+# Bytes read back from the end of a log before taking its trailing lines.
+# Sized in bytes rather than lines × bytes-per-line: collapsing carriage-return
+# redraws (see _tail_lines) turns tens of kilobytes of progress bar into one
+# line, so a window derived from the line count comes back nearly empty.
+_LOG_TAIL_WINDOW_BYTES = 256 * 1024
 
 ProgressCallback = Callable[[float, str], None]
+
+
+def _tail_lines(text: str) -> list[str]:
+    """Split *text* into log lines, one per line the engine actually wrote.
+
+    ``str.splitlines`` splits on ``\\r`` as well as ``\\n``, so a progress bar
+    redrawn with carriage returns costs one "line" per frame. Engines redraw
+    weight-loading bars this way even when stdout is a redirected file, which
+    is enough to spend a whole tail window on redraws of a single bar and bury
+    the traceback the log was read for. Split on ``\\n`` only and keep each
+    line's last frame — what a terminal would have shown.
+
+    The trailing ``\\r`` of a CRLF line is stripped first; taking the last
+    frame of ``"line1\\r"`` would otherwise yield ``""`` and drop every line
+    of a CRLF log.
+    """
+    return [line.rstrip("\r").rsplit("\r", 1)[-1] for line in text.split("\n")]
 
 
 class DeployError(Exception):
@@ -124,13 +146,6 @@ class LocalDeployer:
 
     async def _launch_one(self, cmd: BackendCommand) -> InferHandle:
         """Launch a single subprocess from a BackendCommand."""
-        _LOG_DIR.mkdir(parents=True, exist_ok=True)
-        ts = datetime.now(UTC).strftime("%Y-%m-%d_%H-%M-%S")
-        log_file = _LOG_DIR / f"{cmd.role}-{ts}.log"
-
-        logger.info("Launching [{}]: {}", cmd.role, " ".join(cmd.cli_args))
-        logger.info("Logging to {}", log_file)
-
         env = None
         if cmd.env:
             env = {**os.environ, **cmd.env}
@@ -143,6 +158,9 @@ class LocalDeployer:
         # PATH (subprocess uses os.get_exec_path(env), so cmd.env wins), and a
         # name carrying a directory is relative to cwd — cmd.working_dir, not
         # this process's.
+        # This runs before the log directory and the "Logging to" line, so a
+        # rejected launch neither creates a directory for a process that never
+        # starts nor names a log path that will never exist.
         executable = cmd.cli_args[0] if cmd.cli_args else ""
         search_path = (env or os.environ).get("PATH")
         probe = executable
@@ -154,6 +172,12 @@ class LocalDeployer:
             # where Popen raises PermissionError, not FileNotFoundError.
             if shutil.which(probe, mode=os.F_OK, path=search_path):
                 problem = "is not executable"
+            elif os.path.dirname(probe) and os.path.isdir(probe):
+                # which() rejects a directory under F_OK too, so without this
+                # branch a directory reads as absent while Popen would raise
+                # PermissionError. Guarded on dirname: for a bare name this
+                # path is not what Popen would have run anyway.
+                problem = f"is a directory, not an executable: {probe!r}"
             elif os.path.dirname(probe):
                 problem = f"does not exist at {probe!r}"
             else:
@@ -163,6 +187,13 @@ class LocalDeployer:
                 f"{problem}, so the process was never started and no log "
                 f"exists to inspect. Command: {' '.join(cmd.cli_args)}"
             )
+
+        _LOG_DIR.mkdir(parents=True, exist_ok=True)
+        ts = datetime.now(UTC).strftime("%Y-%m-%d_%H-%M-%S")
+        log_file = _LOG_DIR / f"{cmd.role}-{ts}.log"
+
+        logger.info("Launching [{}]: {}", cmd.role, " ".join(cmd.cli_args))
+        logger.info("Logging to {}", log_file)
 
         with open(log_file, "a") as fh:
             process = subprocess.Popen(
@@ -300,19 +331,21 @@ class LocalDeployer:
             return
 
         # Read only the tail portion instead of the entire file.
-        # 256 bytes/line is a generous estimate for log lines.
-        chunk_size = tail * 256
+        chunk_size = max(tail * 256, _LOG_TAIL_WINDOW_BYTES)
         async with await anyio.open_file(path, "rb") as f:
             file_size = await f.seek(0, 2)  # seek to end
             read_start = max(0, file_size - chunk_size)
             await f.seek(read_start)
             raw = await f.read()
 
-        text = raw.decode(errors="replace")
-        lines = text.splitlines()
+        lines = _tail_lines(raw.decode(errors="replace"))
         # If we didn't read from the start, the first line may be partial — drop it.
         if read_start > 0 and lines:
             lines = lines[1:]
+        # split("\n") leaves a trailing "" for a newline-terminated file, which
+        # splitlines() did not; it would otherwise consume one of `tail` slots.
+        if lines and not lines[-1]:
+            lines = lines[:-1]
         for line in lines[-tail:]:
             yield line
 
@@ -330,8 +363,9 @@ class LocalDeployer:
                 return
             if new_raw:
                 offset += len(new_raw)
-                for line in new_raw.decode(errors="replace").splitlines():
-                    yield line
+                for line in _tail_lines(new_raw.decode(errors="replace")):
+                    if line:
+                        yield line
 
     async def _poll_all_until_ready(
         self,
@@ -433,8 +467,7 @@ class LocalDeployer:
         if not path.exists():
             return []
         try:
-            # Estimate: 256 bytes/line is generous for log lines
-            chunk_size = n * 256
+            chunk_size = max(n * 256, _LOG_TAIL_WINDOW_BYTES)
             async with await anyio.open_file(path, "rb") as f:
                 file_size = await f.seek(0, 2)
                 read_start = max(0, file_size - chunk_size)
@@ -442,7 +475,7 @@ class LocalDeployer:
                 raw = await f.read()
             lines = [
                 line
-                for line in raw.decode(errors="replace").splitlines()
+                for line in _tail_lines(raw.decode(errors="replace"))
                 if line.strip()
             ]
             # Drop first line if partial (didn't read from start)

--- a/tests/unit/infer/test_deployer.py
+++ b/tests/unit/infer/test_deployer.py
@@ -93,6 +93,62 @@ class TestLaunchOne:
         assert "full" in message
 
     @pytest.mark.anyio
+    async def test_rejected_launch_creates_no_log_dir_and_names_no_log(
+        self, tmp_path: Path
+    ):
+        """A launch the gate rejects must leave nothing behind and promise nothing.
+
+        Running the gate after the log directory is created and after "Logging
+        to <path>" is printed hands the operator a path that will never exist,
+        immediately before an error saying no log exists to inspect.
+        """
+        log_dir = tmp_path / "logs"
+        deployer = LocalDeployer()
+        cmd = BackendCommand(
+            cli_args=["sglang-not-installed", "serve"],
+            backend="sglang",
+            role="full",
+            health_url="http://localhost:30000/health",
+        )
+
+        with (
+            patch("sieval.infer.deployer._LOG_DIR", log_dir),
+            patch("sieval.infer.deployer.logger") as mock_logger,
+            pytest.raises(DeployError),
+        ):
+            await deployer._launch_one(cmd)
+
+        assert not log_dir.exists()
+        logged = " ".join(str(call) for call in mock_logger.info.call_args_list)
+        assert "Logging to" not in logged
+
+    @pytest.mark.anyio
+    async def test_directory_is_not_reported_as_absent(self, tmp_path: Path):
+        """A directory at the engine path exists — saying otherwise misleads.
+
+        ``shutil.which`` rejects a directory under ``F_OK`` too, so without an
+        explicit branch it falls through to "does not exist at", while Popen
+        raises PermissionError. Same misdiagnosis class the gate prevents.
+        """
+        engine_dir = tmp_path / "sglang"
+        engine_dir.mkdir()
+
+        deployer = LocalDeployer()
+        cmd = BackendCommand(
+            cli_args=[str(engine_dir), "serve"],
+            backend="sglang",
+            role="full",
+            health_url="http://localhost:30000/health",
+        )
+
+        with pytest.raises(DeployError) as excinfo:
+            await deployer._launch_one(cmd)
+
+        message = str(excinfo.value)
+        assert "is a directory" in message
+        assert "does not exist" not in message
+
+    @pytest.mark.anyio
     async def test_engine_on_a_cmd_env_path_is_not_rejected(self, tmp_path: Path):
         """An engine reachable only via cmd.env's PATH must still launch.
 
@@ -566,6 +622,26 @@ class TestLogs:
         assert lines[-1] == "line5"
 
     @pytest.mark.anyio
+    async def test_logs_collapses_progress_bar_redraws(self, tmp_path: Path):
+        """`sieval infer logs` hits the same redraw problem as the error tail.
+
+        It is the hand-driven route to the very log a failed deploy quotes, so
+        a --tail spent on redraws of one bar fails the operator the same way.
+        """
+        log_file = tmp_path / "engine.log"
+        log_file.write_text(
+            "real line 1\nreal line 2\n"
+            + "".join(f"\rLoading shards: {pct}%" for pct in range(101))
+        )
+
+        deployer = LocalDeployer()
+        handle = _make_handle(log_file=str(log_file))
+        lines = [line async for line in deployer.logs(handle, tail=3)]
+
+        assert "real line 1" in lines
+        assert sum("Loading shards" in line for line in lines) == 1
+
+    @pytest.mark.anyio
     async def test_logs_no_file(self):
         deployer = LocalDeployer()
         handle = _make_handle(log_file="/nonexistent/path.log")
@@ -597,18 +673,21 @@ class TestLogs:
         """Large files: seek near end and drop partial first line."""
         deployer = LocalDeployer()
         log_file = tmp_path / "big.log"
-        # Write a file large enough that chunk_size < file_size (triggers seek)
-        # tail=3, chunk_size=3*256=768. Write >768 bytes.
+        # Write a file large enough that chunk_size < file_size (triggers seek).
         many_lines = [f"log line {i}: " + "x" * 200 for i in range(10)]
         log_file.write_text("\n".join(many_lines) + "\n")
 
         handle = _make_handle(log_file=str(log_file))
         lines = []
-        async for line in deployer.logs(handle, tail=3):
-            lines.append(line)
+        # The read window is sized in bytes, so it must be narrowed here or the
+        # whole file fits and neither the seek nor the partial-drop path runs.
+        with patch("sieval.infer.deployer._LOG_TAIL_WINDOW_BYTES", 768):
+            async for line in deployer.logs(handle, tail=3):
+                lines.append(line)
 
         assert len(lines) == 3
         assert "log line 9" in lines[-1]
+        assert not any("log line 0" in line for line in lines)
 
 
 # ---------- deploy (integration-level, mocked) ----------
@@ -933,16 +1012,84 @@ class TestReadTail:
         """For large files, _read_tail should seek near the end, not read all."""
         deployer = LocalDeployer()
         log_file = tmp_path / "big.log"
-        # Write a file large enough that the seek-based read kicks in
-        # n=5 with 256 bytes/line = 1280 byte chunk. Write >1280 bytes.
+        # Write a file large enough that the seek-based read kicks in.
         many_lines = [f"log line {i}: " + "x" * 200 for i in range(20)]
         log_file.write_text("\n".join(many_lines) + "\n")
 
         handle = _make_handle(log_file=str(log_file))
-        lines = await deployer._read_tail(handle, n=5)
+        # The read window is sized in bytes, so it must be narrowed here or the
+        # whole file fits and the seek path never runs.
+        with patch("sieval.infer.deployer._LOG_TAIL_WINDOW_BYTES", 1280):
+            lines = await deployer._read_tail(handle, n=5)
         assert len(lines) == 5
         # Should contain the last lines
         assert "log line 19" in lines[-1]
+        assert not any("log line 0" in line for line in lines)
+
+    @pytest.mark.anyio
+    async def test_read_tail_keeps_the_error_under_progress_bar_redraws(
+        self, tmp_path: Path
+    ):
+        """A redrawn progress bar must not push the traceback out of the tail.
+
+        Engines redraw weight-loading bars with carriage returns even when
+        stdout is a redirected file, and with ``--dp-size N`` the children that
+        did *not* die keep redrawing into the same log after the one that did
+        has printed its traceback. Counting each frame as a line spends the
+        whole window on redraws of a single bar and buries the only evidence
+        the quoted tail exists to carry.
+        """
+        log_file = tmp_path / "engine.log"
+        log_file.write_text(
+            "[08:45:50] server args: dp_size=4\n"
+            "[08:46:02] Scheduler hit an exception: Traceback "
+            "(most recent call last):\n"
+            "ImportError: /usr/lib/sgl_kernel.so: undefined symbol\n"
+            + "".join(
+                f"\rLoading safetensors checkpoint shards: {pct:3d}% "
+                f"Completed | {pct}/100 [00:{pct:02d}<00:00, 1.9it/s]"
+                for pct in range(101)
+            )
+        )
+
+        deployer = LocalDeployer()
+        handle = _make_handle(log_file=str(log_file))
+        lines = await deployer._read_tail(handle)
+
+        assert any("ImportError" in line for line in lines)
+        # The bar collapses to its final frame rather than 101 of them.
+        assert sum("Loading safetensors" in line for line in lines) == 1
+
+    @pytest.mark.anyio
+    async def test_read_tail_collapses_a_redrawn_line_to_its_last_frame(
+        self, tmp_path: Path
+    ):
+        """One carriage-return-redrawn line is one line: its final frame."""
+        log_file = tmp_path / "bar.log"
+        log_file.write_text("before\nstep 1\rstep 2\rstep 3\nafter\n")
+
+        deployer = LocalDeployer()
+        handle = _make_handle(log_file=str(log_file))
+        lines = await deployer._read_tail(handle)
+
+        assert lines == ["before", "step 3", "after"]
+
+    @pytest.mark.anyio
+    async def test_read_tail_handles_crlf_line_endings(self, tmp_path: Path):
+        """CRLF must not collapse to empty when splitting on \\n.
+
+        Splitting on ``\\n`` leaves a trailing ``\\r`` on every CRLF line, and
+        taking the last carriage-return frame of ``"line1\\r"`` yields ``""``
+        — which would silently drop every line of a CRLF log.
+        """
+        log_file = tmp_path / "crlf.log"
+        log_file.write_bytes(b"line1\r\nline2\r\nline3\r\n")
+
+        deployer = LocalDeployer()
+        handle = _make_handle(log_file=str(log_file))
+        lines = await deployer._read_tail(handle)
+
+        assert lines == ["line1", "line2", "line3"]
 
     @pytest.mark.anyio
     async def test_read_tail_no_file(self):

--- a/tests/unit/infer/test_deployer.py
+++ b/tests/unit/infer/test_deployer.py
@@ -71,12 +71,7 @@ def _make_command(
 class TestLaunchOne:
     @pytest.mark.anyio
     async def test_missing_executable_names_the_binary(self):
-        """A missing engine binary must be reported as such.
-
-        Popen would raise a bare FileNotFoundError naming neither the role nor
-        the command, and indistinguishable from a missing working_dir — while
-        the operator's real question is whether the engine is installed.
-        """
+        """Popen's bare FileNotFoundError names neither the role nor the cmd."""
         deployer = LocalDeployer()
         cmd = BackendCommand(
             cli_args=["sglang-not-installed", "serve", "--port", "30000"],
@@ -96,12 +91,7 @@ class TestLaunchOne:
     async def test_rejected_launch_creates_no_log_dir_and_names_no_log(
         self, tmp_path: Path
     ):
-        """A launch the gate rejects must leave nothing behind and promise nothing.
-
-        Running the gate after the log directory is created and after "Logging
-        to <path>" is printed hands the operator a path that will never exist,
-        immediately before an error saying no log exists to inspect.
-        """
+        """A rejected launch must create no log dir and name no log path."""
         log_dir = tmp_path / "logs"
         deployer = LocalDeployer()
         cmd = BackendCommand(
@@ -124,12 +114,7 @@ class TestLaunchOne:
 
     @pytest.mark.anyio
     async def test_directory_is_not_reported_as_absent(self, tmp_path: Path):
-        """A directory at the engine path exists — saying otherwise misleads.
-
-        ``shutil.which`` rejects a directory under ``F_OK`` too, so without an
-        explicit branch it falls through to "does not exist at", while Popen
-        raises PermissionError. Same misdiagnosis class the gate prevents.
-        """
+        """which() rejects a directory under F_OK, so it must not read absent."""
         engine_dir = tmp_path / "sglang"
         engine_dir.mkdir()
 
@@ -150,13 +135,7 @@ class TestLaunchOne:
 
     @pytest.mark.anyio
     async def test_engine_on_a_cmd_env_path_is_not_rejected(self, tmp_path: Path):
-        """An engine reachable only via cmd.env's PATH must still launch.
-
-        Popen resolves a bare argv[0] against the *child's* PATH, so a plan
-        whose ``env:`` points PATH at the prefix holding the engine works.
-        Probing this process's PATH instead would reject it before launch and
-        report the engine as absent when it is installed.
-        """
+        """Popen resolves argv[0] against the child's PATH, so cmd.env wins."""
         engine = tmp_path / "sglang"
         engine.write_text("#!/bin/sh\nsleep 60\n")
         engine.chmod(0o755)
@@ -183,12 +162,7 @@ class TestLaunchOne:
     async def test_present_but_non_executable_is_not_called_missing(
         self, tmp_path: Path
     ):
-        """A non-executable engine must not be reported as absent.
-
-        Popen raises PermissionError there, not FileNotFoundError, and telling
-        the operator it is "not found on PATH" sends them to install a binary
-        that is already sitting in front of them.
-        """
+        """Popen raises PermissionError here, so reporting it absent misleads."""
         engine = tmp_path / "sglang"
         engine.write_text("#!/bin/sh\nsleep 60\n")
         engine.chmod(0o644)
@@ -213,12 +187,7 @@ class TestLaunchOne:
     async def test_relative_executable_resolves_against_working_dir(
         self, tmp_path: Path
     ):
-        """A relative argv[0] is resolved against working_dir, as Popen does.
-
-        Popen(cwd=...) resolves a name carrying a directory relative to that
-        cwd, so probing it relative to the deployer's own cwd would reject a
-        launch that works.
-        """
+        """Popen(cwd=...) resolves a relative argv[0] there, not against ours."""
         (tmp_path / "bin").mkdir()
         engine = tmp_path / "bin" / "sglang"
         engine.write_text("#!/bin/sh\nsleep 60\n")
@@ -623,11 +592,7 @@ class TestLogs:
 
     @pytest.mark.anyio
     async def test_logs_collapses_progress_bar_redraws(self, tmp_path: Path):
-        """`sieval infer logs` hits the same redraw problem as the error tail.
-
-        It is the hand-driven route to the very log a failed deploy quotes, so
-        a --tail spent on redraws of one bar fails the operator the same way.
-        """
+        """`sieval infer logs` reads the same log, so it must split the same."""
         log_file = tmp_path / "engine.log"
         log_file.write_text(
             "real line 1\nreal line 2\n"
@@ -819,12 +784,7 @@ class TestDeploy:
 
     @pytest.mark.anyio
     async def test_deploy_timeout_quotes_engine_log(self, tmp_path: Path):
-        """A timeout must quote the engine log, like a crash already does.
-
-        The engine's log is written outside the run directory and the process
-        is killed on the way out, so a timeout that does not quote it usually
-        leaves no evidence of why the server never came up.
-        """
+        """The process is killed on the way out; unquoted, its log is lost."""
         log_file = tmp_path / "full.log"
         log_file.write_text("Loading weights...\nCUDA out of memory\n")
         deployer = LocalDeployer()
@@ -937,9 +897,7 @@ class TestDeploy:
         ):
             await deployer.deploy([cmd], detach=False, poll_interval=0.01)
 
-        # A crash quotes the same block a timeout does: tail, log path and the
-        # launch command. The log is written outside the run directory, so the
-        # path is no more discoverable after a crash than after a hang.
+        # A crash quotes the same block as a timeout: tail, log path, command.
         message = str(excinfo.value)
         assert "ERROR: out of memory" in message
         assert "/tmp/test.log" in message
@@ -986,8 +944,7 @@ class TestDeploy:
         assert len(progress_calls) >= 1
         # Each callback gets (elapsed_seconds, summary_string)
         assert "full=" in progress_calls[0][1]
-        # The not-ready reason rides along, so a run's own log says whether
-        # the engine is still loading or already answering unhealthily.
+        # The not-ready reason rides along, not just the phase.
         assert "health_check_failed" in progress_calls[0][1]
 
 
@@ -1032,12 +989,8 @@ class TestReadTail:
     ):
         """A redrawn progress bar must not push the traceback out of the tail.
 
-        Engines redraw weight-loading bars with carriage returns even when
-        stdout is a redirected file, and with ``--dp-size N`` the children that
-        did *not* die keep redrawing into the same log after the one that did
-        has printed its traceback. Counting each frame as a line spends the
-        whole window on redraws of a single bar and buries the only evidence
-        the quoted tail exists to carry.
+        Counting each carriage-return frame as a line spends the whole window
+        on one bar and buries the evidence the tail exists to carry.
         """
         log_file = tmp_path / "engine.log"
         log_file.write_text(
@@ -1076,12 +1029,7 @@ class TestReadTail:
 
     @pytest.mark.anyio
     async def test_read_tail_handles_crlf_line_endings(self, tmp_path: Path):
-        """CRLF must not collapse to empty when splitting on \\n.
-
-        Splitting on ``\\n`` leaves a trailing ``\\r`` on every CRLF line, and
-        taking the last carriage-return frame of ``"line1\\r"`` yields ``""``
-        — which would silently drop every line of a CRLF log.
-        """
+        """The last frame of ``"line1\\r"`` is ``""`` — CRLF must not vanish."""
         log_file = tmp_path / "crlf.log"
         log_file.write_bytes(b"line1\r\nline2\r\nline3\r\n")
 

--- a/tests/unit/infer/test_deployer.py
+++ b/tests/unit/infer/test_deployer.py
@@ -7,6 +7,7 @@ avoid spawning real processes.
 AI-Generated Code - Claude Opus 4.6 (Anthropic)
 """
 
+import os
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -90,6 +91,100 @@ class TestLaunchOne:
         assert "sglang-not-installed" in message
         assert "PATH" in message
         assert "full" in message
+
+    @pytest.mark.anyio
+    async def test_engine_on_a_cmd_env_path_is_not_rejected(self, tmp_path: Path):
+        """An engine reachable only via cmd.env's PATH must still launch.
+
+        Popen resolves a bare argv[0] against the *child's* PATH, so a plan
+        whose ``env:`` points PATH at the prefix holding the engine works.
+        Probing this process's PATH instead would reject it before launch and
+        report the engine as absent when it is installed.
+        """
+        engine = tmp_path / "sglang"
+        engine.write_text("#!/bin/sh\nsleep 60\n")
+        engine.chmod(0o755)
+
+        deployer = LocalDeployer()
+        cmd = BackendCommand(
+            cli_args=["sglang", "serve", "--port", "30000"],
+            backend="sglang",
+            role="full",
+            env={"PATH": f"{tmp_path}:{os.environ['PATH']}"},
+            health_url="http://localhost:30000/health",
+        )
+
+        with (
+            patch("sieval.infer.deployer.subprocess.Popen") as mock_popen,
+            patch("sieval.infer.deployer._LOG_DIR", Path("/tmp")),
+        ):
+            mock_popen.return_value = MagicMock(pid=4242)
+            handle = await deployer._launch_one(cmd)
+
+        assert handle.handle_id == "4242"
+
+    @pytest.mark.anyio
+    async def test_present_but_non_executable_is_not_called_missing(
+        self, tmp_path: Path
+    ):
+        """A non-executable engine must not be reported as absent.
+
+        Popen raises PermissionError there, not FileNotFoundError, and telling
+        the operator it is "not found on PATH" sends them to install a binary
+        that is already sitting in front of them.
+        """
+        engine = tmp_path / "sglang"
+        engine.write_text("#!/bin/sh\nsleep 60\n")
+        engine.chmod(0o644)
+
+        deployer = LocalDeployer()
+        cmd = BackendCommand(
+            cli_args=["sglang", "serve"],
+            backend="sglang",
+            role="full",
+            env={"PATH": str(tmp_path)},
+            health_url="http://localhost:30000/health",
+        )
+
+        with pytest.raises(DeployError) as excinfo:
+            await deployer._launch_one(cmd)
+
+        message = str(excinfo.value)
+        assert "not executable" in message
+        assert "not found on PATH" not in message
+
+    @pytest.mark.anyio
+    async def test_relative_executable_resolves_against_working_dir(
+        self, tmp_path: Path
+    ):
+        """A relative argv[0] is resolved against working_dir, as Popen does.
+
+        Popen(cwd=...) resolves a name carrying a directory relative to that
+        cwd, so probing it relative to the deployer's own cwd would reject a
+        launch that works.
+        """
+        (tmp_path / "bin").mkdir()
+        engine = tmp_path / "bin" / "sglang"
+        engine.write_text("#!/bin/sh\nsleep 60\n")
+        engine.chmod(0o755)
+
+        deployer = LocalDeployer()
+        cmd = BackendCommand(
+            cli_args=["./bin/sglang", "serve"],
+            backend="sglang",
+            role="full",
+            working_dir=str(tmp_path),
+            health_url="http://localhost:30000/health",
+        )
+
+        with (
+            patch("sieval.infer.deployer.subprocess.Popen") as mock_popen,
+            patch("sieval.infer.deployer._LOG_DIR", Path("/tmp")),
+        ):
+            mock_popen.return_value = MagicMock(pid=777)
+            handle = await deployer._launch_one(cmd)
+
+        assert handle.handle_id == "777"
 
     @pytest.mark.anyio
     async def test_creates_handle_with_pid(self):
@@ -686,6 +781,8 @@ class TestDeploy:
         assert str(log_file) in message
         # The reason distinguishes "still loading" from "up but unhealthy".
         assert "connection_refused" in message
+        # The launch command makes a wrong or absent engine visible here too.
+        assert "test serve" in message
 
     @pytest.mark.anyio
     async def test_deploy_timeout_names_log_path_when_empty(self, tmp_path: Path):
@@ -757,9 +854,17 @@ class TestDeploy:
                 "delete",
                 new_callable=AsyncMock,
             ),
-            pytest.raises(DeployError, match="failed"),
+            pytest.raises(DeployError, match="failed") as excinfo,
         ):
             await deployer.deploy([cmd], detach=False, poll_interval=0.01)
+
+        # A crash quotes the same block a timeout does: tail, log path and the
+        # launch command. The log is written outside the run directory, so the
+        # path is no more discoverable after a crash than after a hang.
+        message = str(excinfo.value)
+        assert "ERROR: out of memory" in message
+        assert "/tmp/test.log" in message
+        assert "test serve" in message
 
     @pytest.mark.anyio
     async def test_deploy_progress_callback(self):

--- a/tests/unit/infer/test_deployer.py
+++ b/tests/unit/infer/test_deployer.py
@@ -69,6 +69,29 @@ def _make_command(
 
 class TestLaunchOne:
     @pytest.mark.anyio
+    async def test_missing_executable_names_the_binary(self):
+        """A missing engine binary must be reported as such.
+
+        Popen would raise a bare FileNotFoundError naming neither the role nor
+        the command, and indistinguishable from a missing working_dir — while
+        the operator's real question is whether the engine is installed.
+        """
+        deployer = LocalDeployer()
+        cmd = BackendCommand(
+            cli_args=["sglang-not-installed", "serve", "--port", "30000"],
+            backend="sglang",
+            role="full",
+            health_url="http://localhost:30000/health",
+        )
+        with pytest.raises(DeployError) as excinfo:
+            await deployer._launch_one(cmd)
+
+        message = str(excinfo.value)
+        assert "sglang-not-installed" in message
+        assert "PATH" in message
+        assert "full" in message
+
+    @pytest.mark.anyio
     async def test_creates_handle_with_pid(self):
         """_launch_one should spawn a subprocess and return InferHandle."""
         deployer = LocalDeployer()
@@ -621,6 +644,87 @@ class TestDeploy:
             await deployer.deploy([cmd], detach=False, timeout=0.05, poll_interval=0.01)
 
     @pytest.mark.anyio
+    async def test_deploy_timeout_quotes_engine_log(self, tmp_path: Path):
+        """A timeout must quote the engine log, like a crash already does.
+
+        The engine's log is written outside the run directory and the process
+        is killed on the way out, so a timeout that does not quote it usually
+        leaves no evidence of why the server never came up.
+        """
+        log_file = tmp_path / "full.log"
+        log_file.write_text("Loading weights...\nCUDA out of memory\n")
+        deployer = LocalDeployer()
+        cmd = _make_command()
+
+        with (
+            patch.object(
+                deployer,
+                "_launch_one",
+                new_callable=AsyncMock,
+                return_value=_make_handle(log_file=str(log_file)),
+            ),
+            patch.object(
+                deployer,
+                "status",
+                new_callable=AsyncMock,
+                return_value=(
+                    InferPhase.RUNNING,
+                    {
+                        "ready": InferCondition(
+                            status=False, reason="connection_refused"
+                        )
+                    },
+                ),
+            ),
+            patch.object(deployer, "delete", new_callable=AsyncMock),
+            pytest.raises(DeployTimeoutError) as excinfo,
+        ):
+            await deployer.deploy([cmd], detach=False, timeout=0.05, poll_interval=0.01)
+
+        message = str(excinfo.value)
+        assert "CUDA out of memory" in message
+        assert str(log_file) in message
+        # The reason distinguishes "still loading" from "up but unhealthy".
+        assert "connection_refused" in message
+
+    @pytest.mark.anyio
+    async def test_deploy_timeout_names_log_path_when_empty(self, tmp_path: Path):
+        """An engine that logged nothing still gets its path named."""
+        log_file = tmp_path / "silent.log"
+        log_file.write_text("")
+        deployer = LocalDeployer()
+        cmd = _make_command()
+
+        with (
+            patch.object(
+                deployer,
+                "_launch_one",
+                new_callable=AsyncMock,
+                return_value=_make_handle(log_file=str(log_file)),
+            ),
+            patch.object(
+                deployer,
+                "status",
+                new_callable=AsyncMock,
+                return_value=(
+                    InferPhase.RUNNING,
+                    {
+                        "ready": InferCondition(
+                            status=False, reason="health_check_failed"
+                        )
+                    },
+                ),
+            ),
+            patch.object(deployer, "delete", new_callable=AsyncMock),
+            pytest.raises(DeployTimeoutError) as excinfo,
+        ):
+            await deployer.deploy([cmd], detach=False, timeout=0.05, poll_interval=0.01)
+
+        message = str(excinfo.value)
+        assert str(log_file) in message
+        assert "empty" in message
+
+    @pytest.mark.anyio
     async def test_deploy_process_died_raises(self):
         """Deploy should raise DeployError if a process dies during polling."""
         deployer = LocalDeployer()
@@ -698,6 +802,9 @@ class TestDeploy:
         assert len(progress_calls) >= 1
         # Each callback gets (elapsed_seconds, summary_string)
         assert "full=" in progress_calls[0][1]
+        # The not-ready reason rides along, so a run's own log says whether
+        # the engine is still loading or already answering unhealthily.
+        assert "health_check_failed" in progress_calls[0][1]
 
 
 # ---------- _read_tail ----------


### PR DESCRIPTION
## The gap

A readiness timeout is the only deploy failure that throws its evidence away.

A process that *crashes* raises `DeployError` carrying the engine's log tail. A process that stays alive and never answers `/health` raises this, and nothing else:

```
ERROR | sieval.cli.output - Not all processes ready within 300.0s (full=running)
```

Then the process is killed. The engine's log lives at `Path.home()/".sieval"/"logs"` — outside the run directory — so on an ephemeral worker the only record of *why* the server never came up is destroyed moments after the one message that failed to quote it. A wrapper that harvests results from the run dir keeps nothing.

`full=running` also understates what is known. `status()` computes a **reason** and the summary discards it:

```python
ready_str = "ready" if ready and ready.status else phase.value
```

`connection_refused` (still loading) and `health_check_failed` (up, but unhealthy) are the difference between "raise the timeout" and "the engine is broken", and neither reaches the operator.

This matters most for an engine that spawns subprocesses. With `--dp-size N`, sglang forks a scheduler per replica; when a child dies on a bad install the parent commonly goes on waiting, so the parent PID stays alive and the *only* trace of the real error is the child's traceback in that discarded log.

## Before / after

Before:

```
Not all processes ready within 300.0s (full=running)
```

After, same failure:

```
Not all processes ready within 300.0s (full=running(connection_refused))
--- full (pid 375) cmd: sglang serve --model-path /models/Qwen3-30B-A3B --port 30000 --dp-size 4
    log: /root/.sieval/logs/full-2026-09-01_08-45-45.log ---
[2026-09-01 16:45:50] server args: dp_size=4, mem_fraction_static=None
[2026-09-01 16:46:02] Scheduler hit an exception: Traceback (most recent call last):
  File "sglang/srt/managers/scheduler.py", line 1, in run_scheduler_process
ImportError: /usr/local/lib/python3.12/dist-packages/sgl_kernel.so: undefined symbol
```

The cause, the command that produced it, and where to look — none of which was reachable before.

## What the message now carries

1. **The timeout quotes each not-ready role's log tail, path, and launch command.** The path prints even when the tail is empty, because an engine that logged nothing is itself a finding and the path is not otherwise discoverable. The tail reuses the poll pass that just ran rather than re-probing `/health`.

2. **The not-ready reason rides along in the status summary**, so per-poll progress lines and the final error both distinguish still-loading from unhealthy.

3. **A crash quotes the same block as a timeout.** `FAILED`/`STOPPED` went through its own ad-hoc format that carried the tail but neither the log path nor the command. The log sits outside the run directory either way, so both paths now share `_quote_logs`.

## What was keeping that message from being true

4. **A redrawn progress bar evicted the traceback from the tail.** `str.splitlines()` splits on `\r` as well as `\n`, so a weight-loading bar redrawn with carriage returns cost one "line" per frame — engines do this even when stdout is a redirected file, and with `--dp-size N` the children that did not die keep redrawing after the one that did has printed its traceback. On a 9 KB log the entire 30-line window went to redraws of a single bar, and the `ImportError` this branch exists to surface was not in the message at all. Fixing the split alone was not enough: the read window was sized as lines × 256 bytes, so collapsing the frames made it come back nearly empty — the window is now a byte budget. `sieval infer logs` had the identical defect and is the hand-driven route to the same log, so both go through one `_tail_lines` helper.

5. **A missing engine executable is reported as such** — *a pre-flight gate, not only a message.* Previously `Popen` raised a bare `FileNotFoundError` naming neither the binary nor the role. Resolution mirrors `Popen` exactly, because a gate that resolves differently rejects launches that would have worked: a bare name is looked up in the **child's** PATH (`os.get_exec_path(env)`, so a plan's `env:` wins over ours), and a name carrying a directory is resolved against `working_dir`. A file that exists but is **not executable**, and a **directory** at the engine path, are each reported as themselves — `Popen` raises `PermissionError` in both cases, and sending an operator to install a binary already in front of them is the exact misdiagnosis this gate exists to prevent.

6. **The gate runs before the log directory exists.** It used to run after the directory was created and after `Logging to <path>` was printed, so a rejected launch left a directory behind for a process that never started and named a path that will never exist, one line before saying no log exists.

## Verification

- Full `tests/unit` — **6366 passed**, on top of the current `main`. `ruff` and `ty` clean repo-wide.
- Every behaviour above is pinned by a test confirmed to fail when the corresponding code is reverted — reverse-mutation, all mutants killed.
- The executable-gate resolution rules are checked against the real `_launch_one`, not only mocks: an engine reachable only through a plan's `env:` PATH launches, a genuinely absent binary is still caught, and a non-executable one is reported as non-executable.
- The final commit is prose only, and provably so: after stripping docstrings, the AST of both changed files is byte-identical to the commit before it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
