### PR TITLE
fix(cli): a resume must not abort on a field declared non-matching

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ SiEval is a **model delivery quality verification system**: eval-side knowledge 
 Precise reproducibility is a product contract, not a nicety.
 
 * Safety guards (e.g. `--resume` strict match) ship strict-only. No `--force-*` flags, no bypass env vars, no "(future)" escape-hatch hints in errors.
-* `--resume` match scope is narrowed, not bypassed: only fields that touch neither sample data nor any persisted artifact may differ across a resume — pure scheduling (concurrency, shard-I/O, write buffers) and console-only progress. Everything affecting on-disk content stays strict (sampling/seeds, `max_iterations`, `shard_samples`, `record_*`, `max_retries`, `profile_*`, `detect_anomalies*`, the `progress.json` dump), as does `infer_plans.yaml`.
+* `--resume` match scope is narrowed, not bypassed: only fields that touch neither sample data nor any persisted artifact may differ across a resume — pure scheduling (concurrency, shard-I/O, write buffers), console-only progress, `auto_resume`, the non-serializable `stage_meta` hooks, and top-level `result_dir`. Everything affecting on-disk content stays strict (sampling/seeds, `max_iterations`, `shard_samples`, `record_*`, `max_retries`, `profile_*`, `detect_anomalies*`, the `progress.json` dump, and `runner_config.result_dir`, which picks the artifact directory), as does `infer_plans.yaml`.
 * Recovery: "start fresh" or "match the invocation". Escape-hatch proposals must re-justify the contract, not just add a flag.
 
 ## Toolchain

--- a/sieval/cli/leaderboard/session.py
+++ b/sieval/cli/leaderboard/session.py
@@ -855,13 +855,13 @@ _STRICT_RUNNER_KEYS: frozenset[str] = frozenset(
     }
 )
 
-# Neither adjustable nor strict — listed only so the three buckets partition
-# TaskRunnerConfig exactly (see test_every_field_classified_exactly_once). The
-# strip removes result_dir at top level (reification injects it there); the rest
-# are never reached because they don't survive into a persisted runner_config
-# block: auto_resume is set by the orchestration layer at runtime, stage_meta
-# hooks are non-serializable callables. A hand-authored runner_config field from
-# this set that changed across a resume would still be compared strictly.
+# Neither adjustable nor strict: `auto_resume` only decides WHETHER to resume,
+# the stage_meta hooks are non-serializable callables, and `result_dir` says
+# WHERE output goes. Usually none reach a persisted runner_config block — but a
+# config may spell one out, and then it persists and is compared. `--resume`
+# forces the runner's auto_resume on regardless of the YAML
+# (_build_runner_config), so an invocation that also flips the YAML value to
+# request that resume aborts on the field asking for it, with nothing to match.
 _NONMATCH_RUNNER_KEYS: frozenset[str] = frozenset(
     {
         "result_dir",
@@ -871,13 +871,23 @@ _NONMATCH_RUNNER_KEYS: frozenset[str] = frozenset(
     }
 )
 
+# Stripped from every runner_config block; `result_dir` deliberately is not.
+# Inside a block it selects the artifact directory — a hand-authored value beats
+# the `<result_dir>/<task.name>` MultiTaskRunner derives — so changing it across
+# a resume moves which shards are read and written. Only the top-level key is
+# stripped, where it is the location of the compared file.
+_NONMATCH_KEYS_STRIPPED_IN_BLOCKS: frozenset[str] = _NONMATCH_RUNNER_KEYS - {
+    "result_dir"
+}
+
 
 def _strip_noncomparable_fields(cfg: dict[str, Any]) -> dict[str, Any]:
     """Deep-copy ``cfg`` with resume-mutable fields removed, for comparison.
 
     Strips (input never mutated) top-level ``concurrency_limit`` /
     ``concurrency_limits`` / ``result_dir``, ``models.*.args.concurrency_limit``,
-    and ``_THROUGHPUT_RUNNER_KEYS`` from every ``runner_config`` block.
+    and ``_THROUGHPUT_RUNNER_KEYS`` plus ``_NONMATCH_KEYS_STRIPPED_IN_BLOCKS``
+    from every ``runner_config`` block.
     """
     out = copy.deepcopy(cfg)
 
@@ -905,7 +915,7 @@ def _strip_noncomparable_fields(cfg: dict[str, Any]) -> dict[str, Any]:
         )
     for rc in runner_config_blocks:
         if isinstance(rc, dict):
