### PR TITLE
feat(infer): expose the readiness budget on run, and stop cutting it fine

### DIFF
--- a/sieval/cli/infer/commands.py
+++ b/sieval/cli/infer/commands.py
@@ -187,12 +187,11 @@ def infer_start(
     timeout: Annotated[
         float,
         typer.Option(
-            # `--timeout` stays primary for compatibility; `--ready-timeout`
-            # is the name `sieval run` uses, accepted here so one spelling
-            # works across both commands. See the min= note in cli/run.py.
+            # `--ready-timeout` is what `sieval run` calls this, accepted here
+            # so one spelling works on both; `--timeout` stays primary.
             "--timeout",
             "--ready-timeout",
-            min=1.0,
+            min=1.0,  # see cli/run.py
             help="Seconds to wait for ready",
         ),
     ] = DEFAULT_READY_TIMEOUT,

--- a/sieval/cli/infer/commands.py
+++ b/sieval/cli/infer/commands.py
@@ -33,7 +33,11 @@ from sieval.infer.config import (
     InferPhase,
     ParamValue,
 )
-from sieval.infer.deployer import DeployError, DeployTimeoutError
+from sieval.infer.deployer import (
+    DEFAULT_READY_TIMEOUT,
+    DeployError,
+    DeployTimeoutError,
+)
 from sieval.infer.params import merge_params
 from sieval.infer.recipes import capability_model_type
 from sieval.infer.topology.models import (
@@ -183,7 +187,7 @@ def infer_start(
     timeout: Annotated[
         float,
         typer.Option("--timeout", help="Seconds to wait for ready"),
-    ] = 300.0,
+    ] = DEFAULT_READY_TIMEOUT,
     name: Annotated[
         str | None,
         typer.Option("--name", "-n", help="Override handle name"),

--- a/sieval/cli/infer/commands.py
+++ b/sieval/cli/infer/commands.py
@@ -186,7 +186,15 @@ def infer_start(
     ] = OutputFormat.TEXT,
     timeout: Annotated[
         float,
-        typer.Option("--timeout", help="Seconds to wait for ready"),
+        typer.Option(
+            # `--timeout` stays primary for compatibility; `--ready-timeout`
+            # is the name `sieval run` uses, accepted here so one spelling
+            # works across both commands. See the min= note in cli/run.py.
+            "--timeout",
+            "--ready-timeout",
+            min=1.0,
+            help="Seconds to wait for ready",
+        ),
     ] = DEFAULT_READY_TIMEOUT,
     name: Annotated[
         str | None,

--- a/sieval/cli/infer/lifecycle.py
+++ b/sieval/cli/infer/lifecycle.py
@@ -21,7 +21,11 @@ from loguru import logger
 
 from sieval.infer.backends.translator import BackendCommand
 from sieval.infer.config import InferCondition, InferEnv, InferHandle, InferPhase
-from sieval.infer.deployer import LocalDeployer, collect_basic_env
+from sieval.infer.deployer import (
+    DEFAULT_READY_TIMEOUT,
+    LocalDeployer,
+    collect_basic_env,
+)
 
 HANDLE_DIR = Path.home() / ".sieval" / "handles"
 default_deployer = LocalDeployer()
@@ -184,7 +188,7 @@ async def launch_model(
     *,
     on_progress: Callable[[float, str], None] | None = None,
     detach: bool = False,
-    timeout: float = 300.0,
+    timeout: float = DEFAULT_READY_TIMEOUT,
     already_claimed: bool = False,
 ) -> tuple[list[InferHandle], InferEnv | None]:
     """Claim handle, deploy, collect env, and persist running state.

--- a/sieval/cli/run.py
+++ b/sieval/cli/run.py
@@ -385,9 +385,8 @@ def register_run_command(app: typer.Typer) -> None:
             float,
             typer.Option(
                 "--ready-timeout",
-                # A zero or negative budget makes the poll loop raise
-                # DeployTimeoutError on its first pass, which reads as a broken
-                # engine rather than a bad argument. Reject it at parse time.
+                # Zero or negative makes the poll loop time out on its first
+                # pass, so a bad argument reads as a broken engine.
                 min=1.0,
                 help=(
                     "Seconds to wait for each auto-served model to become "

--- a/sieval/cli/run.py
+++ b/sieval/cli/run.py
@@ -32,7 +32,7 @@ from sieval.core.utils.logging import configure_logging, log_user
 from sieval.infer.backends import get_translator
 from sieval.infer.backends.translator import BackendCommand, inject_user_env
 from sieval.infer.config import InferHandle
-from sieval.infer.deployer import LocalDeployer
+from sieval.infer.deployer import DEFAULT_READY_TIMEOUT, LocalDeployer
 from sieval.infer.recipes import capability_model_type
 from sieval.infer.topology import DeploymentPlan
 from sieval.infer.topology.resolver import auto_resolve_plan
@@ -177,6 +177,7 @@ async def _run_all(
     model: str | None = None,
     result_dir: str | None = None,
     deterministic: bool | None = None,
+    ready_timeout: float = DEFAULT_READY_TIMEOUT,
 ) -> dict[str, object]:
     """Orchestrate: start services -> run eval -> stop services.
 
@@ -291,6 +292,7 @@ async def _run_all(
                     backend=plan.backend,
                     deployer=deployer,
                     on_progress=_progress,
+                    timeout=ready_timeout,
                 )
             except FileExistsError:
                 msg = (
@@ -379,6 +381,16 @@ def register_run_command(app: typer.Typer) -> None:
                 ),
             ),
         ] = None,
+        ready_timeout: Annotated[
+            float,
+            typer.Option(
+                "--ready-timeout",
+                help=(
+                    "Seconds to wait for each auto-served model to become "
+                    "ready. Applies per model, not to the run as a whole."
+                ),
+            ),
+        ] = DEFAULT_READY_TIMEOUT,
         verbose: Annotated[
             bool,
             typer.Option("--verbose", "-v", help="Verbose output"),
@@ -444,6 +456,7 @@ def register_run_command(app: typer.Typer) -> None:
                 model=model,
                 result_dir=result_dir,
                 deterministic=deterministic,
+                ready_timeout=ready_timeout,
             )
 
         try:

--- a/sieval/cli/run.py
+++ b/sieval/cli/run.py
@@ -385,6 +385,10 @@ def register_run_command(app: typer.Typer) -> None:
             float,
             typer.Option(
                 "--ready-timeout",
+                # A zero or negative budget makes the poll loop raise
+                # DeployTimeoutError on its first pass, which reads as a broken
+                # engine rather than a bad argument. Reject it at parse time.
+                min=1.0,
                 help=(
                     "Seconds to wait for each auto-served model to become "
                     "ready. Applies per model, not to the run as a whole."

--- a/sieval/infer/deployer.py
+++ b/sieval/infer/deployer.py
@@ -39,15 +39,12 @@ from sieval.infer.topology.models import (
     deployment_plan_projection,
 )
 
-# Seconds to wait for a freshly launched engine to report ready. Generous by
-# design, because the two failure modes are not symmetric: a process that dies
-# is detected within a poll interval whatever this value is (phase STOPPED or
-# FAILED), so this budget only ever bounds a process that is alive and silent.
-# Setting it too low converts a slow-but-healthy cold start into a hard failure
-# that wastes the whole allocation; setting it too high only delays discovery of
-# a genuine hang. For scale, one cluster served the same 30B MoE checkpoint in
-# 77-82s with a warm page cache but 264s cold — against which the previous 300s
-# was not a budget but a coin toss.
+# Seconds to wait for a freshly launched engine to report ready. Generous
+# because the failure modes are not symmetric: a process that dies is caught
+# within a poll interval whatever this value is (STOPPED/FAILED), so this only
+# bounds one that is alive and silent. Too low fails a healthy cold start and
+# wastes the allocation; too high only delays discovery of a hang. One cluster
+# served the same 30B MoE in 77-82s warm but 264s cold, under the previous 300s.
 DEFAULT_READY_TIMEOUT = 900.0
 
 _HEALTH_CHECK_TIMEOUT = 2.0

--- a/sieval/infer/deployer.py
+++ b/sieval/infer/deployer.py
@@ -39,6 +39,17 @@ from sieval.infer.topology.models import (
     deployment_plan_projection,
 )
 
+# Seconds to wait for a freshly launched engine to report ready. Generous by
+# design, because the two failure modes are not symmetric: a process that dies
+# is detected within a poll interval whatever this value is (phase STOPPED or
+# FAILED), so this budget only ever bounds a process that is alive and silent.
+# Setting it too low converts a slow-but-healthy cold start into a hard failure
+# that wastes the whole allocation; setting it too high only delays discovery of
+# a genuine hang. For scale, one cluster served the same 30B MoE checkpoint in
+# 77-82s with a warm page cache but 264s cold — against which the previous 300s
+# was not a budget but a coin toss.
+DEFAULT_READY_TIMEOUT = 900.0
+
 _HEALTH_CHECK_TIMEOUT = 2.0
 _GRACEFUL_SHUTDOWN_TIMEOUT = 10.0
 _LOG_DIR = Path.home() / ".sieval" / "logs"
@@ -86,7 +97,7 @@ class LocalDeployer:
         commands: list[BackendCommand],
         *,
         detach: bool = False,
-        timeout: float = 300.0,
+        timeout: float = DEFAULT_READY_TIMEOUT,
         poll_interval: float = 5.0,
         on_progress: ProgressCallback | None = None,
     ) -> list[InferHandle]:

--- a/tests/unit/cli/test_run.py
+++ b/tests/unit/cli/test_run.py
@@ -132,11 +132,9 @@ class TestRunCommand:
     def test_ready_timeout_option_reaches_run_all(self, tmp_path: Path):
         """The typer option must arrive at ``_run_all``, not stop at the parser.
 
-        ``test_ready_timeout_reaches_the_deploy_call`` starts *at* ``_run_all``
-        and ``test_run_help_shows_ready_timeout`` stops at ``--help``; between
-        them sits the hand-off in ``register_run_command``. Dropping that one
-        line restores the original defect — an option the user can type that
-        never reaches the deployer — while leaving both neighbours green.
+        Its neighbours start *at* ``_run_all`` and stop at ``--help``; the
+        hand-off in ``register_run_command`` sits between them. Dropping that
+        one line restores the original defect and leaves both of them green.
         """
         config = tmp_path / "test.yaml"
         config.write_text("models: {}\ntasks: {}")
@@ -157,11 +155,10 @@ class TestRunCommand:
         assert await_args.kwargs["ready_timeout"] == 1234.0
 
     def test_ready_timeout_rejects_a_non_positive_budget(self, tmp_path: Path):
-        """A zero/negative budget is a bad argument, not an engine failure.
+        """A zero/negative budget must be refused before anything is launched.
 
-        Without ``min=``, the poll loop accepts it and raises
-        ``DeployTimeoutError`` on its first pass, which reads as a broken
-        engine. Typer must refuse it before anything is launched.
+        Without ``min=`` the poll loop takes it and times out on its first
+        pass, so a bad argument reads as a broken engine.
         """
         config = tmp_path / "test.yaml"
         config.write_text("models: {}\ntasks: {}")
@@ -176,12 +173,7 @@ class TestRunCommand:
         assert mock_run_all.await_count == 0
 
     def test_infer_start_accepts_both_readiness_option_names(self):
-        """One spelling works across both commands.
-
-        ``run`` names the budget ``--ready-timeout``; ``infer start`` shipped
-        it as ``--timeout``. Both names resolve to the same parameter here, so
-        neither spelling is wrong depending on which command you reached for.
-        """
+        """Both spellings resolve to the same parameter, so neither is wrong."""
         import click
         import typer.main
 

--- a/tests/unit/cli/test_run.py
+++ b/tests/unit/cli/test_run.py
@@ -817,7 +817,9 @@ class TestDeterministicPassedToSession:
             await _run_all(config_path=config_path, ready_timeout=1234.0)
 
         launch.assert_awaited_once()
-        assert launch.await_args.kwargs["timeout"] == 1234.0
+        await_args = launch.await_args
+        assert await_args is not None
+        assert await_args.kwargs["timeout"] == 1234.0
 
 
 class TestDeploymentPropagation:

--- a/tests/unit/cli/test_run.py
+++ b/tests/unit/cli/test_run.py
@@ -129,6 +129,73 @@ class TestRunCommand:
         plain = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
         assert "--ready-timeout" in re.sub(r"\s+", " ", plain)
 
+    def test_ready_timeout_option_reaches_run_all(self, tmp_path: Path):
+        """The typer option must arrive at ``_run_all``, not stop at the parser.
+
+        ``test_ready_timeout_reaches_the_deploy_call`` starts *at* ``_run_all``
+        and ``test_run_help_shows_ready_timeout`` stops at ``--help``; between
+        them sits the hand-off in ``register_run_command``. Dropping that one
+        line restores the original defect — an option the user can type that
+        never reaches the deployer — while leaving both neighbours green.
+        """
+        config = tmp_path / "test.yaml"
+        config.write_text("models: {}\ntasks: {}")
+
+        mock_run_all = AsyncMock(return_value={})
+
+        with patch("sieval.cli.run._run_all", mock_run_all):
+            result = runner.invoke(
+                app, ["run", str(config), "--ready-timeout", "1234", "-o", "json"]
+            )
+
+        assert result.exit_code == 0, result.output
+        # A patch target that resolves but no longer intercepts would leave the
+        # kwargs assertion below unreached, and the test vacuously green.
+        assert mock_run_all.await_count == 1
+        await_args = mock_run_all.await_args
+        assert await_args is not None
+        assert await_args.kwargs["ready_timeout"] == 1234.0
+
+    def test_ready_timeout_rejects_a_non_positive_budget(self, tmp_path: Path):
+        """A zero/negative budget is a bad argument, not an engine failure.
+
+        Without ``min=``, the poll loop accepts it and raises
+        ``DeployTimeoutError`` on its first pass, which reads as a broken
+        engine. Typer must refuse it before anything is launched.
+        """
+        config = tmp_path / "test.yaml"
+        config.write_text("models: {}\ntasks: {}")
+
+        mock_run_all = AsyncMock(return_value={})
+        for bad in ("0", "-30"):
+            with patch("sieval.cli.run._run_all", mock_run_all):
+                result = runner.invoke(
+                    app, ["run", str(config), "--ready-timeout", bad]
+                )
+            assert result.exit_code == 2, f"{bad} was accepted: {result.output}"
+        assert mock_run_all.await_count == 0
+
+    def test_infer_start_accepts_both_readiness_option_names(self):
+        """One spelling works across both commands.
+
+        ``run`` names the budget ``--ready-timeout``; ``infer start`` shipped
+        it as ``--timeout``. Both names resolve to the same parameter here, so
+        neither spelling is wrong depending on which command you reached for.
+        """
+        import click
+        import typer.main
+
+        root = typer.main.get_command(app)
+        assert isinstance(root, click.Group)
+        infer = root.commands["infer"]
+        assert isinstance(infer, click.Group)
+
+        param = next(p for p in infer.commands["start"].params if p.name == "timeout")
+        assert set(param.opts) == {"--timeout", "--ready-timeout"}
+        # Same non-positive guard as `run --ready-timeout`.
+        assert isinstance(param.type, click.FloatRange)
+        assert param.type.min == 1.0
+
     def test_ready_timeout_default_is_shared_with_infer_start(self):
         """One named default, so the two commands cannot drift apart again.
 
@@ -160,18 +227,6 @@ class TestRunCommand:
             inspect.signature(infer_start).parameters["timeout"].default
             == DEFAULT_READY_TIMEOUT
         )
-
-    def test_ready_timeout_default_leaves_room_for_a_cold_start(self):
-        """The default must not sit on top of an observed cold-start time.
-
-        A dead process is reported within a poll interval regardless of this
-        value, so the budget only bounds an alive-but-silent engine: too small
-        and a healthy cold load is failed outright. One cluster measured 264s
-        cold for a 30B MoE, so 300s was not a margin.
-        """
-        from sieval.infer.deployer import DEFAULT_READY_TIMEOUT
-
-        assert DEFAULT_READY_TIMEOUT >= 600.0
 
     def test_run_help_shows_deterministic_flag_only(self):
         """--deterministic appears; --no-deterministic does not (monotone).

--- a/tests/unit/cli/test_run.py
+++ b/tests/unit/cli/test_run.py
@@ -4,6 +4,7 @@ AI-Generated Code - Claude Opus 4.6 (Anthropic)
 """
 
 import json
+import re
 from collections.abc import Callable
 from pathlib import Path
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
@@ -120,6 +121,57 @@ class TestRunCommand:
         assert "--result-dir" in error
         assert str(existing) in error
         assert "auto_resume=True" not in error
+
+    def test_run_help_shows_ready_timeout(self):
+        """`sieval run` exposes the readiness budget it has always enforced."""
+        result = runner.invoke(app, ["run", "--help"])
+        assert result.exit_code == 0
+        plain = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
+        assert "--ready-timeout" in re.sub(r"\s+", " ", plain)
+
+    def test_ready_timeout_default_is_shared_with_infer_start(self):
+        """One named default, so the two commands cannot drift apart again.
+
+        `sieval run` enforced a hardcoded 300s that no flag could reach while
+        `sieval infer start` had its own literal default. Three copies of the
+        same number is how that happened; this pins them to one.
+        """
+        import inspect
+
+        from sieval.cli.infer.commands import infer_start
+        from sieval.cli.infer.lifecycle import launch_model
+        from sieval.cli.run import _run_all
+        from sieval.infer.deployer import DEFAULT_READY_TIMEOUT, LocalDeployer
+
+        assert (
+            inspect.signature(LocalDeployer.deploy).parameters["timeout"].default
+            == DEFAULT_READY_TIMEOUT
+        )
+        assert (
+            inspect.signature(launch_model).parameters["timeout"].default
+            == DEFAULT_READY_TIMEOUT
+        )
+        assert (
+            inspect.signature(_run_all).parameters["ready_timeout"].default
+            == DEFAULT_READY_TIMEOUT
+        )
+        # typer wraps the default in the parameter's own default slot
+        assert (
+            inspect.signature(infer_start).parameters["timeout"].default
+            == DEFAULT_READY_TIMEOUT
+        )
+
+    def test_ready_timeout_default_leaves_room_for_a_cold_start(self):
+        """The default must not sit on top of an observed cold-start time.
+
+        A dead process is reported within a poll interval regardless of this
+        value, so the budget only bounds an alive-but-silent engine: too small
+        and a healthy cold load is failed outright. One cluster measured 264s
+        cold for a 30B MoE, so 300s was not a margin.
+        """
+        from sieval.infer.deployer import DEFAULT_READY_TIMEOUT
+
+        assert DEFAULT_READY_TIMEOUT >= 600.0
 
     def test_run_help_shows_deterministic_flag_only(self):
         """--deterministic appears; --no-deterministic does not (monotone).
@@ -712,6 +764,60 @@ class TestDeterministicPassedToSession:
         # YAML→session semantics are covered by TestDeterministicMode
         # in test_session.py.
         assert kwargs["deterministic"] is None
+
+    @pytest.mark.anyio
+    async def test_ready_timeout_reaches_the_deploy_call(self, tmp_path: Path):
+        """--ready-timeout must arrive at launch_model, not stop at the CLI.
+
+        The readiness budget was previously unreachable from `sieval run`: the
+        default was applied three call-frames down and nothing threaded a
+        caller's value to it.
+        """
+        from sieval.cli.run import _run_all
+
+        config = {
+            "models": {
+                "model_a": {
+                    "path": "/tmp/ckpt",
+                    "infer": {"backend": "vllm", "recipe": "test"},
+                }
+            },
+            "result_dir": str(tmp_path / "out"),
+            "tasks": {},
+        }
+        config_path = tmp_path / "cfg.yaml"
+        config_path.write_text(yaml.safe_dump(config))
+
+        mock_translator = MagicMock()
+        mock_translator.translate.return_value = [
+            BackendCommand(
+                cli_args=["vllm", "serve"],
+                backend="vllm",
+                host="localhost",
+                role="full",
+                health_url="http://localhost:8000/health",
+            )
+        ]
+        launch = AsyncMock(return_value=([_fake_handle()], None))
+
+        with (
+            patch(
+                "sieval.cli.run.resolve_infer_config",
+                new=AsyncMock(return_value=("model_a", _fake_plan(), {})),
+            ),
+            patch("sieval.cli.run.get_translator", return_value=mock_translator),
+            patch("sieval.cli.run.launch_model", new=launch),
+            patch("sieval.cli.run.cleanup_model", new=AsyncMock()),
+            patch("sieval.infer.topology.validator.validate_plan", return_value=[]),
+            patch(
+                "sieval.cli.leaderboard.session.arun_session",
+                new=AsyncMock(return_value={}),
+            ),
+        ):
+            await _run_all(config_path=config_path, ready_timeout=1234.0)
+
+        launch.assert_awaited_once()
+        assert launch.await_args.kwargs["timeout"] == 1234.0
 
 
 class TestDeploymentPropagation:

--- a/tests/unit/infer/test_deployer.py
+++ b/tests/unit/infer/test_deployer.py
@@ -18,6 +18,7 @@ from sieval.core.models import ServingFacts
 from sieval.infer.backends.translator import BackendCommand
 from sieval.infer.config import InferCondition, InferHandle, InferPhase
 from sieval.infer.deployer import (
+    DEFAULT_READY_TIMEOUT,
     DeployError,
     DeployTimeoutError,
     LocalDeployer,
@@ -63,6 +64,22 @@ def _make_command(
         role=role,
         health_url=health_url,
     )
+
+
+# ---------- DEFAULT_READY_TIMEOUT ----------
+
+
+class TestDefaultReadyTimeout:
+    def test_leaves_room_for_a_cold_start(self):
+        """The default must not sit on top of an observed cold-start time.
+
+        A dead process is reported within a poll interval regardless of this
+        value (``_poll_all_until_ready`` raises on FAILED/STOPPED before it
+        checks the deadline), so the budget only ever bounds an alive-but-
+        silent engine: too small and a healthy cold load is failed outright.
+        One cluster measured 264s cold for a 30B MoE, so 300s was not a margin.
+        """
+        assert DEFAULT_READY_TIMEOUT >= 600.0
 
 
 # ---------- _launch_one ----------

--- a/tests/unit/infer/test_deployer.py
+++ b/tests/unit/infer/test_deployer.py
@@ -71,14 +71,7 @@ def _make_command(
 
 class TestDefaultReadyTimeout:
     def test_leaves_room_for_a_cold_start(self):
-        """The default must not sit on top of an observed cold-start time.
-
-        A dead process is reported within a poll interval regardless of this
-        value (``_poll_all_until_ready`` raises on FAILED/STOPPED before it
-        checks the deadline), so the budget only ever bounds an alive-but-
-        silent engine: too small and a healthy cold load is failed outright.
-        One cluster measured 264s cold for a 30B MoE, so 300s was not a margin.
-        """
+        """264s cold was measured for a 30B MoE, so 300s was not a margin."""
         assert DEFAULT_READY_TIMEOUT >= 600.0
 
 


### PR DESCRIPTION
## The gap

`sieval run` enforces a readiness timeout that no flag can reach. The value is written three separate times:

| where | value |
|---|---|
| `LocalDeployer.deploy(timeout=...)` | `300.0` |
| `launch_model(timeout=...)` (`cli/infer/lifecycle.py`) | `300.0` |
| `sieval infer start --timeout` default | `300.0` |

`sieval run` never passes one, so it silently takes the default three frames down. `sieval infer start` has a flag; the all-in-one path — the one most likely to be handed a cold, large checkpoint — has none.

## 300s was not a budget

**The failure modes are asymmetric.** A process that dies is reported within one poll interval regardless of this value, because that is phase `STOPPED`/`FAILED`, not a timeout. This budget therefore only ever bounds a process that is **alive and silent** — still loading, or hung. Setting it too low converts a slow-but-healthy cold start into a hard failure that discards the whole GPU allocation; setting it too high only delays discovery of a genuine hang. The costs are not comparable.

**And it had no margin.** Measured on one cluster, the same 30B MoE checkpoint, identical launch line (`--tp 4 --dp-size 2 --dtype bfloat16 --mem-fraction-static 0.9 --context-length 40960`):

| run | ready at |
|---|---|
| warm page cache | **77 s** |
| warm page cache | **82 s** |
| cold | **264 s** |

A 3.4× spread from page cache and shared-storage contention alone, under a 300 s ceiling — 14% of headroom over an observed *success*. A run that legitimately loads four replicas from cold storage has no chance, and the failure it produces looks like a broken engine rather than an impatient client.

## Changes

**`--ready-timeout` on `sieval run`**, threaded through `_run_all` → `launch_model`.

Named for what it bounds rather than mirroring `infer start --timeout`: `run` also evaluates and grades, so a bare `--timeout` there would read as a budget for the whole run. The help text states it applies **per model**, since each deployment gets its own budget.

**The default moves 300s → 900s**, and all four call sites now read one named `DEFAULT_READY_TIMEOUT`, so they cannot drift apart again. The rationale lives with the constant, since the next person to touch it will ask why it is large.

900s is a judgement call, not a measurement: it clears the observed cold start by ~3.4× while still bounding a hang. **A reviewer who wants the flag without the new default can revert the constant alone** — the wiring does not depend on its value.

## Verification

- `tests/unit` failure set is **byte-identical** to the `origin/main` baseline (46, all pre-existing missing-optional-dep failures in this environment); 6235 passed.
- All four new tests fail on the parent commit. One is a drift guard asserting the deployer, `launch_model`, `_run_all` and `infer start` defaults are the *same* constant — three copies of a number is how this bug happened, and that test is what stops it recurring.
- The wiring test asserts a caller's `ready_timeout=1234.0` actually arrives as `launch_model(timeout=1234.0)`, rather than being accepted and dropped.
- `ruff check` / `ruff format` / `ty` clean on the changed files.
- Not verified on live hardware.

## Relation to the other two

Found while investigating one failed run, with [#133](https://github.com/scitix/sieval/pull/133) (a bare `NVIDIA H200` matched no recipe hardware key, silently dropping every profile param) and [#134](https://github.com/scitix/sieval/pull/134) (a readiness timeout discarded the engine log that explained it). Independent of both: this one is about the budget, #134 about what you learn when it runs out. They compose — a longer budget is only tolerable because #134 makes the eventual failure legible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)