### PR TITLE
docs(recipes): trim the comments #133 added to what they have to carry

### DIFF
--- a/sieval/infer/recipes/qwen2_5.yaml
+++ b/sieval/infer/recipes/qwen2_5.yaml
@@ -24,12 +24,8 @@
 #   H100-80G:  80GB HBM3,  Hopper, native FP8, NVLink 4 (900GB/s)
 #   H200-141G: 141GB HBM3e, Hopper, same compute as H100 but 1.76x memory
 #
-#   The A100-80G bf16 params mirror H100-80G rather than A100-40G: what bounds
-#   max_model_len across these entries is capacity, and both cards hold 80GB of
-#   the same weights and KV cache. That equivalence is where these numbers come
-#   from -- they were not measured on an A100-80G. Bandwidth and compute differ
-#   (HBM2e vs HBM3, Ampere vs Hopper) but neither feeds these params. There is
-#   no fp8 block for the same reason A100-40G has none: Ampere lacks native FP8.
+#   A100-80G bf16 is copied from H100-80G, not measured: capacity is what
+#   bounds max_model_len here, and both cards hold 80GB.
 #
 # Precision notes:
 #   bf16 profiles include explicit dtype to prevent auto-detection fallback.

--- a/sieval/infer/recipes/qwen3.yaml
+++ b/sieval/infer/recipes/qwen3.yaml
@@ -20,12 +20,8 @@
 #   H100-80G:  80GB HBM3,  Hopper, native FP8, NVLink 4 (900GB/s)
 #   H200-141G: 141GB HBM3e, Hopper, same compute as H100 but 1.76x memory
 #
-#   The A100-80G bf16 params mirror H100-80G rather than A100-40G: what bounds
-#   max_model_len across these entries is capacity, and both cards hold 80GB of
-#   the same weights and KV cache. That equivalence is where these numbers come
-#   from -- they were not measured on an A100-80G. Bandwidth and compute differ
-#   (HBM2e vs HBM3, Ampere vs Hopper) but neither feeds these params. There is
-#   no fp8 block for the same reason A100-40G has none: Ampere lacks native FP8.
+#   A100-80G bf16 is copied from H100-80G, not measured: capacity is what
+#   bounds max_model_len here, and both cards hold 80GB.
 #
 # Precision notes:
 #   bf16 profiles include explicit dtype to prevent auto-detection fallback.

--- a/sieval/infer/recipes/registry.py
+++ b/sieval/infer/recipes/registry.py
@@ -354,27 +354,23 @@ def match_recipe(family: str, param_billions: float) -> Recipe | None:
     return None
 
 
-# A hardware key's memory token ("80G", "141G") states the card's capacity; the
-# remaining tokens name the model ("H200"). nvidia-smi reports the capacity for
-# some cards ("NVIDIA A100-SXM4-80GB") but not others ("NVIDIA H200"), so the
-# two kinds of token cannot be required alike.
+# A key's memory token ("80G") states capacity; the rest name the model ("H200").
+# nvidia-smi reports capacity for some cards but not others, so the two kinds of
+# token cannot be required alike.
 _MEMORY_TOKEN_RE = re.compile(r"^\d+(?:g|gb|gib)$")
 
-# A reported capacity has to start on a boundary. The "10G" inside a product
-# name like "NVIDIA A10G" is part of the model, and reading it as a capacity
-# would push that card down the "states a size" branch below, refusing the very
-# fallback it needs.
+# A reported capacity must start on a boundary: the "10G" in "NVIDIA A10G" names
+# the model, and reading it as a size would deny that card the model-name
+# fallback below.
 _GPU_STATES_MEMORY_RE = re.compile(r"(?<![a-z0-9])\d+\s*(?:g|gb|gib)\b")
 
 
 def _model_token_matches(token: str, gpu_lower: str) -> bool:
     """Does *token* name the GPU model, sitting on a token boundary?
 
-    The ``"exact"`` reading can use a plain substring test because the key's
-    memory token corroborates it — "80g" is found inside "80gb". A model-only
-    reading has no such second witness, so a bare substring would let one
-    card's key claim another's name: "h20" sits inside "h200", and "h200"
-    inside "gh200".
+    A model-only match has no memory token corroborating it, so a bare
+    substring would let one card's key claim another's name: "h20" sits inside
+    "h200", "h200" inside "gh200".
     """
     pattern = rf"(?<![a-z0-9]){re.escape(token)}(?![a-z0-9])"
     return re.search(pattern, gpu_lower) is not None
@@ -385,10 +381,9 @@ def _classify_hardware_key(
 ) -> Literal["exact", "model"] | None:
     """Classify how well *hw_key* describes the GPU named by *gpu_lower*.
 
-    Returns ``"exact"`` when every token of the key appears in the GPU string,
-    ``"model"`` when only the model tokens do (the key's memory token is
-    absent), or ``None`` when the model tokens disagree — which includes a key
-    naming no model at all, such as a bare ``"80G"``.
+    ``"exact"`` when every token of the key appears in the GPU string,
+    ``"model"`` when only the model tokens do, ``None`` when they disagree —
+    which includes a key naming no model at all, such as a bare ``"80G"``.
     """
     tokens = re.split(r"[-_\s]+", hw_key.lower())
     if all(token in gpu_lower for token in tokens):