-            for key in _THROUGHPUT_RUNNER_KEYS:
+            for key in _THROUGHPUT_RUNNER_KEYS | _NONMATCH_KEYS_STRIPPED_IN_BLOCKS:
                 rc.pop(key, None)
 
     return out

--- a/tests/unit/cli/leaderboard/test_session.py
+++ b/tests/unit/cli/leaderboard/test_session.py
@@ -21,6 +21,7 @@ import yaml
 from sieval.cli._filter_spec import VALUES_DIGEST_KEY, compute_values_digest
 from sieval.cli.leaderboard.session import (
     _DETERMINISTIC_SEED_CONTRACT_KEY,
+    _NONMATCH_KEYS_STRIPPED_IN_BLOCKS,
     _NONMATCH_RUNNER_KEYS,
     _STRICT_RUNNER_KEYS,
     _THROUGHPUT_RUNNER_KEYS,
@@ -6979,6 +6980,53 @@ class TestStripNoncomparableFields:
         out = _strip_noncomparable_fields(cfg)
         assert "concurrency_limit" not in out["models"]["m"]["args"]
         assert out["models"]["m"]["args"]["temperature"] == 0.0
+
+    @staticmethod
+    def _both_placements(rc: dict) -> list[dict]:
+        """Strip `rc` as a top-level default and as a per-task override.
+
+        runner_config carries the same keys in both places; the strip must
+        treat them identically.
+        """
+        top = _strip_noncomparable_fields({"runner_config": dict(rc)})
+        per_task = _strip_noncomparable_fields(
+            {"tasks": {"t": {"runner_config": dict(rc)}}}
+        )
+        return [top["runner_config"], per_task["tasks"]["t"]["runner_config"]]
+
+    def test_removes_hand_authored_nonmatch_runner_fields(self):
+        """A non-match field written out by hand must not block a resume.
+
+        `auto_resume` is the live case: an invocation that flips the YAML value
+        to request a resume would otherwise abort on the field asking for it.
+        """
+        for key, before in (
+            ("auto_resume", False),
+            ("stage_meta_hook", None),
+            ("stage_meta_hooks", []),
+        ):
+            for rc in self._both_placements({key: before, "max_iterations": 3}):
+                assert key not in rc, f"{key} must not be compared across a resume"
+                assert rc["max_iterations"] == 3, "strict fields must survive"
+
+    def test_nonmatch_bucket_is_fully_stripped(self):
+        """Every key declared stripped-in-blocks is, not just the ones we listed."""
+        cfg = {"runner_config": dict.fromkeys(_NONMATCH_KEYS_STRIPPED_IN_BLOCKS, "x")}
+        assert _strip_noncomparable_fields(cfg)["runner_config"] == {}
+
+    def test_runner_config_result_dir_stays_compared(self):
+        """`result_dir` inside a runner_config block is NOT resume-mutable.
+
+        There it selects the artifact directory, so stripping it would let a
+        run that moves its own shards through as a clean resume.
+        """
+        for rc in self._both_placements({"result_dir": "./A"}):
+            assert rc == {"result_dir": "./A"}
+
+    def test_top_level_result_dir_is_still_stripped(self):
+        """The top-level key keeps its long-standing exemption."""
+        out = _strip_noncomparable_fields({"result_dir": "./A", "models": {}})
+        assert "result_dir" not in out
 
     def test_removes_runner_config_throughput_keeps_strict(self):
         cfg = {


### PR DESCRIPTION
## Type

- fix — bug fix or alignment correction

## Summary

- `TaskRunnerConfig`'s fields are partitioned into three buckets — throughput,
  strict, and non-match — and `test_every_field_classified_exactly_once`
  enforces that the partition is total and disjoint.
  `_strip_noncomparable_fields` implemented only two of them: it stripped
  `_THROUGHPUT_RUNNER_KEYS` and left `_NONMATCH_RUNNER_KEYS` in the compared
  config, so the bucket whose entire meaning is "not compared" was compared.
  Outside the classification test the set had **no production reader at all**.
- It hid because those fields usually never reach a persisted `runner_config`:
  `auto_resume` is normally absent from the YAML, and the `stage_meta` hooks are
  non-serializable. But a config is free to spell one out, and then it does
  persist and is compared. `auto_resume` is the live case: `--resume` forces the
  runner's value on regardless of the YAML (`_build_runner_config`), so an
  invocation that *also* flips the YAML value to request that resume aborts on
  the very field asking for it:

  ```text
  Resume aborted: effective_config.yaml does not match current invocation.
  Diff:
    - runner_config.auto_resume: False → True
  ```

  and there is nothing to match back to — satisfying the gate means keeping
  `auto_resume: false`, which is precisely the field requesting the resume.
- `auto_resume` and the `stage_meta` hooks are therefore stripped from every
  `runner_config` block. **`result_dir` stays in the bucket but is deliberately
  not stripped there:** inside a block it selects the artifact directory — a
  hand-authored value (top-level default or per-task override) beats the
  `<result_dir>/<task.name>` `MultiTaskRunner` derives — so changing it across a
  resume moves which shards are read and written. Only the top-level key is
  stripped, as before, where it is the location of the compared file.
- The strict set is untouched, so everything shaping on-disk content still has
  to match exactly. `CLAUDE.md`'s statement of the resume contract is updated to
  name the newly non-compared fields and the `runner_config.result_dir`
  carve-out, so the prose and the code agree.

## Test Plan

### Automated

- [x] Lint/format clean (`ruff check && ruff format --check`)
- [x] Type check clean (`ty check`)
- [x] Unit tests pass (`tests/unit/cli` — 1152 passed; `test_session.py` 387)
- [x] Four tests in `tests/unit/cli/leaderboard/test_session.py`, each covering
      both placements (top-level default and per-task override) via a
      `_both_placements` helper — the single-placement gap is what let the
      `result_dir` case slip through in the first place.
- [x] Mutation-checked in **both** directions, not just green:
      re-widening the strip to the whole bucket fails
      `test_runner_config_result_dir_stays_compared`; dropping the non-match
      strip fails `test_removes_hand_authored_nonmatch_runner_fields` and
      `test_nonmatch_bucket_is_fully_stripped`.

### Manual

Reproduced and then fixed against a stalled real run — a 1034-sample Spider eval
on a 397B model that had lost 53 samples to upstream API timeouts:

- [x] Before: `Resume aborted: ... runner_config.auto_resume: False → True`, with
      no recovery but discarding the `result_dir` and re-running from scratch
      (~2–4 h of inference to recover 53 samples).
- [x] After: the resume is accepted, reports `Retry prepared: 53 samples`, and
      recovers 50 of them — `fails` 53 → 3, judged rollouts 981 → 1031. Scores
      moved only as the added samples warrant (48.94% → 51.84% execution
      accuracy), and the strict fields were still compared throughout.

## Checklist

### Required (all PRs)

- [x] PR title follows conventional format (`type(scope): description`)
- [x] No internal paths, credentials, or personal info in committed files
- [x] AI-generated code has `AI-Generated Code - <model> (<provider>)` in module docstring
- [x] No new upper-layer dependencies added to `core/`
- [x] Deleted code verified — no remaining call sites depend on it

### If: Breaking Change

- [x] Described what breaks and migration path in Summary — a resume that
      previously aborted on `auto_resume` or a `stage_meta` hook now proceeds.
      No config that resumed before stops resuming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