@@ -412,19 +407,12 @@ def resolve_hardware_profile(
     For example, key ``"H100-80G"`` matches GPU string
     ``"NVIDIA H100-SXM5-80GB"``.
 
-    Some drivers report a bare product name with no capacity — ``"NVIDIA
-    H200"`` — which no ``<model>-<memory>`` key can satisfy that way. When
-    the GPU string states no capacity at all, a key is therefore allowed to
-    match on its model tokens alone, but only when exactly one key does; two
-    candidates mean the recipe distinguishes memory tiers we cannot tell
-    apart, so we refuse rather than guess. A GPU string that *does* state a
-    capacity must still agree with the key, so a 40G card never inherits an
-    80G profile.
-
-    Matching on the model name alone also demands a token boundary, which the
-    corroborated ``"exact"`` reading does not: without a memory token to
-    confirm it, a plain substring would let ``"H20-96G"`` claim an ``"NVIDIA
-    H200"``, or ``"H200-141G"`` a ``"NVIDIA GH200"``.
+    Some drivers report a bare product name — ``"NVIDIA H200"`` — that no
+    ``<model>-<memory>`` key can match that way. A GPU string stating no
+    capacity may therefore match on model tokens alone, and only when exactly
+    one key does; two candidates are refused rather than guessed. One that
+    *does* state a capacity must still agree with the key, so a 40G card never
+    inherits an 80G profile.
 
     Args:
         recipe: Typed Recipe with a ``hardware`` field.

--- a/tests/unit/infer/recipes/test_a100_tiers.py
+++ b/tests/unit/infer/recipes/test_a100_tiers.py
@@ -1,9 +1,8 @@
 """Tests for the A100 memory tiers declared in the qwen recipe files.
 
-The A100-80G entries are *derived* from H100-80G, not measured: both cards hold
-80GB, and capacity is what bounds ``max_model_len`` across these entries, so the
-bf16 block is copied. That reasoning lives in the "Hardware notes" header of
-each recipe file; these tests keep the copy from drifting out from under it.
+The A100-80G entries are copied from H100-80G, not measured — see the "Hardware
+notes" header of each recipe file. These tests keep the copy from drifting out
+from under that note.
 
 AI-Generated Code - Claude Opus 5 (1M context) (Anthropic)
 """
@@ -25,8 +24,8 @@ class TestA100TierDerivation:
     def test_a100_80g_bf16_mirrors_h100_80g(self) -> None:
         """Equal capacity, equal bf16 block.
 
-        If a real A100-80G measurement ever replaces the derivation, update the
-        recipe files' header notes and this test together.
+        If a real measurement ever replaces the copy, update the recipe headers
+        and this test together.
         """
         for name in _recipes_with_a100_80g():
             hardware = load_recipe(name).hardware
@@ -48,8 +47,8 @@ class TestA100TierResolution:
     def test_80gb_card_gets_the_80g_tier(self) -> None:
         """An 80GB A100 gets the 80G tier — not the 40G one, and not nothing.
 
-        Before A100-80G shipped, the only A100 key was 40G, so these strings
-        state a capacity no key agreed with and resolved to no params at all.
+        With only A100-40G declared, these strings stated a capacity no key
+        agreed with and resolved to no params at all.
         """
         recipe = load_recipe("qwen3-30b-a3b")
         for gpu in ("NVIDIA A100-SXM4-80GB", "NVIDIA A100 80GB PCIe"):
@@ -68,9 +67,8 @@ class TestA100TierResolution:
     def test_bare_a100_is_ambiguous_now_both_tiers_ship(self) -> None:
         """A bare 'NVIDIA A100' names no capacity, so the tier is a coin flip.
 
-        This is the ambiguity guard costing a match that used to resolve: with
-        only A100-40G declared, it was the sole candidate. Refusing is the
-        intended trade — nvidia-smi reports the capacity for this card.
+        The ambiguity guard costs a match that resolved while A100-40G was the
+        sole candidate. Intended: nvidia-smi does report this card's capacity.
         """
         recipe = load_recipe("qwen3-30b-a3b")
         assert resolve_hardware_profile(recipe, "NVIDIA A100", "bf16", "vllm") is None

--- a/tests/unit/infer/test_recipes.py
+++ b/tests/unit/infer/test_recipes.py
@@ -286,9 +286,8 @@ class TestResolveHardwareProfile:
     ) -> None:
         """'NVIDIA H100' (no capacity reported) still matches 'H100-80G'.
 
-        Some drivers report only the product name, which can never contain the
-        key's memory token. Refusing to match there silently drops every
-        profile param from the launch command.
+        A product name can never contain the key's memory token; refusing to
+        match silently drops every profile param from the launch command.
         """
         result = resolve_hardware_profile(sample_recipe, "NVIDIA H100", "bf16", "vllm")
         assert result is not None
@@ -297,9 +296,8 @@ class TestResolveHardwareProfile:
     def test_bare_product_name_h200_matches_shipped_recipe(self) -> None:
         """The reported case: nvidia-smi says 'NVIDIA H200', key is 'H200-141G'.
 
-        Compared against the recipe's own entry rather than literal numbers, so
-        retuning the YAML cannot fail a matching-logic test. The second assert
-        keeps that from passing vacuously on an empty entry.
+        Compared against the recipe's own entry so retuning the YAML cannot
+        fail a matching-logic test; the bare assert keeps that non-vacuous.
         """
         recipe = load_recipe("qwen3-30b-a3b")
         result = resolve_hardware_profile(recipe, "NVIDIA H200", "bf16", "sglang")
@@ -307,12 +305,7 @@ class TestResolveHardwareProfile:
         assert result
 
     def test_stated_capacity_must_still_agree(self) -> None:
-        """A 40G card must not inherit the 80G profile.
-
-        The GPU names its capacity, so a model-token match would be a
-        downgrade in safety, not a rescue: the 80G context length would not
-        fit.
-        """
+        """A 40G card must not inherit the 80G profile — the context won't fit."""
         recipe = Recipe(
             name="only-80g",
             hardware={"A100-80G": {"bf16": {"vllm": {"max_model_len": 32768}}}},
@@ -351,8 +344,8 @@ class TestResolveHardwareProfile:
     def test_product_name_digits_are_not_a_reported_capacity(self) -> None:
         """'NVIDIA A10G' states no capacity — its "10G" names the model.
 
-        Read as a capacity, it would push the card down the "GPU stated a size"
-        branch and refuse the very model-name fallback it needs.
+        Read as a size, the card takes the "stated a capacity" branch and is
+        refused the model-name fallback it needs.
         """
         recipe = Recipe(
             name="a10g",


### PR DESCRIPTION
## Type

- docs — documentation only

## Summary

#133's comments restated themselves. This keeps every load-bearing fact and drops the rest — 67 lines out, 38 in.

- **Recipe headers** (`qwen2_5.yaml`, `qwen3.yaml`): the A100-80G note explained "no fp8 block because Ampere lacks native FP8" one line below `A100-80G: 80GB HBM2e, Ampere, no native FP8 (bf16 only)`, and argued that bandwidth and compute "do not feed these params" — a non-fact stated to be dismissed. What survives is the derivation and its caveat: copied from H100-80G, not measured, because capacity is what bounds `max_model_len`.
- **`resolve_hardware_profile`**: its second added paragraph reproduced `_model_token_matches`'s docstring, `H20`/`GH200` examples and all. Dropped from the caller, kept at the helper that implements it.
- **`_MEMORY_TOKEN_RE`, `_GPU_STATES_MEMORY_RE`, `_classify_hardware_key`, and the test docstrings**: same claims, fewer lines.

Nothing was cut that a reader needs: the boundary rule, the two-candidate refusal, the "stated capacity must still agree" guard, and the "copied, not measured" caveat all stay — each now stated once, where it belongs.

## Related Issues

Refs #133

## Test Plan

### Automated

- [x] Lint/format clean (`ruff check && ruff format --check`) — 3 files, all clean
- [x] Type check clean (`ty check`) — `All checks passed!`
- [x] Unit tests pass — `tests/unit/infer` 445 passed

### Manual

- [x] **Comments-only, proven rather than asserted.** For each of the five files, the version at `94599907` and this one are compared structurally: the three `.py` files by `ast.dump` with every docstring stripped, the two recipe YAMLs by `yaml.safe_load`. All five report `SAME` — no code path, no launch parameter, and no recipe value moved.

```
SAME  ast(no-docstrings)  sieval/infer/recipes/registry.py
SAME  ast(no-docstrings)  tests/unit/infer/recipes/test_a100_tiers.py
SAME  ast(no-docstrings)  tests/unit/infer/test_recipes.py
SAME  parsed yaml         sieval/infer/recipes/qwen2_5.yaml
SAME  parsed yaml         sieval/infer/recipes/qwen3.yaml
```

- [x] Checked that no hash or digest reads recipe file bytes, so trimming YAML comments cannot rotate a persisted artifact.

## Checklist

### Required (all PRs)

- [x] PR title follows conventional format (`type(scope): description`)
- [x] No internal paths, credentials, or personal info in committed files
- [x] AI-generated code has `AI-Generated Code - <model> (<provider>)` in module docstring — `test_a100_tiers.py`'s marker line is untouched
- [x] No new upper-layer dependencies added to `core/`
- [x] Deleted code verified — no code was deleted; see the AST/YAML equivalence above

🤖 Generated with [Claude Code](https://claude.com/claude-code)
