### PR TITLE
feat(models): add OpenAI Responses API dialect

### DIFF
--- a/sieval/core/models/dialect_registry.py
+++ b/sieval/core/models/dialect_registry.py
@@ -1,4 +1,4 @@
-"""Stable dialect descriptors and executable PR-1 binders.
+"""Stable dialect descriptors and executable adapter binders.
 
 Descriptors are serializable symbol metadata.  Binders are ordinary functions
 and exist only for dialect packages that are executable in the current delivery
@@ -38,6 +38,10 @@ from .dialects.openai_completions import (
     CAPABILITY_DECISIONS as OPENAI_COMPLETIONS_CAPABILITY_DECISIONS,
 )
 from .dialects.openai_completions import OpenAICompletionsDialect
+from .dialects.openai_responses import (
+    CAPABILITY_DECISIONS as OPENAI_RESPONSES_CAPABILITY_DECISIONS,
+)
+from .dialects.openai_responses import OpenAIResponsesDialect
 from .ir import (
     ChatInput,
     ChatMessage,
@@ -313,6 +317,10 @@ def _bind_openai_completions(connection: Any, requested_model_id: str) -> Dialec
     return OpenAICompletionsDialect(connection, requested_model_id)
 
 
+def _bind_openai_responses(connection: Any, requested_model_id: str) -> Dialect:
+    return OpenAIResponsesDialect(connection, requested_model_id)
+
+
 def _binder(
     function: Callable[[Any, str], Dialect],
     decisions: Mapping[str, DialectCapabilityDecision],
@@ -338,6 +346,13 @@ DIALECT_BINDERS: Mapping[str, DialectBinder] = MappingProxyType(
             cast(
                 Mapping[str, DialectCapabilityDecision],
                 OPENAI_COMPLETIONS_CAPABILITY_DECISIONS,
+            ),
+        ),
+        "openai_responses": _binder(
+            _bind_openai_responses,
+            cast(
+                Mapping[str, DialectCapabilityDecision],
+                OPENAI_RESPONSES_CAPABILITY_DECISIONS,
             ),
         ),
     }
@@ -372,7 +387,8 @@ DIALECT_SPECS: Mapping[str, DialectSpec] = MappingProxyType(
         "openai_responses": _spec(
             "openai_responses",
             "openai_sdk",
-            request_seed_support=RequestSeedSupport.RESERVED,
+            decisions=_registered_decisions("openai_responses"),
+            request_seed_support=RequestSeedSupport.UNSUPPORTED,
             input_kinds=("chat",),
             input_modalities=("text", "image", "tool_call", "tool_result"),
         ),

--- a/sieval/core/models/dialects/openai_responses.py
+++ b/sieval/core/models/dialects/openai_responses.py
@@ -1,0 +1,2076 @@
+"""OpenAI Responses API dialect for the provider-neutral model IR.
+
+This adapter deliberately implements only semantics the shared IR can preserve.
+Unsupported request fields and output item variants fail before they can be
+silently reinterpreted.  Streaming is lifted from the single terminal event's
+complete ``Response`` object, so the streaming and non-streaming paths share one
+response parser.
+
+AI-Generated Code - GPT-5.6 (OpenAI)
+"""
+
+import json
+import math
+from collections.abc import AsyncIterable, Callable, Mapping, Sequence
+from copy import deepcopy
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import Any, NoReturn, cast
+
+from sieval.core.models._shared import copy_json_value, thaw_json_mapping
+from sieval.core.models.capabilities import (
+    CAPABILITY_KEYS,
+    Capability,
+    CapabilityKey,
+    DialectCapabilityBinding,
+    DialectCapabilityDecision,
+    HostedToolsOptions,
+    MultimodalInputOptions,
+    ReasoningOptions,
+    Supported,
+    TopLogprobsOptions,
+    Unsupported,
+)
+from sieval.core.models.deployment import BINDING_RESOURCE_KEYS
+from sieval.core.models.dialect import (
+    DialectError,
+    Guarantee,
+    OutputContract,
+    OutputContractError,
+    OutputRule,
+    PreparedRequest,
+    RequestAudit,
+    RuntimePlanView,
+    WireEvidence,
+    WireObservation,
+    active_request_leaves,
+    validate_reasoning,
+    validate_request_invariants,
+    validate_runtime_binding_plan,
+    validate_structured_output,
+    validate_tool_calls,
+    validate_top_logprobs,
+)
+from sieval.core.models.ir import (
+    ChatInput,
+    ChatMessage,
+    Citation,
+    FunctionToolCall,
+    HostedToolSpec,
+    ImagePart,
+    ReasoningOutput,
+    Request,
+    Response,
+    ServerToolUse,
+    StructuredOutput,
+    TextPart,
+    TokenLogprob,
+    ToolCallPart,
+    ToolResultPart,
+    TopKEntry,
+    UsageStats,
+)
+from sieval.core.types import JSONValue
+
+_OPENAI_REASONING_EFFORTS = frozenset(
+    {"none", "minimal", "low", "medium", "high", "xhigh", "max"}
+)
+_SUPPORTED_HOSTED_TOOL_KINDS = frozenset({"web_search", "web_search_preview"})
+_SUPPORTED_IMAGE_MEDIA_TYPES = frozenset(
+    {"image/gif", "image/jpeg", "image/png", "image/webp"}
+)
+_SUPPORTED_IMAGE_DETAILS = frozenset({"auto", "high", "low", "original"})
+_OPAQUE_CONTINUATION_VERSION = 2
+_REASONING_ITEM_KEYS = frozenset(
+    {"type", "id", "summary", "content", "encrypted_content", "status"}
+)
+_REASONING_ITEM_STATUSES = frozenset({"in_progress", "completed", "incomplete"})
+_REASONING_TEXT_PART_KEYS = frozenset({"type", "text"})
+_HISTORY_ITEM_TYPES = frozenset(
+    {
+        "message",
+        "reasoning",
+        "function_call",
+        "function_call_output",
+        "web_search_call",
+    }
+)
+_MESSAGE_ITEM_KEYS = frozenset({"type", "id", "role", "status", "content"})
+_MESSAGE_ROLES = frozenset({"system", "developer", "user", "assistant"})
+_MESSAGE_ITEM_STATUSES = frozenset({"in_progress", "completed", "incomplete"})
+_TERMINAL_ITEM_STATUSES = frozenset({"completed", "incomplete"})
+_FUNCTION_CALL_ITEM_KEYS = frozenset(
+    {"type", "id", "call_id", "name", "arguments", "status"}
+)
+_FUNCTION_CALL_OUTPUT_ITEM_KEYS = frozenset(
+    {"type", "id", "call_id", "output", "status"}
+)
+_WEB_SEARCH_ITEM_KEYS = frozenset({"type", "id", "status", "action"})
+_INPUT_TEXT_PART_KEYS = frozenset({"type", "text"})
+_INPUT_IMAGE_PART_KEYS = frozenset({"type", "image_url", "detail"})
+_OUTPUT_TEXT_PART_KEYS = frozenset({"type", "text", "annotations", "logprobs"})
+_MISSING = object()
+
+
+def _validate_top_logprobs_config(options: object) -> None:
+    assert isinstance(options, TopLogprobsOptions)
+    if options.minimum > 20:
+        raise ValueError("openai_responses supports at most 20 top logprobs")
+
+
+def _validate_reasoning_config(options: object) -> None:
+    assert isinstance(options, ReasoningOptions)
+    if options.budget_tokens is not None:
+        raise ValueError("openai_responses does not support reasoning budget_tokens")
+    if options.effort is not None and options.effort not in _OPENAI_REASONING_EFFORTS:
+        raise ValueError(f"openai_responses does not support effort {options.effort!r}")
+
+
+def _validate_hosted_tools_config(options: object) -> None:
+    assert isinstance(options, HostedToolsOptions)
+    unsupported = set(options.kinds) - _SUPPORTED_HOSTED_TOOL_KINDS
+    if unsupported:
+        raise ValueError(
+            "openai_responses currently supports only web-search hosted tools; "
+            f"unsupported kinds: {sorted(unsupported)}"
+        )
+
+
+def _validate_multimodal_config(options: object) -> None:
+    assert isinstance(options, MultimodalInputOptions)
+    unsupported = set(options.modalities) - {"image"}
+    if unsupported:
+        raise ValueError(
+            f"openai_responses does not support modalities {sorted(unsupported)}"
+        )
+
+
+def _decisions() -> Mapping[CapabilityKey, DialectCapabilityDecision]:
+    decisions: dict[CapabilityKey, DialectCapabilityDecision] = {
+        "input_scoring": Unsupported("Responses cannot score input tokens"),
+        "sampled_logprobs": Supported(
+            DialectCapabilityBinding(
+                "sampled_logprobs",
+                request_leaves=("scoring.sampled_logprobs",),
+                response_channels=("logprobs",),
+            )
+        ),
+        "top_logprobs": Supported(
+            DialectCapabilityBinding(
+                "top_logprobs",
+                request_leaves=("scoring.top_logprobs",),
+                response_channels=("top_logprobs",),
+                _config_validator=_validate_top_logprobs_config,
+            )
+        ),
+        "reasoning": Supported(
+            DialectCapabilityBinding(
+                "reasoning",
+                request_leaves=("reasoning.effort", "reasoning.summary"),
+                response_channels=("reasoning",),
+                _config_validator=_validate_reasoning_config,
+            )
+        ),
+        "function_tools": Supported(
+            DialectCapabilityBinding(
+                "function_tools",
+                request_leaves=(
+                    "tools.functions",
+                    "tools.choice",
+                    "tools.parallel",
+                ),
+                response_channels=("tool_calls",),
+            )
+        ),
+        "hosted_tools": Supported(
+            DialectCapabilityBinding(
+                "hosted_tools",
+                request_leaves=("tools.hosted",),
+                response_channels=("server_tool_uses",),
+                _config_validator=_validate_hosted_tools_config,
+            )
+        ),
+        "structured_output": Supported(
+            DialectCapabilityBinding(
+                "structured_output",
+                request_leaves=(
+                    "structured_output.format",
+                    "structured_output.schema",
+                    "structured_output.name",
+                    "structured_output.strict",
+                ),
+                response_channels=("structured_output",),
+            )
+        ),
+        "stateful_session": Supported(
+            DialectCapabilityBinding(
+                "stateful_session",
+                request_leaves=("session.previous_response_id",),
+                response_channels=("session_id",),
+            )
+        ),
+        "opaque_continuation": Supported(
+            DialectCapabilityBinding(
+                "opaque_continuation",
+                request_leaves=("session.opaque_continuation",),
+                response_channels=("reasoning",),
+            )
+        ),
+        "multimodal_input": Supported(
+            DialectCapabilityBinding(
+                "multimodal_input",
+                request_leaves=(
+                    "input.modality.image",
+                    "input.modality.image.detail",
+                    "input.modality.image.media_type",
+                ),
+                _config_validator=_validate_multimodal_config,
+            )
+        ),
+        "prefill": Unsupported("Responses has no assistant-prefill field"),
+        "fim": Unsupported("Responses has no completion-suffix field"),
+    }
+    if set(decisions) != set(CAPABILITY_KEYS):
+        raise AssertionError("OpenAI Responses capability row is incomplete")
+    return MappingProxyType(decisions)
+
+
+def _tuple_validator(item_type: type, channel: str) -> Callable[[object], None]:
+    def validate(value: object) -> None:
+        if not isinstance(value, tuple) or not all(
+            isinstance(item, item_type) for item in value
+        ):
+            raise OutputContractError(f"{channel} channel has invalid shape")
+
+    return validate
+
+
+CAPABILITY_DECISIONS = _decisions()
+
+
+OUTPUT_CONTRACT = OutputContract(
+    {
+        "reasoning": OutputRule(Guarantee.PRESENT_OR_ERROR, validate_reasoning),
+        "tool_calls": OutputRule(Guarantee.BEST_EFFORT, validate_tool_calls),
+        "server_tool_uses": OutputRule(
+            Guarantee.BEST_EFFORT,
+            _tuple_validator(ServerToolUse, "server_tool_uses"),
+        ),
+        "structured_output": OutputRule(
+            Guarantee.PRESENT_OR_ERROR, validate_structured_output
+        ),
+        "logprobs": OutputRule(
+            Guarantee.PRESENT_OR_ERROR,
+            _tuple_validator(TokenLogprob, "logprobs"),
+        ),
+        "top_logprobs": OutputRule(Guarantee.PRESENT_OR_ERROR, validate_top_logprobs),
+        "input_scoring": OutputRule(Guarantee.NEVER),
+        "citations": OutputRule(
+            Guarantee.BEST_EFFORT,
+            _tuple_validator(Citation, "citations"),
+        ),
+        "grounding": OutputRule(Guarantee.NEVER),
+        "session_id": OutputRule(Guarantee.PRESENT_OR_ERROR),
+        "usage": OutputRule(Guarantee.BEST_EFFORT),
+    }
+)
+
+
+_UNSUPPORTED_REQUEST_PATHS = frozenset(
+    {
+        "sampling.top_k",
+        "sampling.stop",
+        "sampling.seed",
+        "sampling.frequency_penalty",
+        "sampling.presence_penalty",
+        "sampling.n",
+    }
+)
+
+_IR_OWNED_BODY_KEYS = BINDING_RESOURCE_KEYS | frozenset(
+    {
+        "model",
+        "input",
+        "instructions",
+        "messages",
+        "prompt",
+        "max_tokens",
+        "max_completion_tokens",
+        "max_output_tokens",
+        "temperature",
+        "top_p",
+        "top_k",
+        "stop",
+        "seed",
+        "frequency_penalty",
+        "presence_penalty",
+        "n",
+        "logprobs",
+        "top_logprobs",
+        "echo",
+        "score_input",
+        "return_logprobs",
+        "reasoning",
+        "reasoning_effort",
+        "tools",
+        "functions",
+        "tool_choice",
+        "function_call",
+        "parallel_tool_calls",
+        "server_tools",
+        "web_search_options",
+        "text",
+        "response_format",
+        "previous_response_id",
+        "session_id",
+        "opaque_continuation",
+        "suffix",
+        "include",
+        "stream",
+        "stream_options",
+        "extra_body",
+    }
+)
+
+
+@dataclass(frozen=True)
+class _ResponsesContext:
+    request: Request
+
+
+@dataclass(frozen=True)
+class _ResponsesExecutionContext:
+    request: Request
+    request_params: Mapping[str, JSONValue]
+    input_items: tuple[Mapping[str, JSONValue], ...]
+    requested_store: bool
+    store_explicit: bool
+    has_hidden_previous_response: bool
+
+
+@dataclass(frozen=True)
+class _LegacyPlan:
+    dialect_id: str = "openai_responses"
+    available_capabilities: frozenset[str] = frozenset(
+        key
+        for key, decision in CAPABILITY_DECISIONS.items()
+        if isinstance(decision, Supported)
+    )
+    capability_minimums: Mapping[str, Mapping[str, JSONValue]] = field(
+        default_factory=dict
+    )
+    required_output_channels: frozenset[str] = frozenset()
+
+
+def _request_stores_response(req: Request) -> bool:
+    options = req.dialect_options
+    return options is None or options.values.get("store") is not False
+
+
+def _execution_context(
+    prepared: PreparedRequest,
+    context: _ResponsesContext,
+) -> tuple[dict[str, JSONValue], bool, _ResponsesExecutionContext]:
+    body = prepared.thaw_body()
+    model = body.get("model")
+    if not isinstance(model, str) or not model:
+        raise DialectError("prepared Responses request has an invalid model")
+    stream = body.get("stream")
+    if not isinstance(stream, bool):
+        raise DialectError("prepared Responses request has an invalid stream flag")
+
+    raw_input = body.get("input")
+    if not isinstance(raw_input, list):
+        raise DialectError("prepared Responses request has an invalid input body")
+    copied_input = copy_json_value(raw_input, "Responses request input")
+    if not isinstance(copied_input, list):
+        raise AssertionError("copied Responses input must remain a list")
+    input_items: list[Mapping[str, JSONValue]] = []
+    for index, item in enumerate(copied_input):
+        if not isinstance(item, dict):
+            raise DialectError(
+                f"prepared Responses input item {index} must be an object"
+            )
+        input_items.append(item)
+
+    extra_body = body.get("extra_body")
+    if extra_body is not None and not isinstance(extra_body, dict):
+        raise DialectError("prepared Responses extra_body must be an object")
+    extra_mapping = extra_body if isinstance(extra_body, dict) else None
+    store_explicit = extra_mapping is not None and "store" in extra_mapping
+    raw_store = extra_mapping.get("store", True) if extra_mapping is not None else True
+    if not isinstance(raw_store, bool):
+        raise DialectError("prepared Responses store must be a boolean")
+
+    request_params = thaw_json_mapping(
+        {key: value for key, value in body.items() if key not in {"model", "input"}},
+        "Responses request parameters",
+    )
+    return (
+        body,
+        stream,
+        _ResponsesExecutionContext(
+            request=context.request,
+            request_params=request_params,
+            input_items=tuple(input_items),
+            requested_store=raw_store,
+            store_explicit=store_explicit,
+            has_hidden_previous_response="previous_response_id" in body,
+        ),
+    )
+
+
+def _get(raw: object, name: str, default: object = None) -> object:
+    if isinstance(raw, Mapping):
+        return cast(Mapping[object, object], raw).get(name, default)
+    return getattr(raw, name, default)
+
+
+def _sequence(raw: object, path: str) -> Sequence[object]:
+    if not isinstance(raw, Sequence) or isinstance(raw, str | bytes):
+        raise OutputContractError(f"{path} must be a sequence")
+    return cast(Sequence[object], raw)
+
+
+def _required_string(raw: object, path: str) -> str:
+    if not isinstance(raw, str) or not raw:
+        raise OutputContractError(f"{path} must be a non-empty string")
+    return raw
+
+
+def _string(raw: object, path: str) -> str:
+    if not isinstance(raw, str):
+        raise OutputContractError(f"{path} must be a string")
+    return raw
+
+
+def _optional_string(raw: object, path: str) -> str | None:
+    if raw is None:
+        return None
+    if not isinstance(raw, str):
+        raise OutputContractError(f"{path} must be a string or None")
+    return raw
+
+
+def _finite_logprob(raw: object, path: str) -> float:
+    if isinstance(raw, bool) or not isinstance(raw, int | float):
+        raise OutputContractError(f"{path} must be numeric")
+    value = float(raw)
+    if not math.isfinite(value):
+        raise OutputContractError(f"{path} must be finite")
+    return value
+
+
+def _json_text(value: JSONValue) -> str:
+    if isinstance(value, str):
+        return value
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def _arguments_text(value: JSONValue) -> str:
+    return value if isinstance(value, str) else _json_text(value)
+
+
+def _image_rejection(part: ImagePart) -> tuple[str, str] | None:
+    if part.url is not None:
+        if not part.url:
+            return ("input.modality.image", "Responses image URLs must not be empty")
+        if part.media_type is not None:
+            return (
+                "input.modality.image.media_type",
+                "Responses has no media-type field for URL-backed images",
+            )
+    else:
+        if not part.data:
+            return (
+                "input.modality.image",
+                "Responses inline images require non-empty base64 data",
+            )
+        if part.media_type is None:
+            return (
+                "input.modality.image",
+                "Responses inline images require an explicit image media type",
+            )
+        if part.media_type not in _SUPPORTED_IMAGE_MEDIA_TYPES:
+            return (
+                "input.modality.image.media_type",
+                f"unsupported Responses image media type {part.media_type!r}",
+            )
+    if part.detail is not None and part.detail not in _SUPPORTED_IMAGE_DETAILS:
+        return (
+            "input.modality.image.detail",
+            f"unsupported Responses image detail {part.detail!r}",
+        )
+    return None
+
+
+def _image_to_wire(part: ImagePart) -> dict[str, JSONValue]:
+    rejection = _image_rejection(part)
+    if rejection is not None:
+        raise DialectError(rejection[1])
+    if part.url is not None:
+        image_url = part.url
+    else:
+        assert part.media_type is not None
+        image_url = f"data:{part.media_type};base64,{part.data}"
+    return {
+        "type": "input_image",
+        "image_url": image_url,
+        "detail": part.detail if part.detail is not None else "auto",
+    }
+
+
+def _message_to_input_items(message: ChatMessage) -> list[dict[str, JSONValue]]:
+    if message.name is not None:
+        raise DialectError("Responses messages cannot carry ChatMessage.name")
+
+    results = [part for part in message.content if isinstance(part, ToolResultPart)]
+
+    if results:
+        if message.role != "tool" or len(results) != 1 or len(message.content) != 1:
+            raise DialectError(
+                "a Responses tool-result message must contain exactly one result"
+            )
+        result = results[0]
+        if result.is_error:
+            raise DialectError(
+                "Responses function_call_output cannot transmit is_error"
+            )
+        return [
+            {
+                "type": "function_call_output",
+                "call_id": result.call_id,
+                "output": _json_text(result.result),
+            }
+        ]
+
+    if message.role == "tool":
+        raise DialectError("a Responses tool message requires one result part")
+    if any(isinstance(part, ToolCallPart) for part in message.content) and (
+        message.role != "assistant"
+    ):
+        raise DialectError("historical function calls require an assistant message")
+
+    items: list[dict[str, JSONValue]] = []
+    inline_run: list[TextPart | ImagePart] = []
+
+    def flush_inline(*, force: bool = False) -> None:
+        if not inline_run and not force:
+            return
+        if all(isinstance(part, TextPart) for part in inline_run):
+            content: JSONValue = "".join(
+                cast(TextPart, part).text for part in inline_run
+            )
+        else:
+            parts: list[JSONValue] = []
+            for part in inline_run:
+                if isinstance(part, TextPart):
+                    parts.append({"type": "input_text", "text": part.text})
+                else:
+                    parts.append(_image_to_wire(part))
+            content = parts
+        items.append(
+            {
+                "type": "message",
+                "role": message.role,
+                "content": content,
+            }
+        )
+        inline_run.clear()
+
+    for part in message.content:
+        if isinstance(part, TextPart | ImagePart):
+            inline_run.append(part)
+            continue
+        if isinstance(part, ToolCallPart):
+            flush_inline()
+            items.append(
+                {
+                    "type": "function_call",
+                    "call_id": part.call_id,
+                    "name": part.name,
+                    "arguments": _arguments_text(part.arguments),
+                }
+            )
+            continue
+        raise DialectError(f"unsupported Responses message part {type(part).__name__}")
+
+    flush_inline(force=not message.content)
+    return items
+
+
+def _function_tool_to_wire(raw: Mapping[str, JSONValue]) -> dict[str, JSONValue]:
+    data = dict(raw)
+    if data.get("type") != "function":
+        raise DialectError("function tool declarations require type='function'")
+    nested = data.get("function")
+    if nested is not None:
+        if set(data) != {"type", "function"} or not isinstance(nested, Mapping):
+            raise DialectError("invalid Chat-shaped function tool declaration")
+        source = dict(nested)
+    else:
+        source = data
+        source.pop("type", None)
+
+    allowed = {"name", "description", "parameters", "strict"}
+    unknown = set(source) - allowed
+    if unknown:
+        raise DialectError(
+            "unsupported function tool field(s): " + ", ".join(sorted(unknown))
+        )
+    name = source.get("name")
+    if not isinstance(name, str) or not name:
+        raise DialectError("function tool name must be a non-empty string")
+
+    result: dict[str, JSONValue] = {"type": "function", "name": name}
+    for key in ("description", "parameters", "strict"):
+        if key in source:
+            result[key] = source[key]
+    return result
+
+
+def _tool_choice_to_wire(raw: JSONValue) -> JSONValue:
+    if isinstance(raw, str):
+        if raw not in {"none", "auto", "required"}:
+            raise DialectError(f"unsupported Responses tool choice {raw!r}")
+        return raw
+    if not isinstance(raw, Mapping):
+        raise DialectError("Responses tool choice must be a string or mapping")
+    data = dict(raw)
+    if data.get("type") != "function":
+        raise DialectError("only function-specific mapped tool choices are supported")
+    nested = data.get("function")
+    if nested is not None:
+        if set(data) != {"type", "function"} or not isinstance(nested, Mapping):
+            raise DialectError("invalid Chat-shaped function tool choice")
+        name = nested.get("name")
+    else:
+        if set(data) != {"type", "name"}:
+            raise DialectError("invalid Responses function tool choice")
+        name = data.get("name")
+    if not isinstance(name, str) or not name:
+        raise DialectError("function tool choice requires a non-empty name")
+    return {"type": "function", "name": name}
+
+
+def _hosted_tool_to_wire(spec: HostedToolSpec) -> dict[str, JSONValue]:
+    if spec.kind not in _SUPPORTED_HOSTED_TOOL_KINDS:
+        raise DialectError(
+            f"unsupported Responses hosted tool kind {spec.kind!r}; "
+            "only web search is currently losslessly lifted"
+        )
+    if "type" in spec.config:
+        raise DialectError("hosted tool config cannot override its type")
+    return {"type": spec.kind, **dict(spec.config)}
+
+
+def _structured_text_config(req: Request) -> dict[str, JSONValue] | None:
+    params = req.structured_output
+    if params.format is None:
+        return None
+    if params.format == "json_object":
+        return {"format": {"type": "json_object"}}
+    schema: dict[str, JSONValue] = {
+        "type": "json_schema",
+        "name": params.name if params.name is not None else "response",
+        "schema": dict(params.schema or {}),
+    }
+    if params.strict is not None:
+        schema["strict"] = params.strict
+    return {"format": schema}
+
+
+def _reject_nonstandard_json_constant(value: str) -> NoReturn:
+    raise ValueError(f"non-standard JSON constant {value!r}")
+
+
+def _unique_json_object(
+    pairs: list[tuple[str, JSONValue]],
+) -> dict[str, JSONValue]:
+    result: dict[str, JSONValue] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON object key {key!r}")
+        result[key] = value
+    return result
+
+
+def _decode_opaque_continuation(value: str) -> list[dict[str, JSONValue]]:
+    try:
+        raw = json.loads(
+            value,
+            object_pairs_hook=_unique_json_object,
+            parse_constant=_reject_nonstandard_json_constant,
+        )
+    except (json.JSONDecodeError, ValueError) as exc:
+        raise DialectError("invalid Responses opaque continuation JSON") from exc
+    if not isinstance(raw, dict):
+        raise DialectError("invalid Responses opaque continuation envelope")
+    unknown = set(raw) - {"version", "items"}
+    if unknown:
+        raise DialectError(
+            "invalid Responses opaque continuation envelope field(s): "
+            + ", ".join(sorted(unknown))
+        )
+    version = raw.get("version")
+    if type(version) is not int or version != _OPAQUE_CONTINUATION_VERSION:
+        raise DialectError("unsupported Responses opaque continuation version")
+    items = raw.get("items")
+    if not isinstance(items, list) or not items:
+        raise DialectError("Responses opaque continuation has no history items")
+    result: list[dict[str, JSONValue]] = []
+    saw_reasoning = False
+    for index, item in enumerate(items):
+        try:
+            payload = _history_item_payload(
+                item,
+                index,
+                require_encrypted_reasoning=True,
+            )
+        except OutputContractError as exc:
+            raise DialectError(
+                f"invalid Responses opaque continuation item {index}: {exc}"
+            ) from exc
+        saw_reasoning |= payload["type"] == "reasoning"
+        result.append(payload)
+    if not saw_reasoning:
+        raise DialectError("Responses opaque continuation has no reasoning item")
+    return result
+
+
+def _canonical_wire_value(value: object, path: str) -> str:
+    return json.dumps(
+        copy_json_value(value, path),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    )
+
+
+def _wire_values_match(expected: object, actual: object, path: str) -> bool:
+    try:
+        return _canonical_wire_value(expected, path) == _canonical_wire_value(
+            actual, path
+        )
+    except (TypeError, ValueError):
+        return False
+
+
+def _verification_json_text(value: JSONValue) -> str:
+    if isinstance(value, str):
+        return value
+    return json.dumps(
+        copy_json_value(value, "Responses verification value"),
+        ensure_ascii=False,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def _verification_image(part: ImagePart) -> dict[str, JSONValue]:
+    image_url = (
+        part.url
+        if part.url is not None
+        else f"data:{part.media_type};base64,{part.data}"
+    )
+    return {
+        "type": "input_image",
+        "image_url": image_url,
+        "detail": part.detail if part.detail is not None else "auto",
+    }
+
+
+def _verification_message_items(message: ChatMessage) -> list[dict[str, JSONValue]]:
+    results = [part for part in message.content if isinstance(part, ToolResultPart)]
+    if results:
+        result = results[0]
+        return [
+            {
+                "type": "function_call_output",
+                "call_id": result.call_id,
+                "output": _verification_json_text(result.result),
+            }
+        ]
+
+    items: list[dict[str, JSONValue]] = []
+    inline: list[TextPart | ImagePart] = []
+
+    def flush_inline(*, force: bool = False) -> None:
+        if not inline and not force:
+            return
+        if all(isinstance(part, TextPart) for part in inline):
+            content: JSONValue = "".join(cast(TextPart, part).text for part in inline)
+        else:
+            content = [
+                {"type": "input_text", "text": part.text}
+                if isinstance(part, TextPart)
+                else _verification_image(part)
+                for part in inline
+            ]
+        items.append(
+            {
+                "type": "message",
+                "role": message.role,
+                "content": content,
+            }
+        )
+        inline.clear()
+
+    for part in message.content:
+        if isinstance(part, TextPart | ImagePart):
+            inline.append(part)
+        elif isinstance(part, ToolCallPart):
+            flush_inline()
+            items.append(
+                {
+                    "type": "function_call",
+                    "call_id": part.call_id,
+                    "name": part.name,
+                    "arguments": _verification_json_text(part.arguments),
+                }
+            )
+    flush_inline(force=not message.content)
+    return items
+
+
+def _verification_continuation_items(value: str) -> list[JSONValue]:
+    raw = json.loads(
+        value,
+        object_pairs_hook=_unique_json_object,
+        parse_constant=_reject_nonstandard_json_constant,
+    )
+    if not isinstance(raw, dict) or raw.get("version") != _OPAQUE_CONTINUATION_VERSION:
+        raise ValueError("invalid opaque continuation envelope")
+    items = raw.get("items")
+    if not isinstance(items, list):
+        raise ValueError("invalid opaque continuation items")
+    expected: list[JSONValue] = []
+    for item in items:
+        copied = copy_json_value(item, "opaque continuation item")
+        if not isinstance(copied, dict):
+            raise TypeError("opaque continuation item must be an object")
+        if copied.get("type") == "reasoning":
+            copied = {key: item for key, item in copied.items() if item is not None}
+        expected.append(copied)
+    return expected
+
+
+@dataclass(frozen=True)
+class _ResponsesInputVerifier:
+    source: ChatInput
+    opaque_continuation: str | None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "source", deepcopy(self.source))
+
+    def verify(self, body: Mapping[str, JSONValue]) -> str | None:
+        actual = body.get("input")
+        if not isinstance(actual, list):
+            return "body.input must be a list"
+        try:
+            expected = (
+                _verification_continuation_items(self.opaque_continuation)
+                if self.opaque_continuation is not None
+                else []
+            )
+            for message in self.source.messages:
+                expected.extend(_verification_message_items(message))
+        except (TypeError, ValueError, json.JSONDecodeError):
+            return "source input cannot be verified"
+        if not _wire_values_match(expected, actual, "Responses input"):
+            return "body.input changed or reordered"
+        return None
+
+
+def _verification_function_tool(
+    raw: Mapping[str, JSONValue],
+) -> dict[str, JSONValue]:
+    data = dict(raw)
+    nested = data.get("function")
+    source = (
+        dict(nested)
+        if isinstance(nested, Mapping)
+        else {key: value for key, value in data.items() if key != "type"}
+    )
+    result: dict[str, JSONValue] = {
+        "type": "function",
+        "name": source.get("name"),
+    }
+    for key in ("description", "parameters", "strict"):
+        if key in source:
+            result[key] = source[key]
+    return result
+
+
+@dataclass(frozen=True)
+class _ResponsesToolsVerifier:
+    functions: tuple[Mapping[str, JSONValue], ...]
+    hosted: tuple[HostedToolSpec, ...]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "functions", deepcopy(self.functions))
+        object.__setattr__(self, "hosted", deepcopy(self.hosted))
+
+    def verify(self, body: Mapping[str, JSONValue]) -> str | None:
+        expected: list[JSONValue] = [
+            _verification_function_tool(tool) for tool in self.functions
+        ]
+        expected.extend(
+            {"type": tool.kind, **dict(tool.config)} for tool in self.hosted
+        )
+        actual = body.get("tools")
+        if not _wire_values_match(expected, actual, "Responses tools"):
+            return "body.tools changed or reordered"
+        if self.hosted:
+            includes = body.get("include")
+            if not isinstance(includes, list) or (
+                "web_search_call.action.sources" not in includes
+            ):
+                return "body.include omitted hosted-tool sources"
+        return None
+
+
+@dataclass(frozen=True)
+class _ResponsesToolChoiceVerifier:
+    source: JSONValue
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "source",
+            copy_json_value(self.source, "Responses tool choice"),
+        )
+
+    def verify(self, body: Mapping[str, JSONValue]) -> str | None:
+        source = self.source
+        if isinstance(source, str):
+            expected: JSONValue = source
+        else:
+            if not isinstance(source, dict):
+                return "source tool choice is invalid"
+            nested = source.get("function")
+            name = (
+                nested.get("name") if isinstance(nested, dict) else source.get("name")
+            )
+            expected = {"type": "function", "name": name}
+        if not _wire_values_match(
+            expected, body.get("tool_choice"), "Responses tool choice"
+        ):
+            return "body.tool_choice changed"
+        return None
+
+
+@dataclass(frozen=True)
+class _ResponsesLogprobsVerifier:
+    top_logprobs: int
+
+    def verify(self, body: Mapping[str, JSONValue]) -> str | None:
+        actual = body.get("top_logprobs")
+        if (
+            not isinstance(actual, int)
+            or isinstance(actual, bool)
+            or actual != self.top_logprobs
+        ):
+            return "body.top_logprobs changed"
+        includes = body.get("include")
+        if not isinstance(includes, list) or (
+            "message.output_text.logprobs" not in includes
+        ):
+            return "body.include omitted message logprobs"
+        return None
+
+
+def _plain_json(value: object, path: str) -> JSONValue:
+    model_dump = getattr(value, "model_dump", None)
+    if callable(model_dump):
+        value = model_dump(mode="json", exclude_none=True)
+    if value is None or isinstance(value, str | int | bool):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise OutputContractError(f"{path} contains a non-finite float")
+        return value
+    if isinstance(value, Mapping):
+        result: dict[str, JSONValue] = {}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise OutputContractError(f"{path} contains a non-string key")
+            result[key] = _plain_json(item, f"{path}.{key}")
+        return result
+    if isinstance(value, Sequence) and not isinstance(value, str | bytes):
+        return [
+            _plain_json(item, f"{path}[{index}]") for index, item in enumerate(value)
+        ]
+    attributes = getattr(value, "__dict__", None)
+    if isinstance(attributes, dict):
+        return _plain_json(
+            {key: item for key, item in attributes.items() if not key.startswith("_")},
+            path,
+        )
+    raise OutputContractError(
+        f"{path} contains unsupported value {type(value).__name__}"
+    )
+
+
+def _validate_reasoning_text_parts(
+    payload: Mapping[str, JSONValue],
+    *,
+    field_name: str,
+    expected_type: str,
+    item_index: int,
+    required: bool,
+) -> None:
+    path = f"response.output[{item_index}].{field_name}"
+    raw = payload.get(field_name)
+    if raw is None:
+        if required:
+            raise OutputContractError(f"{path} must be a list")
+        return
+    if not isinstance(raw, list):
+        raise OutputContractError(f"{path} must be a list")
+    for part_index, part in enumerate(raw):
+        part_path = f"{path}[{part_index}]"
+        if not isinstance(part, dict):
+            raise OutputContractError(f"{part_path} must be an object")
+        unknown = set(part) - _REASONING_TEXT_PART_KEYS
+        if unknown:
+            raise OutputContractError(
+                f"{part_path} has unsupported field(s): " + ", ".join(sorted(unknown))
+            )
+        if set(part) != _REASONING_TEXT_PART_KEYS:
+            raise OutputContractError(f"{part_path} requires type and text")
+        if part["type"] != expected_type:
+            raise OutputContractError(f"{part_path}.type must be {expected_type!r}")
+        if not isinstance(part["text"], str):
+            raise OutputContractError(f"{part_path}.text must be a string")
+
+
+def _reasoning_payload(raw: object, index: int) -> dict[str, JSONValue]:
+    raw_payload = _plain_json(raw, f"response.output[{index}]")
+    if not isinstance(raw_payload, dict) or raw_payload.get("type") != "reasoning":
+        raise OutputContractError("reasoning output item has invalid shape")
+    unknown = set(raw_payload) - _REASONING_ITEM_KEYS
+    if unknown:
+        raise OutputContractError(
+            "reasoning output item has unsupported field(s): "
+            + ", ".join(sorted(unknown))
+        )
+    payload = {key: value for key, value in raw_payload.items() if value is not None}
+    item_id = payload.get("id")
+    if not isinstance(item_id, str) or not item_id:
+        raise OutputContractError("reasoning output item is missing id")
+    _validate_reasoning_text_parts(
+        payload,
+        field_name="summary",
+        expected_type="summary_text",
+        item_index=index,
+        required=True,
+    )
+    _validate_reasoning_text_parts(
+        payload,
+        field_name="content",
+        expected_type="reasoning_text",
+        item_index=index,
+        required=False,
+    )
+    status = payload.get("status")
+    if status is not None and (
+        not isinstance(status, str) or status not in _REASONING_ITEM_STATUSES
+    ):
+        raise OutputContractError("reasoning output item has invalid status")
+    encrypted = payload.get("encrypted_content")
+    if encrypted is not None and not isinstance(encrypted, str):
+        raise OutputContractError(
+            "reasoning output item encrypted_content must be a string"
+        )
+    return cast(dict[str, JSONValue], payload)
+
+
+def _opaque_history_bundle(
+    input_items: Sequence[Mapping[str, JSONValue]],
+    output_items: Sequence[object],
+    *,
+    has_hidden_previous_response: bool,
+) -> str | None:
+    """Serialize the complete stateless Responses history for the next call.
+
+    OpenAI's stateless contract requires replaying the exact prior input and
+    every output item in order.  A request chained through
+    ``previous_response_id`` has hidden server-side history, so no faithful
+    standalone continuation can be constructed for that response.
+    """
+
+    if has_hidden_previous_response:
+        return None
+    history = [dict(item) for item in input_items]
+    saw_reasoning = any(item.get("type") == "reasoning" for item in history)
+    if not saw_reasoning and not any(
+        _get(item, "type") == "reasoning" for item in output_items
+    ):
+        return None
+    for index, item in enumerate(output_items):
+        payload = _history_item_payload(
+            item,
+            index,
+            require_encrypted_reasoning=False,
+        )
+        if payload["type"] == "reasoning":
+            encrypted = payload.get("encrypted_content")
+            if not isinstance(encrypted, str) or not encrypted:
+                return None
+            saw_reasoning = True
+        history.append(payload)
+    return json.dumps(
+        {"version": _OPAQUE_CONTINUATION_VERSION, "items": history},
+        ensure_ascii=False,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def _visible_reasoning_text(raw: object, path: str) -> tuple[str | None, bool]:
+    summary_texts: list[str] = []
+    summary = _sequence(_get(raw, "summary", []), f"{path}.summary")
+    for index, part in enumerate(summary):
+        if _get(part, "type") != "summary_text":
+            raise OutputContractError(f"{path}.summary[{index}] has unknown type")
+        summary_texts.append(
+            _string(_get(part, "text"), f"{path}.summary[{index}].text")
+        )
+    if summary_texts:
+        return "\n".join(summary_texts), True
+
+    content = _get(raw, "content")
+    if content is None:
+        return None, False
+    content_texts: list[str] = []
+    for index, part in enumerate(_sequence(content, f"{path}.content")):
+        if _get(part, "type") != "reasoning_text":
+            raise OutputContractError(f"{path}.content[{index}] has unknown type")
+        content_texts.append(
+            _string(_get(part, "text"), f"{path}.content[{index}].text")
+        )
+    return "\n".join(content_texts) or None, False
+
+
+def _usage_detail(raw: object, container: str, name: str) -> int | None:
+    details = _get(raw, container)
+    value = _get(details, name) if details is not None else None
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        return None
+    return value
+
+
+def _usage_stats(raw: object) -> UsageStats | None:
+    if raw is None:
+        return None
+    values: list[int] = []
+    for name in ("input_tokens", "output_tokens"):
+        value = _get(raw, name)
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            raise OutputContractError(
+                f"Responses usage.{name} must be a non-negative integer"
+            )
+        values.append(value)
+    computed = values[0] + values[1]
+    reported = _get(raw, "total_tokens")
+    reported_total = (
+        reported
+        if isinstance(reported, int)
+        and not isinstance(reported, bool)
+        and reported >= 0
+        and reported != computed
+        else None
+    )
+    # ``cache_write_tokens`` is newer than the repository's minimum OpenAI SDK
+    # and has no field in the shared UsageStats record. Usage is explicitly a
+    # best-effort channel, so the adapter preserves every representable count
+    # without inventing a destination for that future breakdown.
+    return UsageStats(
+        input_tokens=values[0],
+        output_tokens=values[1],
+        total_tokens=computed,
+        reasoning_tokens=_usage_detail(
+            raw, "output_tokens_details", "reasoning_tokens"
+        ),
+        cached_tokens=_usage_detail(raw, "input_tokens_details", "cached_tokens"),
+        reported_total_tokens=reported_total,
+    )
+
+
+def _finish_reason(raw: object) -> str:
+    status = _get(raw, "status")
+    incomplete_details = _get(raw, "incomplete_details")
+    error = _get(raw, "error")
+    if status == "completed":
+        if error is not None:
+            raise OutputContractError("completed Responses reply contains an error")
+        if incomplete_details is not None:
+            raise OutputContractError(
+                "completed Responses reply contains incomplete_details"
+            )
+        return "completed"
+    if status == "incomplete":
+        if error is not None:
+            raise OutputContractError("incomplete Responses reply contains an error")
+        reason = (
+            _get(incomplete_details, "reason")
+            if incomplete_details is not None
+            else None
+        )
+        return _required_string(reason, "response.incomplete_details.reason")
+    if status == "failed":
+        if incomplete_details is not None:
+            raise OutputContractError(
+                "failed Responses reply contains incomplete_details"
+            )
+        if error is None:
+            raise OutputContractError("failed Responses reply omitted its error")
+        code = _get(error, "code") if error is not None else None
+        message = _get(error, "message") if error is not None else None
+        raise OutputContractError(
+            "Responses request failed"
+            + (f" ({code})" if isinstance(code, str) and code else "")
+            + (f": {message}" if isinstance(message, str) and message else "")
+        )
+    raise OutputContractError(f"Responses reply has non-terminal status {status!r}")
+
+
+def _parse_logprobs(
+    raw: object,
+    path: str,
+) -> tuple[list[TokenLogprob], list[tuple[TopKEntry, ...]]]:
+    sampled: list[TokenLogprob] = []
+    alternatives: list[tuple[TopKEntry, ...]] = []
+    for position, item in enumerate(_sequence(raw, path)):
+        token = _string(_get(item, "token"), f"{path}[{position}].token")
+        logprob = _finite_logprob(_get(item, "logprob"), f"{path}[{position}].logprob")
+        sampled.append(TokenLogprob(token=token, logprob=logprob))
+        top: list[TopKEntry] = []
+        raw_top = _get(item, "top_logprobs", [])
+        for rank, entry in enumerate(
+            _sequence(raw_top, f"{path}[{position}].top_logprobs")
+        ):
+            top.append(
+                TopKEntry(
+                    token=_string(
+                        _get(entry, "token"),
+                        f"{path}[{position}].top_logprobs[{rank}].token",
+                    ),
+                    logprob=_finite_logprob(
+                        _get(entry, "logprob"),
+                        f"{path}[{position}].top_logprobs[{rank}].logprob",
+                    ),
+                )
+            )
+        alternatives.append(tuple(top))
+    return sampled, alternatives
+
+
+def _url_citations(raw: object, path: str) -> list[Citation]:
+    citations: list[Citation] = []
+    for index, annotation in enumerate(_sequence(raw, path)):
+        annotation_type = _get(annotation, "type")
+        if annotation_type != "url_citation":
+            raise OutputContractError(
+                f"{path}[{index}] type {annotation_type!r} has no lossless IR mapping"
+            )
+        citations.append(
+            Citation(
+                url=_required_string(_get(annotation, "url"), f"{path}[{index}].url"),
+                title=_optional_string(
+                    _get(annotation, "title"), f"{path}[{index}].title"
+                ),
+            )
+        )
+    return citations
+
+
+def _function_call(raw: object, path: str) -> FunctionToolCall:
+    arguments = _get(raw, "arguments")
+    if not isinstance(arguments, str):
+        raise OutputContractError(f"{path}.arguments must be a string")
+    return FunctionToolCall(
+        call_id=_required_string(_get(raw, "call_id"), f"{path}.call_id"),
+        name=_required_string(_get(raw, "name"), f"{path}.name"),
+        arguments=arguments,
+    )
+
+
+def _validate_terminal_item_status(
+    raw: object,
+    path: str,
+) -> None:
+    status = _get(raw, "status", _MISSING)
+    if status is _MISSING or status is None:
+        return
+    if status == "in_progress":
+        raise OutputContractError(
+            f"{path} remains in_progress in a terminal Responses reply"
+        )
+    if not isinstance(status, str) or status not in _TERMINAL_ITEM_STATUSES:
+        raise OutputContractError(f"{path}.status {status!r} is not terminal")
+
+
+def _web_search_use(raw: object, path: str) -> ServerToolUse:
+    status = _required_string(_get(raw, "status"), f"{path}.status")
+    if status in {"in_progress", "searching"}:
+        raise OutputContractError(
+            f"{path} remains {status} in a terminal Responses reply"
+        )
+    if status not in {"completed", "failed", "incomplete"}:
+        raise OutputContractError(
+            f"{path}.status {status!r} has no terminal shared-IR mapping"
+        )
+    action_value = _plain_json(_get(raw, "action"), f"{path}.action")
+    if not isinstance(action_value, dict):
+        raise OutputContractError(f"{path}.action must be an object")
+    action = dict(action_value)
+    result = action.pop("sources", None)
+    return ServerToolUse(
+        tool_type="web_search",
+        tool_use_id=_required_string(_get(raw, "id"), f"{path}.id"),
+        input=action,
+        result=result,
+        error_code=None if status == "completed" else status,
+    )
+
+
+def _reject_unknown_history_fields(
+    payload: Mapping[str, JSONValue],
+    allowed: frozenset[str],
+    path: str,
+) -> None:
+    unknown = set(payload) - allowed
+    if unknown:
+        raise OutputContractError(
+            f"{path} has unsupported field(s): " + ", ".join(sorted(unknown))
+        )
+
+
+def _validate_history_status(value: object, path: str) -> None:
+    if not isinstance(value, str) or value not in _MESSAGE_ITEM_STATUSES:
+        raise OutputContractError(f"{path} has invalid status {value!r}")
+
+
+def _validate_input_content_part(
+    part: object,
+    path: str,
+) -> None:
+    if not isinstance(part, Mapping):
+        raise OutputContractError(f"{path} must be an object")
+    payload = cast(Mapping[str, JSONValue], part)
+    part_type = payload.get("type")
+    if part_type == "input_text":
+        _reject_unknown_history_fields(payload, _INPUT_TEXT_PART_KEYS, path)
+        _string(payload.get("text"), f"{path}.text")
+        return
+    if part_type == "input_image":
+        _reject_unknown_history_fields(payload, _INPUT_IMAGE_PART_KEYS, path)
+        _required_string(payload.get("image_url"), f"{path}.image_url")
+        detail = payload.get("detail")
+        if not isinstance(detail, str) or detail not in _SUPPORTED_IMAGE_DETAILS:
+            raise OutputContractError(f"{path}.detail has invalid value {detail!r}")
+        return
+    raise OutputContractError(f"{path} has unsupported type {part_type!r}")
+
+
+def _validate_output_content_part(
+    part: object,
+    path: str,
+) -> None:
+    if not isinstance(part, Mapping):
+        raise OutputContractError(f"{path} must be an object")
+    payload = cast(Mapping[str, JSONValue], part)
+    if payload.get("type") != "output_text":
+        raise OutputContractError(
+            f"{path} has unsupported type {payload.get('type')!r}"
+        )
+    _reject_unknown_history_fields(payload, _OUTPUT_TEXT_PART_KEYS, path)
+    _string(payload.get("text"), f"{path}.text")
+    annotations = payload.get("annotations")
+    if annotations is not None:
+        _url_citations(annotations, f"{path}.annotations")
+    logprobs = payload.get("logprobs")
+    if logprobs is not None:
+        _parse_logprobs(logprobs, f"{path}.logprobs")
+
+
+def _validate_history_message(
+    payload: Mapping[str, JSONValue],
+    path: str,
+) -> None:
+    _reject_unknown_history_fields(payload, _MESSAGE_ITEM_KEYS, path)
+    role = payload.get("role")
+    if not isinstance(role, str) or role not in _MESSAGE_ROLES:
+        raise OutputContractError(f"{path}.role has invalid value {role!r}")
+    content = payload.get("content")
+    is_output = "id" in payload or "status" in payload
+    if is_output:
+        _required_string(payload.get("id"), f"{path}.id")
+        _validate_history_status(payload.get("status"), f"{path}.status")
+        if role != "assistant":
+            raise OutputContractError(f"{path}.role must be 'assistant'")
+        for index, part in enumerate(_sequence(content, f"{path}.content")):
+            _validate_output_content_part(part, f"{path}.content[{index}]")
+        return
+    if isinstance(content, str):
+        return
+    for index, part in enumerate(_sequence(content, f"{path}.content")):
+        _validate_input_content_part(part, f"{path}.content[{index}]")
+
+
+def _validate_history_function_call(
+    payload: Mapping[str, JSONValue],
+    path: str,
+) -> None:
+    _reject_unknown_history_fields(payload, _FUNCTION_CALL_ITEM_KEYS, path)
+    _required_string(payload.get("call_id"), f"{path}.call_id")
+    _required_string(payload.get("name"), f"{path}.name")
+    _string(payload.get("arguments"), f"{path}.arguments")
+    if "id" in payload:
+        _required_string(payload.get("id"), f"{path}.id")
+    if "status" in payload:
+        _validate_history_status(payload.get("status"), f"{path}.status")
+
+
+def _validate_history_function_call_output(
+    payload: Mapping[str, JSONValue],
+    path: str,
+) -> None:
+    _reject_unknown_history_fields(payload, _FUNCTION_CALL_OUTPUT_ITEM_KEYS, path)
+    _required_string(payload.get("call_id"), f"{path}.call_id")
+    _string(payload.get("output"), f"{path}.output")
+    if "id" in payload:
+        _required_string(payload.get("id"), f"{path}.id")
+    if "status" in payload:
+        _validate_history_status(payload.get("status"), f"{path}.status")
+
+
+def _history_item_payload(
+    raw: object,
+    index: int,
+    *,
+    require_encrypted_reasoning: bool,
+) -> dict[str, JSONValue]:
+    path = f"history.items[{index}]"
+    raw_payload = _plain_json(raw, path)
+    if not isinstance(raw_payload, dict):
+        raise OutputContractError(f"{path} must be an object")
+    payload = raw_payload
+    item_type = payload.get("type")
+    if not isinstance(item_type, str) or item_type not in _HISTORY_ITEM_TYPES:
+        raise OutputContractError(f"{path} has unsupported type {item_type!r}")
+    if item_type == "reasoning":
+        reasoning = _reasoning_payload(payload, index)
+        if require_encrypted_reasoning:
+            encrypted = reasoning.get("encrypted_content")
+            if not isinstance(encrypted, str) or not encrypted:
+                raise OutputContractError(
+                    f"{path} reasoning item has no encrypted_content"
+                )
+        return reasoning
+    if item_type == "message":
+        _validate_history_message(payload, path)
+    elif item_type == "function_call":
+        _validate_history_function_call(payload, path)
+    elif item_type == "function_call_output":
+        _validate_history_function_call_output(payload, path)
+    else:
+        _reject_unknown_history_fields(payload, _WEB_SEARCH_ITEM_KEYS, path)
+        _web_search_use(payload, path)
+    return dict(payload)
+
+
+def _structured_output(req: Request, text: str) -> StructuredOutput | None:
+    if req.structured_output.format is None:
+        return None
+    try:
+        return StructuredOutput(
+            json.loads(
+                text,
+                object_pairs_hook=_unique_json_object,
+                parse_constant=_reject_nonstandard_json_constant,
+            )
+        )
+    except (TypeError, ValueError) as exc:
+        raise OutputContractError("structured output is not valid JSON") from exc
+
+
+class OpenAIResponsesDialect:
+    """Executable adapter for ``client.responses.create``."""
+
+    dialect_id = "openai_responses"
+    connection_family = "openai_sdk"
+    capability_decisions = CAPABILITY_DECISIONS
+    output_contract = OUTPUT_CONTRACT
+    CAPABILITIES = frozenset(
+        {
+            Capability.Chat,
+            Capability.FunctionCalling,
+            Capability.ServerTools,
+            Capability.Reasoning,
+            Capability.ReasoningEffort,
+            Capability.SampledLogprobs,
+            Capability.StructuredOutput,
+            Capability.TopKLogprobs,
+        }
+    )
+
+    def __init__(self, client: Any, requested_model_id: str):
+        if not requested_model_id:
+            raise ValueError("requested_model_id must not be empty")
+        self._client = client
+        self._requested_model_id = requested_model_id
+
+    @property
+    def capabilities(self) -> frozenset[Capability]:
+        """Deprecated enum view retained during the compatibility cycle."""
+
+        return self.CAPABILITIES
+
+    def validate_request(
+        self, req: Request, audit: RequestAudit, plan: RuntimePlanView
+    ) -> None:
+        """Account for every active leaf and reject unsupported semantics."""
+
+        audit.require_matches_request(req)
+        del plan
+        has_named_message = isinstance(req.input, ChatInput) and any(
+            message.name is not None for message in req.input.messages
+        )
+        image_rejection = None
+        if isinstance(req.input, ChatInput):
+            image_rejection = next(
+                (
+                    rejection
+                    for message in req.input.messages
+                    for part in message.content
+                    if isinstance(part, ImagePart)
+                    if (rejection := _image_rejection(part)) is not None
+                ),
+                None,
+            )
+        has_both_continuations = (
+            req.session.previous_response_id is not None
+            and req.session.opaque_continuation is not None
+        )
+        response_is_stored = _request_stores_response(req)
+
+        for path in audit.active_paths:
+            if path == "input.chat" and has_named_message:
+                audit.rejected(path, "Responses messages have no name field")
+            elif path in {"input.completion", "input.completion.suffix"}:
+                audit.rejected(path, "openai_responses requires ChatInput")
+            elif path in _UNSUPPORTED_REQUEST_PATHS:
+                audit.rejected(path, "Responses has no equivalent request field")
+            elif path == "scoring.input_scoring":
+                audit.rejected(path, "Responses cannot score input tokens")
+            elif path == "scoring.top_logprobs" and req.scoring.top_logprobs > 20:
+                audit.rejected(path, "Responses supports at most 20 top logprobs")
+            elif path == "reasoning.budget_tokens":
+                audit.rejected(path, "Responses has no reasoning token-budget field")
+            elif (
+                path == "reasoning.effort"
+                and req.reasoning.effort not in _OPENAI_REASONING_EFFORTS
+            ):
+                audit.rejected(
+                    path,
+                    f"unsupported OpenAI reasoning effort {req.reasoning.effort!r}",
+                )
+            elif path == "tools.hosted" and any(
+                tool.kind not in _SUPPORTED_HOSTED_TOOL_KINDS
+                for tool in req.tools.hosted
+            ):
+                audit.rejected(
+                    path,
+                    "only Responses web-search hosted tools currently have a "
+                    "lossless IR mapping",
+                )
+            elif image_rejection is not None and path == image_rejection[0]:
+                audit.rejected(path, image_rejection[1])
+            elif path == "input.modality.tool_result.is_error":
+                audit.rejected(
+                    path,
+                    "Responses function_call_output cannot transmit is_error",
+                )
+            elif path.startswith("session.") and has_both_continuations:
+                audit.rejected(
+                    path,
+                    "previous_response_id and opaque continuation are mutually "
+                    "exclusive",
+                )
+            elif path == "session.previous_response_id" and not response_is_stored:
+                # OpenAI permits this as a one-way continuation, but SiEval's
+                # stateful_session contract requires a reusable output ID.
+                audit.rejected(
+                    path,
+                    "store=false is stateless and cannot return a reusable "
+                    "session_id; use stored response chaining or replay the "
+                    "prior output items",
+                )
+            elif path == "structured_output.format" and (
+                req.structured_output.format not in {"json_object", "json_schema"}
+            ):
+                audit.rejected(path, "unsupported Responses text format")
+            elif (
+                path
+                in {
+                    "structured_output.schema",
+                    "structured_output.name",
+                    "structured_output.strict",
+                }
+                and req.structured_output.format != "json_schema"
+            ):
+                audit.rejected(
+                    path,
+                    "schema, name, and strict require format='json_schema'",
+                )
+            elif path == "structured_output.name" and req.structured_output.name == "":
+                audit.rejected(path, "Responses JSON schema names must not be empty")
+            elif path.startswith("dialect_options."):
+                key = path.removeprefix("dialect_options.")
+                if key == "conversation":
+                    audit.rejected(
+                        path,
+                        "Responses conversation state is not yet modeled by the "
+                        "provider-neutral stateful_session contract",
+                    )
+                elif key == "instructions":
+                    audit.rejected(
+                        path,
+                        "Responses instructions must be expressed through "
+                        "provider-neutral system or developer messages",
+                    )
+                elif key == "store" and (
+                    req.dialect_options is None
+                    or not isinstance(req.dialect_options.values[key], bool)
+                ):
+                    audit.rejected(path, "Responses store must be a boolean")
+                elif (
+                    key == "background"
+                    and req.dialect_options is not None
+                    and req.dialect_options.values[key] is True
+                ):
+                    audit.rejected(
+                        path,
+                        "background Responses cannot complete in this synchronous "
+                        "execution contract",
+                    )
+                elif key in _IR_OWNED_BODY_KEYS:
+                    audit.rejected(
+                        path,
+                        f"{key!r} must use its canonical provider-neutral field",
+                    )
+
+    def prepare(self, req: Request, audit: RequestAudit) -> PreparedRequest:
+        """Lower one audited request into Responses API keyword arguments."""
+
+        audit.require_matches_request(req)
+        audit.raise_rejections()
+        if not isinstance(req.input, ChatInput):
+            raise DialectError("openai_responses requires ChatInput")
+
+        active_paths = frozenset(audit.active_paths)
+        continuation = req.session.opaque_continuation
+        input_verifier = _ResponsesInputVerifier(
+            req.input,
+            continuation.value if continuation is not None else None,
+        )
+
+        def consume(path: str, *wire: WireEvidence) -> None:
+            if path in active_paths and path not in audit.decisions:
+                audit.consumed(path, *wire)
+
+        input_items: list[dict[str, JSONValue]] = []
+        if continuation is not None:
+            input_items.extend(_decode_opaque_continuation(continuation.value))
+        for message in req.input.messages:
+            input_items.extend(_message_to_input_items(message))
+        canonical_input_items = [
+            _history_item_payload(
+                item,
+                index,
+                require_encrypted_reasoning=True,
+            )
+            for index, item in enumerate(input_items)
+        ]
+
+        for path in (
+            "input.chat",
+            "input.modality.text",
+            "input.modality.image",
+            "input.modality.image.detail",
+            "input.modality.image.media_type",
+            "input.modality.tool_call",
+            "input.modality.tool_result",
+        ):
+            consume(path, input_verifier)
+
+        body: dict[str, Any] = {
+            "model": self._requested_model_id,
+            "input": canonical_input_items,
+            "stream": req.scheduling.stream,
+        }
+        sampling = req.sampling
+        if sampling.max_tokens is not None:
+            body["max_output_tokens"] = sampling.max_tokens
+            consume(
+                "sampling.max_tokens",
+                WireObservation(("max_output_tokens",)),
+            )
+        for name in ("temperature", "top_p"):
+            value = getattr(sampling, name)
+            if value is not None:
+                body[name] = value
+                consume(f"sampling.{name}", WireObservation((name,)))
+
+        includes: set[str] = set()
+        # Plain/non-reasoning Responses endpoints may reject encrypted reasoning.
+        # Request it only when reasoning state is active or already being replayed.
+        if (
+            continuation is not None
+            or req.reasoning.effort not in {None, "none"}
+            or req.reasoning.summary not in {None, "none"}
+        ):
+            includes.add("reasoning.encrypted_content")
+        logprobs_verifier = _ResponsesLogprobsVerifier(req.scoring.top_logprobs)
+        if req.scoring.sampled_logprobs:
+            body["top_logprobs"] = req.scoring.top_logprobs
+            includes.add("message.output_text.logprobs")
+            consume("scoring.sampled_logprobs", logprobs_verifier)
+        if req.scoring.top_logprobs > 0:
+            body["top_logprobs"] = req.scoring.top_logprobs
+            consume(
+                "scoring.top_logprobs",
+                WireObservation(("top_logprobs",)),
+                logprobs_verifier,
+            )
+
+        reasoning: dict[str, JSONValue] = {}
+        if req.reasoning.effort is not None:
+            reasoning["effort"] = req.reasoning.effort
+            consume(
+                "reasoning.effort",
+                WireObservation(("reasoning", "effort")),
+            )
+        if req.reasoning.summary == "none":
+            audit.noop(
+                "reasoning.summary",
+                "omitting Responses reasoning.summary requests no visible summary",
+            )
+        elif req.reasoning.summary is not None:
+            reasoning["summary"] = req.reasoning.summary
+            consume(
+                "reasoning.summary",
+                WireObservation(("reasoning", "summary")),
+            )
+        if reasoning:
+            body["reasoning"] = reasoning
+        tools: list[dict[str, JSONValue]] = []
+        tools_verifier = _ResponsesToolsVerifier(
+            req.tools.functions,
+            req.tools.hosted,
+        )
+        if req.tools.functions:
+            tools.extend(_function_tool_to_wire(tool) for tool in req.tools.functions)
+            consume("tools.functions", tools_verifier)
+        if req.tools.hosted:
+            tools.extend(_hosted_tool_to_wire(tool) for tool in req.tools.hosted)
+            includes.add("web_search_call.action.sources")
+            consume("tools.hosted", tools_verifier)
+        if tools:
+            body["tools"] = tools
+        if req.tools.choice is not None:
+            body["tool_choice"] = _tool_choice_to_wire(req.tools.choice)
+            consume(
+                "tools.choice",
+                _ResponsesToolChoiceVerifier(req.tools.choice),
+            )
+        if req.tools.parallel is not None:
+            body["parallel_tool_calls"] = req.tools.parallel
+            consume(
+                "tools.parallel",
+                WireObservation(("parallel_tool_calls",)),
+            )
+
+        text_config = _structured_text_config(req)
+        if text_config is not None:
+            body["text"] = text_config
+        if req.structured_output.format is not None:
+            consume(
+                "structured_output.format",
+                WireObservation(("text", "format", "type")),
+            )
+        if req.structured_output.schema is not None:
+            consume(
+                "structured_output.schema",
+                WireObservation(("text", "format", "schema")),
+            )
+        if req.structured_output.name is not None:
+            consume(
+                "structured_output.name",
+                WireObservation(("text", "format", "name")),
+            )
+        if req.structured_output.strict is not None:
+            consume(
+                "structured_output.strict",
+                WireObservation(("text", "format", "strict")),
+            )
+
+        if req.session.previous_response_id is not None:
+            body["previous_response_id"] = req.session.previous_response_id
+            consume(
+                "session.previous_response_id",
+                WireObservation(("previous_response_id",)),
+            )
+        if continuation is not None:
+            consume("session.opaque_continuation", input_verifier)
+        if req.scheduling.stream:
+            consume("scheduling.stream", WireObservation(("stream",)))
+
+        if includes:
+            body["include"] = sorted(includes)
+
+        extra_body: dict[str, JSONValue] = {}
+        options = req.dialect_options
+        if options is not None:
+            if not options.values:
+                audit.noop(
+                    "dialect_options",
+                    "an empty matching options mapping has no wire semantics",
+                )
+            for key, option_value in options.values.items():
+                path = f"dialect_options.{key}"
+                if path in audit.decisions:
+                    continue
+                extra_body[key] = option_value
+                audit.passthrough(path, "extra_body")
+        if extra_body:
+            body["extra_body"] = extra_body
+
+        return PreparedRequest(
+            operation="responses.create",
+            body=cast(Mapping[str, JSONValue], body),
+            context=_ResponsesContext(request=deepcopy(req)),
+        )
+
+    def _lift(self, raw: object, context: _ResponsesExecutionContext) -> Response:
+        finish_reason = _finish_reason(raw)
+        response_id = _required_string(_get(raw, "id"), "response.id")
+        reported_store = _get(raw, "store", _MISSING)
+        if reported_store is _MISSING:
+            response_is_stored = context.requested_store
+        else:
+            if not isinstance(reported_store, bool):
+                raise OutputContractError("response.store must be a boolean")
+            if context.store_explicit and reported_store is not context.requested_store:
+                raise OutputContractError(
+                    "response.store contradicts the requested store value"
+                )
+            response_is_stored = reported_store
+        usage = _usage_stats(_get(raw, "usage"))
+        text_parts: list[str] = []
+        reasoning_payloads: list[dict[str, JSONValue]] = []
+        reasoning_texts: list[str] = []
+        requested_reasoning_summary = context.request.reasoning.summary not in {
+            None,
+            "none",
+        }
+        tool_calls: list[FunctionToolCall] = []
+        server_uses: list[ServerToolUse] = []
+        citations: list[Citation] = []
+        sampled_logprobs: list[TokenLogprob] = []
+        top_logprobs: list[tuple[TopKEntry, ...]] = []
+        saw_logprobs = False
+        requested_logprobs = context.request.scoring.sampled_logprobs
+
+        output = _sequence(_get(raw, "output"), "response.output")
+        for item_index, item in enumerate(output):
+            path = f"response.output[{item_index}]"
+            item_type = _get(item, "type")
+            if item_type == "message":
+                _validate_terminal_item_status(item, path)
+                content = _sequence(_get(item, "content"), f"{path}.content")
+                for content_index, part in enumerate(content):
+                    part_path = f"{path}.content[{content_index}]"
+                    part_type = _get(part, "type")
+                    if part_type == "refusal":
+                        raise OutputContractError(
+                            "Responses refusal has no faithful shared-IR channel"
+                        )
+                    if part_type != "output_text":
+                        raise OutputContractError(
+                            f"{part_path} has unsupported type {part_type!r}"
+                        )
+                    part_text = _string(_get(part, "text"), f"{part_path}.text")
+                    text_parts.append(part_text)
+                    raw_annotations = _get(part, "annotations", [])
+                    citations.extend(
+                        _url_citations(raw_annotations, f"{part_path}.annotations")
+                    )
+                    raw_logprobs = _get(part, "logprobs")
+                    if requested_logprobs and part_text and raw_logprobs is None:
+                        raise OutputContractError(
+                            f"{part_path}.logprobs is absent for non-empty text"
+                        )
+                    if raw_logprobs is not None:
+                        saw_logprobs = True
+                        sampled, alternatives = _parse_logprobs(
+                            raw_logprobs, f"{part_path}.logprobs"
+                        )
+                        if requested_logprobs and part_text and not sampled:
+                            raise OutputContractError(
+                                f"{part_path}.logprobs is empty for non-empty text"
+                            )
+                        sampled_logprobs.extend(sampled)
+                        top_logprobs.extend(alternatives)
+            elif item_type == "function_call":
+                _validate_terminal_item_status(item, path)
+                tool_calls.append(_function_call(item, path))
+            elif item_type == "reasoning":
+                _validate_terminal_item_status(item, path)
+                reasoning_payloads.append(_reasoning_payload(item, item_index))
+                text, is_summary = _visible_reasoning_text(item, path)
+                if requested_reasoning_summary and (not is_summary or not text):
+                    raise OutputContractError(
+                        f"{path} omitted the requested visible reasoning summary"
+                    )
+                if text:
+                    reasoning_texts.append(text)
+            elif item_type == "web_search_call":
+                server_uses.append(_web_search_use(item, path))
+            else:
+                raise OutputContractError(
+                    f"Responses output item type {item_type!r} has no IR mapping"
+                )
+
+        text = "".join(text_parts)
+        opaque_history = _opaque_history_bundle(
+            context.input_items,
+            output,
+            has_hidden_previous_response=context.has_hidden_previous_response,
+        )
+        reasoning: tuple[ReasoningOutput | None, ...] | None = None
+        if reasoning_payloads or opaque_history is not None:
+            effort = _get(_get(raw, "reasoning"), "effort")
+            reasoning = (
+                ReasoningOutput(
+                    text="\n".join(reasoning_texts) or None,
+                    opaque_roundtrip=opaque_history,
+                    thinking_tokens=(
+                        usage.reasoning_tokens
+                        if usage is not None and usage.reasoning_tokens is not None
+                        else 0
+                    ),
+                    effort_used=_optional_string(effort, "response.reasoning.effort"),
+                ),
+            )
+
+        return Response(
+            texts=(text,),
+            reasoning=reasoning,
+            finish_reasons=(finish_reason,),
+            tool_calls=tuple(tool_calls) or None,
+            server_tool_uses=tuple(server_uses) or None,
+            structured_output=_structured_output(context.request, text),
+            logprobs=(
+                tuple(sampled_logprobs) if saw_logprobs or requested_logprobs else None
+            ),
+            top_logprobs=(
+                tuple(top_logprobs)
+                if context.request.scoring.top_logprobs > 0
+                else None
+            ),
+            citations=tuple(citations) or None,
+            session_id=response_id if response_is_stored else None,
+            usage=usage,
+            request_params=context.request_params,
+            response_model=_optional_string(_get(raw, "model"), "response.model"),
+            system_fingerprint=_optional_string(
+                _get(raw, "system_fingerprint"), "response.system_fingerprint"
+            ),
+        )
+
+    async def _lift_stream(
+        self, stream: object, context: _ResponsesExecutionContext
+    ) -> Response:
+        if not isinstance(stream, AsyncIterable):
+            raise OutputContractError(
+                "streaming Responses reply is not asynchronously iterable"
+            )
+        terminal: object | None = None
+        terminal_type: str | None = None
+        saw_terminal = False
+        expected_status = {
+            "response.completed": "completed",
+            "response.incomplete": "incomplete",
+            "response.failed": "failed",
+        }
+        async for event in stream:
+            event_type = _get(event, "type")
+            if event_type == "error":
+                message = _get(event, "message")
+                raise OutputContractError(
+                    "Responses stream error"
+                    + (f": {message}" if isinstance(message, str) else "")
+                )
+            if event_type not in expected_status:
+                continue
+            if saw_terminal:
+                raise OutputContractError(
+                    "Responses stream emitted two terminal events"
+                )
+            saw_terminal = True
+            terminal = _get(event, "response")
+            if terminal is None:
+                raise OutputContractError(
+                    f"Responses terminal event {event_type!r} omitted its response"
+                )
+            terminal_type = cast(str, event_type)
+        if not saw_terminal or terminal is None or terminal_type is None:
+            raise OutputContractError("Responses stream omitted its terminal response")
+        status = _get(terminal, "status")
+        if status != expected_status[terminal_type]:
+            raise OutputContractError(
+                f"Responses terminal event {terminal_type!r} carried status {status!r}"
+            )
+        return self._lift(terminal, context)
+
+    async def execute(self, prepared: PreparedRequest) -> Response:
+        """Execute through the borrowed SDK client and lift the terminal reply."""
+
+        if prepared.operation != "responses.create":
+            raise DialectError(f"unexpected Responses operation {prepared.operation!r}")
+        context = prepared.context
+        if not isinstance(context, _ResponsesContext):
+            raise DialectError("prepared Responses request has invalid context")
+        body, stream, execution_context = _execution_context(prepared, context)
+        raw = await self._client.responses.create(**body)
+        if stream:
+            return await self._lift_stream(raw, execution_context)
+        return self._lift(raw, execution_context)
+
+    async def arun(self, req: Request) -> Response:
+        """One-cycle direct path; canonical ``Model`` uses the split contract."""
+
+        plan = _LegacyPlan()
+        validate_request_invariants(req)
+        validate_runtime_binding_plan(plan, req)
+        audit = RequestAudit(active_request_leaves(req))
+        self.validate_request(req, audit, plan)
+        audit.raise_rejections()
+        prepared = self.prepare(req, audit)
+        audit.finish(prepared)
+        response = await self.execute(prepared)
+        self.output_contract.validate(plan, req, response)
+        return response

--- a/sieval/core/models/dialects/openai_responses.py
+++ b/sieval/core/models/dialects/openai_responses.py
@@ -1140,8 +1140,9 @@ def _opaque_history_bundle(
             encrypted = payload.get("encrypted_content")
             if not isinstance(encrypted, str) or not encrypted:
                 return None
-            saw_reasoning = True
         history.append(payload)
+    # Guaranteed by the returns above: the bundle holds a reasoning item with
+    # encrypted_content, which _decode_opaque_continuation requires next hop.
     return json.dumps(
         {"version": _OPAQUE_CONTINUATION_VERSION, "items": history},
         ensure_ascii=False,
@@ -1657,7 +1658,11 @@ class OpenAIResponsesDialect:
                 audit.rejected(path, "Responses JSON schema names must not be empty")
             elif path.startswith("dialect_options."):
                 key = path.removeprefix("dialect_options.")
-                if key == "conversation":
+                if not key:
+                    # ``finish`` refuses this too, but without the request path;
+                    # reject at admission like the other OpenAI dialects.
+                    audit.rejected(path, "dialect option keys must be non-empty")
+                elif key == "conversation":
                     audit.rejected(
                         path,
                         "Responses conversation state is not yet modeled by the "
@@ -1886,7 +1891,9 @@ class OpenAIResponsesDialect:
         finish_reason = _finish_reason(raw)
         response_id = _required_string(_get(raw, "id"), "response.id")
         reported_store = _get(raw, "store", _MISSING)
-        if reported_store is _MISSING:
+        # A compliant reply omits ``store``; a partially compatible endpoint may
+        # echo an explicit null. Treat that as unreported, not a type violation.
+        if reported_store is _MISSING or reported_store is None:
             response_is_stored = context.requested_store
         else:
             if not isinstance(reported_store, bool):

--- a/sieval/core/models/dialects/openai_responses.py
+++ b/sieval/core/models/dialects/openai_responses.py
@@ -81,6 +81,12 @@ _SUPPORTED_IMAGE_MEDIA_TYPES = frozenset(
 )
 _SUPPORTED_IMAGE_DETAILS = frozenset({"auto", "high", "low", "original"})
 _OPAQUE_CONTINUATION_VERSION = 2
+
+# Keep the accepted wire vocabulary local instead of deriving it from the SDK.
+# AsyncOpenAI uses lenient response construction by default, so an unknown
+# provider shape can be coerced into a known SDK model instead of being rejected;
+# opaque continuation replay bypasses SDK parsing entirely.  Value-identical
+# sets below remain separate because they mirror independent upstream enums.
 _REASONING_ITEM_KEYS = frozenset(
     {"type", "id", "summary", "content", "encrypted_content", "status"}
 )
@@ -789,6 +795,12 @@ def _verification_image(part: ImagePart) -> dict[str, JSONValue]:
 
 
 def _verification_message_items(message: ChatMessage) -> list[dict[str, JSONValue]]:
+    """Independently derive the expected wire items for audit verification.
+
+    Do not reuse ``_message_to_input_items`` here: the verifier must detect
+    lowering drift rather than reproduce it through the same implementation.
+    """
+
     results = [part for part in message.content if isinstance(part, ToolResultPart)]
     if results:
         result = results[0]
@@ -1105,7 +1117,9 @@ def _opaque_history_bundle(
     OpenAI's stateless contract requires replaying the exact prior input and
     every output item in order.  A request chained through
     ``previous_response_id`` has hidden server-side history, so no faithful
-    standalone continuation can be constructed for that response.
+    standalone continuation can be constructed for that response.  Output
+    message logprobs remain part of that history because Responses accepts its
+    output-message shape as input and manual replay must preserve items intact.
     """
 
     if has_hidden_previous_response:
@@ -1241,6 +1255,10 @@ def _finish_reason(raw: object) -> str:
             "Responses request failed"
             + (f" ({code})" if isinstance(code, str) and code else "")
             + (f": {message}" if isinstance(message, str) and message else "")
+        )
+    if status == "cancelled":
+        raise OutputContractError(
+            "Responses reply has unsupported terminal status 'cancelled'"
         )
     raise OutputContractError(f"Responses reply has non-terminal status {status!r}")
 
@@ -1886,6 +1904,7 @@ class OpenAIResponsesDialect:
             None,
             "none",
         }
+        saw_reasoning_summary = False
         tool_calls: list[FunctionToolCall] = []
         server_uses: list[ServerToolUse] = []
         citations: list[Citation] = []
@@ -1941,11 +1960,10 @@ class OpenAIResponsesDialect:
                 _validate_terminal_item_status(item, path)
                 reasoning_payloads.append(_reasoning_payload(item, item_index))
                 text, is_summary = _visible_reasoning_text(item, path)
-                if requested_reasoning_summary and (not is_summary or not text):
-                    raise OutputContractError(
-                        f"{path} omitted the requested visible reasoning summary"
-                    )
-                if text:
+                if is_summary and text:
+                    saw_reasoning_summary = True
+                    reasoning_texts.append(text)
+                elif not requested_reasoning_summary and text:
                     reasoning_texts.append(text)
             elif item_type == "web_search_call":
                 server_uses.append(_web_search_use(item, path))
@@ -1953,6 +1971,11 @@ class OpenAIResponsesDialect:
                 raise OutputContractError(
                     f"Responses output item type {item_type!r} has no IR mapping"
                 )
+
+        if requested_reasoning_summary and not saw_reasoning_summary:
+            raise OutputContractError(
+                "Responses reply omitted the requested visible reasoning summary"
+            )
 
         text = "".join(text_parts)
         opaque_history = _opaque_history_bundle(

--- a/sieval/core/utils/meta.py
+++ b/sieval/core/utils/meta.py
@@ -13,12 +13,16 @@ from sieval.core.tasks.context import TaskStageMeta
 #: Finish reasons that mean the generation stopped before the model chose to.
 #:
 #: Every spelling, not one canonical name: the IR does not normalize these, so a
-#: set holding only ``length`` (OpenAI-compatible) would read zero against
-#: ``max_tokens`` (Anthropic). ``content_filter`` is in because the output is cut
-#: short the same way; separating causes is what the raw ``finish_reasons`` are
-#: for. Shared with :func:`sieval.core.tasks.anomaly.detect_truncated_output` so
-#: the rule and the report key cannot drift apart.
-TRUNCATION_FINISH_REASONS = frozenset({"length", "max_tokens", "content_filter"})
+#: set holding only ``length`` (OpenAI-compatible Chat/Completions and SGLang
+#: native) would read zero against ``max_output_tokens`` (OpenAI Responses) or
+#: ``max_tokens`` (Anthropic).
+#: ``content_filter`` is in because the output is cut short the same way;
+#: separating causes is what the raw ``finish_reasons`` are for. Shared with
+#: :func:`sieval.core.tasks.anomaly.detect_truncated_output` so the rule and the
+#: report key cannot drift apart.
+TRUNCATION_FINISH_REASONS = frozenset(
+    {"length", "max_output_tokens", "max_tokens", "content_filter"}
+)
 
 
 def build_model_call_meta(output: ModelOutput) -> ModelCallMeta:

--- a/tests/unit/cli/leaderboard/test_session.py
+++ b/tests/unit/cli/leaderboard/test_session.py
@@ -70,6 +70,7 @@ from sieval.cli.validation import _VALID_OPERATIONS
 from sieval.core.models.capabilities import CapabilityIntent, RequestDefaults
 from sieval.core.models.connection_factory import DEFAULT_REQUEST_TIMEOUT
 from sieval.core.models.deployment import RouteIntent
+from sieval.core.models.dialect import RequestAuditError
 from sieval.core.models.dialect_registry import RequestSeedSupport
 from sieval.core.models.model import Model
 from sieval.core.models.reconcile import (
@@ -6865,9 +6866,9 @@ class TestDeterministicRequestSeedPolicy:
         assert args == {"seed": 0, "temperature": 0.5}
 
     def test_reserved_seed_policy_fails_loudly(self):
-        with pytest.raises(ValueError, match="openai_responses.*has not declared"):
+        with pytest.raises(ValueError, match="anthropic_messages.*has not declared"):
             _resolve_deterministic_request_seed(
-                dialect_id="openai_responses",
+                dialect_id="anthropic_messages",
                 explicit_seed_present=False,
             )
 
@@ -6963,6 +6964,41 @@ class TestDeterministicMode:
             session._setup_postlaunch_reconciliation()
             session._setup_models()
         return session
+
+    @staticmethod
+    def _responses_connection() -> tuple[types.SimpleNamespace, AsyncMock]:
+        response = types.SimpleNamespace(
+            id="resp_1",
+            status="completed",
+            output=[
+                types.SimpleNamespace(
+                    type="message",
+                    id="msg_1",
+                    role="assistant",
+                    status="completed",
+                    content=[
+                        types.SimpleNamespace(
+                            type="output_text",
+                            text="ok",
+                            annotations=[],
+                            logprobs=None,
+                        )
+                    ],
+                )
+            ],
+            incomplete_details=None,
+            error=None,
+            usage=None,
+            model="served-responses",
+            reasoning=types.SimpleNamespace(effort=None),
+            system_fingerprint=None,
+        )
+        create = AsyncMock(return_value=response)
+        connection = types.SimpleNamespace(
+            close=AsyncMock(),
+            responses=types.SimpleNamespace(create=create),
+        )
+        return connection, create
 
     # ------------------------------------------------------------------
     # EvalSession resolves deterministic internally: the kwarg is the
@@ -7128,6 +7164,114 @@ class TestDeterministicMode:
         assert call.kwargs["seed"] == DETERMINISTIC_DEFAULT_SEED
         assert output.request_params is not None
         assert output.request_params["seed"] == DETERMINISTIC_DEFAULT_SEED
+
+    @pytest.mark.anyio
+    async def test_responses_deterministic_skips_automatic_seed_end_to_end(
+        self, tmp_path
+    ):
+        connection, create = self._responses_connection()
+        session = self._bind_models(
+            tmp_path,
+            {
+                "deterministic": True,
+                "models": {
+                    "m1": {
+                        "name": "mock-responses",
+                        "type": "chat",
+                        "dialect": "openai_responses",
+                    }
+                },
+            },
+            connection=connection,
+        )
+
+        try:
+            session._stamp_deterministic_seed_contract()
+            model = session.models["m1"]
+            assert model.dialect_id == "openai_responses"
+            assert "seed" not in model.meta()["default_params"]
+
+            output = await model.agenerate("hello", stream=False)
+
+            call = create.await_args
+            assert call is not None
+            assert "seed" not in call.kwargs
+            assert output.request_params is not None
+            assert "seed" not in output.request_params
+            contract = session._reified_config[_DETERMINISTIC_SEED_CONTRACT_KEY]
+            binding = contract["bindings"]["model:m1"]
+            assert binding["request_seed_support"] == "unsupported"
+            assert binding["seed_present"] is False
+            assert binding["seed"] is None
+            assert binding["seed_provenance"] == "none"
+        finally:
+            await session._close_owned_model_resources()
+
+    @pytest.mark.anyio
+    async def test_responses_explicit_seed_rejects_before_sdk_io(self, tmp_path):
+        connection, create = self._responses_connection()
+        session = self._bind_models(
+            tmp_path,
+            {
+                "deterministic": True,
+                "models": {
+                    "m1": {
+                        "name": "mock-responses",
+                        "type": "chat",
+                        "dialect": "openai_responses",
+                        "args": {"seed": 7},
+                    }
+                },
+            },
+            connection=connection,
+        )
+
+        try:
+            model = session.models["m1"]
+            assert model.meta()["default_params"]["seed"] == 7
+            with pytest.raises(RequestAuditError, match="sampling.seed"):
+                await model.agenerate("hello", stream=False)
+            create.assert_not_awaited()
+        finally:
+            await session._close_owned_model_resources()
+
+    @pytest.mark.anyio
+    async def test_responses_child_strips_chat_base_automatic_seed(self, tmp_path):
+        connection, create = self._responses_connection()
+        session = self._bind_models(
+            tmp_path,
+            {
+                "deterministic": True,
+                "models": {
+                    "base": {
+                        "name": "mock-chat",
+                        "type": "chat",
+                        "dialect": "openai_chat",
+                    },
+                    "responses": {
+                        "base": "base",
+                        "dialect": "openai_responses",
+                    },
+                },
+            },
+            connection=connection,
+        )
+
+        try:
+            base = session.models["base"]
+            responses = session.models["responses"]
+            assert base.meta()["default_params"]["seed"] == 0
+            assert "seed" not in responses.meta()["default_params"]
+
+            output = await responses.agenerate("hello", stream=False)
+
+            call = create.await_args
+            assert call is not None
+            assert "seed" not in call.kwargs
+            assert output.request_params is not None
+            assert "seed" not in output.request_params
+        finally:
+            await session._close_owned_model_resources()
 
     @pytest.mark.anyio
     async def test_task_infer_seed_contract_matches_each_candidate_wire(self, tmp_path):

--- a/tests/unit/cli/test_validation.py
+++ b/tests/unit/cli/test_validation.py
@@ -450,9 +450,21 @@ class TestValidateModelCapabilities:
                 capabilities={"input_scoring": True, "fim": {}},
             )
         )
+        responses = validate_eval_config(
+            self._config(
+                dialect="openai_responses",
+                capabilities={
+                    "reasoning": {"effort": "high", "summary": "detailed"},
+                    "hosted_tools": {"kinds": ["web_search"]},
+                    "stateful_session": True,
+                    "input_scoring": False,
+                },
+            )
+        )
 
         assert chat.ok, chat.errors
         assert completions.ok, completions.errors
+        assert responses.ok, responses.errors
 
     @pytest.mark.parametrize("dialect", [None, "", 7, ["openai_chat"]])
     def test_explicit_malformed_dialect_is_rejected(self, dialect):
@@ -504,7 +516,6 @@ class TestValidateModelCapabilities:
     @pytest.mark.parametrize(
         ("dialect", "message"),
         [
-            ("openai_responses", "reserved for a later"),
             ("sglang_native", "legacy bypass"),
             ("vllm_native", "explicitly deferred"),
         ],
@@ -1591,7 +1602,6 @@ class TestRunDryRun:
         [
             "    dialect: chat\n",
             "    dialect: null\n",
-            "    dialect: openai_responses\n",
             "    dialect: openai_chat\n    capabilities: null\n",
             (
                 "    dialect: openai_chat\n"
@@ -1621,6 +1631,31 @@ class TestRunDryRun:
         assert not direct.ok
         assert schema_check["ok"] is False
         assert schema_check["detail"] == "; ".join(direct.errors)
+
+    def test_active_responses_dialect_reconciles_to_its_runtime_plan(self, tmp_path):
+        """Dry-run carries Responses through task reconciliation, not just schema."""
+        from sieval.cli.validation import run_dry_run
+
+        config = self._capability_config(tmp_path, dialect="openai_responses")
+        content = config.read_text(encoding="utf-8")
+
+        direct = validate_eval_config(yaml.safe_load(content))
+        dry_run = run_dry_run(config)
+        schema_check = next(
+            check for check in dry_run["checks"] if check["name"] == "schema"
+        )
+        reconcile_check = next(
+            check
+            for check in dry_run["checks"]
+            if check["name"] == "capability_reconcile"
+        )
+
+        assert direct.ok, direct.errors
+        assert schema_check["ok"] is True
+        assert reconcile_check["ok"] is True
+        binding_plans = reconcile_check["plan"]["binding_plans"]
+        assert len(binding_plans) == 1
+        assert next(iter(binding_plans.values()))["dialect_id"] == "openai_responses"
 
     def test_schema_validation_failure(self, tmp_path):
         """Config with bad schema returns schema check failure."""

--- a/tests/unit/core/models/dialects/test_openai_responses.py
+++ b/tests/unit/core/models/dialects/test_openai_responses.py
@@ -36,6 +36,7 @@ from sieval.core.models.dialect import (
     DialectError,
     OutputContractError,
     PreparedRequest,
+    Rejected,
     RequestAudit,
     RequestAuditError,
     active_request_leaves,
@@ -2033,6 +2034,13 @@ class TestPreflightRejections:
                 ),
                 "store must be a boolean",
             ),
+            (
+                Request(
+                    input=_chat(),
+                    dialect_options=DialectOptions("openai_responses", {"": 1}),
+                ),
+                "dialect option keys must be non-empty",
+            ),
         ],
     )
     async def test_every_request_rejection_happens_before_io(
@@ -2046,6 +2054,26 @@ class TestPreflightRejections:
             await dialect.arun(model_request)
 
         create.assert_not_awaited()
+
+    def test_empty_option_key_is_rejected_during_validation(self) -> None:
+        """Pin *which* layer rejects, not merely that something does.
+
+        ``finish`` is a backstop with identical wording, so matching only the
+        message still passes with this dialect's check deleted.
+        """
+
+        dialect, _ = _dialect()
+        model_request = Request(
+            input=_chat(),
+            dialect_options=DialectOptions("openai_responses", {"": 1}),
+        )
+        audit = RequestAudit(active_request_leaves(model_request))
+
+        dialect.validate_request(model_request, audit, SimpleNamespace())
+
+        decision = audit.decisions["dialect_options."]
+        assert isinstance(decision, Rejected)
+        assert "non-empty" in decision.reason
 
     @pytest.mark.anyio
     @pytest.mark.parametrize("option_key", _RESPONSES_IR_OWNED_OPTIONS)
@@ -2465,6 +2493,43 @@ class TestResponseLifting:
             OutputContractError, match="response.store must be a boolean"
         ):
             await dialect.arun(Request(input=_chat()))
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize(
+        ("options", "expected_session_id"),
+        [
+            pytest.param(None, "resp_1", id="implicit-store-true"),
+            pytest.param({"store": False}, None, id="explicit-store-false"),
+            pytest.param({"store": True}, "resp_1", id="explicit-store-true"),
+        ],
+    )
+    async def test_explicit_null_store_is_treated_as_unreported(
+        self,
+        options: dict[str, JSONValue] | None,
+        expected_session_id: str | None,
+    ) -> None:
+        """A partially compatible endpoint may echo ``store`` as a JSON null.
+
+        ``None`` is not the ``_MISSING`` sentinel, so without the null check
+        every reply from such an endpoint fails the boolean guard.
+        """
+
+        raw = _response()
+        raw.store = None
+        dialect, _ = _dialect(raw)
+
+        response = await dialect.arun(
+            Request(
+                input=_chat(),
+                dialect_options=(
+                    None
+                    if options is None
+                    else DialectOptions("openai_responses", options)
+                ),
+            )
+        )
+
+        assert response.session_id == expected_session_id
 
     @pytest.mark.anyio
     async def test_store_false_falls_back_to_request_when_response_omits_it(

--- a/tests/unit/core/models/dialects/test_openai_responses.py
+++ b/tests/unit/core/models/dialects/test_openai_responses.py
@@ -1001,6 +1001,16 @@ class TestWireTranslation:
             response_payload = _sdk_response_payload()
             response_payload["id"] = f"resp_{len(requests)}"
             response_payload["store"] = False
+            response_output = cast(list[dict[str, Any]], response_payload["output"])
+            message_content = cast(list[dict[str, Any]], response_output[1]["content"])
+            message_content[0]["logprobs"] = [
+                {
+                    "bytes": [65],
+                    "logprob": -0.1,
+                    "token": "A",
+                    "top_logprobs": [],
+                }
+            ]
             return httpx.Response(200, json=response_payload)
 
         http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
@@ -1050,6 +1060,14 @@ class TestWireTranslation:
         ]
         assert requests[1]["input"][0]["content"] == "hello"
         assert requests[1]["input"][3]["content"] == "next"
+        assert requests[1]["input"][2]["content"][0]["logprobs"] == [
+            {
+                "bytes": [65],
+                "logprob": -0.1,
+                "token": "A",
+                "top_logprobs": [],
+            }
+        ]
 
     @pytest.mark.anyio
     async def test_json_object_format_and_flat_function_tool_are_lowered(self) -> None:
@@ -2713,11 +2731,11 @@ class TestResponseLifting:
             (_reasoning(summary=""),),
             (
                 _reasoning("rs_raw", summary=None, content="raw reasoning"),
-                _reasoning("rs_summary", summary="visible summary"),
+                _reasoning("rs_empty", summary=""),
             ),
         ],
     )
-    async def test_requested_reasoning_summary_must_exist_on_every_item(
+    async def test_requested_reasoning_summary_requires_one_nonempty_summary(
         self, reasoning_items: tuple[object, ...]
     ) -> None:
         dialect, _ = _dialect(_response(*reasoning_items, _message()))
@@ -2729,6 +2747,29 @@ class TestResponseLifting:
                     reasoning=ReasoningParams(summary="detailed"),
                 )
             )
+
+    @pytest.mark.anyio
+    async def test_requested_reasoning_summary_is_response_level(self) -> None:
+        dialect, _ = _dialect(
+            _response(
+                _reasoning("rs_first", summary="first summary"),
+                _reasoning("rs_raw", summary=None, content="raw reasoning"),
+                _reasoning("rs_empty", summary=""),
+                _reasoning("rs_second", summary="second summary"),
+                _message(),
+            )
+        )
+
+        response = await dialect.arun(
+            Request(
+                input=_chat(),
+                reasoning=ReasoningParams(summary="detailed"),
+            )
+        )
+
+        assert response.reasoning is not None
+        assert response.reasoning[0] is not None
+        assert response.reasoning[0].text == "first summary\nsecond summary"
 
     @pytest.mark.anyio
     async def test_missing_encrypted_reasoning_is_not_advertised_as_opaque(
@@ -2837,7 +2878,7 @@ class TestResponseLifting:
                 ),
                 "server_error.*boom",
             ),
-            (_response(status="cancelled"), "non-terminal status"),
+            (_response(status="cancelled"), "unsupported terminal status"),
             (
                 _response(status="completed", error=SimpleNamespace(code="x")),
                 "completed.*error",
@@ -3071,10 +3112,10 @@ class TestResponseLifting:
         assert response.reasoning[0].text == "visible"
 
     @pytest.mark.anyio
-    async def test_missing_requested_channel_fails_output_contract(self) -> None:
+    async def test_missing_requested_reasoning_summary_fails_loudly(self) -> None:
         dialect, _ = _dialect(_response())
 
-        with pytest.raises(OutputContractError, match="required.*reasoning"):
+        with pytest.raises(OutputContractError, match="requested visible reasoning"):
             await dialect.arun(
                 Request(
                     input=_chat(),

--- a/tests/unit/core/models/dialects/test_openai_responses.py
+++ b/tests/unit/core/models/dialects/test_openai_responses.py
@@ -1,0 +1,3284 @@
+"""Contract tests for the OpenAI Responses API dialect.
+
+AI-Generated Code - GPT-5.6 (OpenAI)
+"""
+
+import json
+from collections.abc import Callable, Iterable, Mapping
+from copy import deepcopy
+from dataclasses import replace
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+from openai import AsyncOpenAI
+from openai.types.responses import Response as SDKResponse
+from openai.types.responses import (
+    ResponseCompletedEvent,
+    ResponseErrorEvent,
+    ResponseFailedEvent,
+    ResponseIncompleteEvent,
+    ResponseTextDeltaEvent,
+)
+
+from sieval.core.models.capabilities import (
+    Capability,
+    HostedToolsOptions,
+    MultimodalInputOptions,
+    ReasoningOptions,
+    Supported,
+    TopLogprobsOptions,
+)
+from sieval.core.models.deployment import BINDING_RESOURCE_KEYS
+from sieval.core.models.dialect import (
+    DialectError,
+    OutputContractError,
+    PreparedRequest,
+    RequestAudit,
+    RequestAuditError,
+    active_request_leaves,
+    validate_runtime_binding_plan,
+)
+from sieval.core.models.dialects import openai_responses as openai_responses_module
+from sieval.core.models.dialects.openai_responses import (
+    CAPABILITY_DECISIONS,
+    OUTPUT_CONTRACT,
+    OpenAIResponsesDialect,
+)
+from sieval.core.models.ir import (
+    ChatInput,
+    ChatMessage,
+    CompletionInput,
+    DialectOptions,
+    FunctionToolCall,
+    HostedToolSpec,
+    ImagePart,
+    OpaqueContinuation,
+    ReasoningOutput,
+    ReasoningParams,
+    Request,
+    SamplingParams,
+    SchedulingParams,
+    ScoringParams,
+    ServerToolUse,
+    SessionParams,
+    StructuredOutputParams,
+    TextPart,
+    TokenLogprob,
+    ToolCallPart,
+    ToolParams,
+    ToolResultPart,
+    TopKEntry,
+    UsageStats,
+)
+from sieval.core.types import JSONValue
+
+
+class _AsyncItems:
+    def __init__(self, items: Iterable[object]):
+        self._items = iter(items)
+
+    def __aiter__(self) -> "_AsyncItems":
+        return self
+
+    async def __anext__(self) -> object:
+        try:
+            return next(self._items)
+        except StopIteration as exc:
+            raise StopAsyncIteration from exc
+
+
+def _chat(*messages: ChatMessage) -> ChatInput:
+    if not messages:
+        messages = (ChatMessage("user", (TextPart("hello"),)),)
+    return ChatInput(messages)
+
+
+def _text(
+    value: str = "ok",
+    *,
+    annotations: list[object] | None = None,
+    logprobs: list[object] | None = None,
+) -> object:
+    return SimpleNamespace(
+        type="output_text",
+        text=value,
+        annotations=[] if annotations is None else annotations,
+        logprobs=logprobs,
+    )
+
+
+def _message(*content: object, status: object = "completed") -> object:
+    if not content:
+        content = (_text(),)
+    return SimpleNamespace(
+        type="message",
+        id="msg_1",
+        role="assistant",
+        status=status,
+        content=list(content),
+    )
+
+
+def _reasoning(
+    item_id: str = "rs_1",
+    *,
+    summary: str | None = "summary",
+    content: str | None = None,
+    encrypted: str | None = "opaque",
+    status: object = "completed",
+) -> object:
+    summaries = (
+        [] if summary is None else [SimpleNamespace(type="summary_text", text=summary)]
+    )
+    contents = (
+        None
+        if content is None
+        else [SimpleNamespace(type="reasoning_text", text=content)]
+    )
+    return SimpleNamespace(
+        type="reasoning",
+        id=item_id,
+        summary=summaries,
+        content=contents,
+        encrypted_content=encrypted,
+        status=status,
+    )
+
+
+def _usage(
+    input_tokens: object = 2,
+    output_tokens: object = 3,
+    total_tokens: object = 5,
+    *,
+    cached_tokens: object = 1,
+    reasoning_tokens: object = 2,
+) -> object:
+    return SimpleNamespace(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        total_tokens=total_tokens,
+        input_tokens_details=SimpleNamespace(
+            cached_tokens=cached_tokens,
+            cache_write_tokens=17,
+        ),
+        output_tokens_details=SimpleNamespace(reasoning_tokens=reasoning_tokens),
+    )
+
+
+def _response(
+    *output: object,
+    status: str = "completed",
+    response_id: object = "resp_1",
+    incomplete_reason: object | None = None,
+    error: object | None = None,
+    usage: object | None = None,
+    model: object | None = "provider/model",
+    reasoning_effort: object | None = "high",
+) -> SimpleNamespace:
+    if not output:
+        output = (_message(),)
+    details = (
+        None if incomplete_reason is None else SimpleNamespace(reason=incomplete_reason)
+    )
+    return SimpleNamespace(
+        id=response_id,
+        status=status,
+        output=list(output),
+        incomplete_details=details,
+        error=error,
+        usage=usage,
+        model=model,
+        reasoning=SimpleNamespace(effort=reasoning_effort),
+    )
+
+
+def _dialect(
+    response: object | None = None,
+    *,
+    requested_model_id: str = "requested/model",
+) -> tuple[OpenAIResponsesDialect, AsyncMock]:
+    client = MagicMock()
+    create = AsyncMock(return_value=_response() if response is None else response)
+    client.responses.create = create
+    return OpenAIResponsesDialect(client, requested_model_id), create
+
+
+def _prepare_for_audit(
+    dialect: OpenAIResponsesDialect,
+    request: Request,
+) -> tuple[RequestAudit, PreparedRequest]:
+    audit = RequestAudit(active_request_leaves(request))
+    dialect.validate_request(request, audit, SimpleNamespace())
+    audit.raise_rejections()
+    return audit, dialect.prepare(request, audit)
+
+
+def _awaited_kwargs(create: AsyncMock) -> dict[str, Any]:
+    create.assert_awaited()
+    call = create.await_args
+    assert call is not None
+    return dict(call.kwargs)
+
+
+def _logprob() -> object:
+    return SimpleNamespace(
+        token="A",
+        bytes=[65],
+        logprob=-0.1,
+        top_logprobs=[SimpleNamespace(token="B", bytes=[66], logprob=-2.0)],
+    )
+
+
+def _sdk_response_payload() -> dict[str, object]:
+    """Minimal response accepted by the repository's locked OpenAI SDK."""
+
+    return {
+        "id": "resp_sdk",
+        "object": "response",
+        "created_at": 1.0,
+        "status": "completed",
+        "error": None,
+        "incomplete_details": None,
+        "instructions": None,
+        "metadata": {},
+        "model": "provider/model",
+        "output": [
+            {
+                "type": "reasoning",
+                "id": "rs_sdk",
+                "summary": [{"type": "summary_text", "text": "why"}],
+                "content": None,
+                "encrypted_content": "encrypted",
+                "status": "completed",
+            },
+            {
+                "type": "message",
+                "id": "msg_sdk",
+                "status": "completed",
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "output_text",
+                        "text": "sdk output",
+                        "annotations": [],
+                        "logprobs": None,
+                    }
+                ],
+            },
+        ],
+        "parallel_tool_calls": True,
+        "temperature": 1.0,
+        "tool_choice": "auto",
+        "tools": [],
+        "top_p": 1.0,
+        "background": False,
+        "conversation": None,
+        "max_output_tokens": None,
+        "max_tool_calls": None,
+        "previous_response_id": None,
+        "prompt": None,
+        "prompt_cache_key": None,
+        "prompt_cache_retention": None,
+        "reasoning": {"effort": "high", "summary": "detailed"},
+        "safety_identifier": None,
+        "service_tier": "default",
+        "text": {"format": {"type": "text"}},
+        "top_logprobs": 0,
+        "truncation": "disabled",
+        "usage": None,
+        "user": None,
+    }
+
+
+def _sdk_completed_event(
+    *,
+    sequence_number: int = 1,
+    response: dict[str, object] | None = None,
+) -> ResponseCompletedEvent:
+    return ResponseCompletedEvent.model_validate(
+        {
+            "type": "response.completed",
+            "sequence_number": sequence_number,
+            "response": _sdk_response_payload() if response is None else response,
+        }
+    )
+
+
+def _sdk_incomplete_response_payload(reason: str) -> dict[str, object]:
+    response = _sdk_response_payload()
+    response["status"] = "incomplete"
+    response["incomplete_details"] = {"reason": reason}
+    return response
+
+
+def _sdk_failed_event() -> ResponseFailedEvent:
+    response = _sdk_response_payload()
+    response["status"] = "failed"
+    response["error"] = {"code": "server_error", "message": "boom"}
+    response["output"] = []
+    return ResponseFailedEvent.model_validate(
+        {
+            "type": "response.failed",
+            "sequence_number": 1,
+            "response": response,
+        }
+    )
+
+
+def _sdk_error_event() -> ResponseErrorEvent:
+    return ResponseErrorEvent.model_validate(
+        {
+            "type": "error",
+            "sequence_number": 1,
+            "code": "server_error",
+            "message": "bad stream",
+            "param": None,
+        }
+    )
+
+
+def _opaque_reasoning_continuation(**overrides: object) -> str:
+    item: dict[str, object] = {
+        "type": "reasoning",
+        "id": "rs_1",
+        "summary": [],
+        "encrypted_content": "opaque",
+    }
+    item.update(overrides)
+    return json.dumps({"version": 2, "items": [item]}, separators=(",", ":"))
+
+
+def _sdk_web_search_response(status: str) -> SDKResponse:
+    raw = _sdk_response_payload()
+    raw["output"] = [
+        {
+            "type": "web_search_call",
+            "id": "ws_1",
+            "status": status,
+            "action": {
+                "type": "open_page",
+                "url": "https://example.test/source",
+            },
+        }
+    ]
+    return SDKResponse.model_validate(raw)
+
+
+_RESPONSES_IR_OWNED_OPTIONS = (
+    "echo",
+    "extra_body",
+    "frequency_penalty",
+    "function_call",
+    "functions",
+    "include",
+    "input",
+    "instructions",
+    "logprobs",
+    "max_completion_tokens",
+    "max_output_tokens",
+    "max_tokens",
+    "messages",
+    "model",
+    "n",
+    "opaque_continuation",
+    "parallel_tool_calls",
+    "presence_penalty",
+    "previous_response_id",
+    "prompt",
+    "reasoning",
+    "reasoning_effort",
+    "response_format",
+    "return_logprobs",
+    "score_input",
+    "seed",
+    "server_tools",
+    "session_id",
+    "stop",
+    "stream",
+    "stream_options",
+    "suffix",
+    "temperature",
+    "text",
+    "tool_choice",
+    "tools",
+    "top_k",
+    "top_logprobs",
+    "top_p",
+    "web_search_options",
+)
+
+
+class TestWireTranslation:
+    @pytest.mark.anyio
+    async def test_mapping_response_and_string_tool_result_need_no_sdk_shim(
+        self,
+    ) -> None:
+        raw: Mapping[str, object] = {
+            "id": "resp_mapping",
+            "status": "completed",
+            "error": None,
+            "output": [
+                {
+                    "type": "message",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": "mapped",
+                            "annotations": [],
+                            "logprobs": None,
+                        }
+                    ],
+                }
+            ],
+            "usage": None,
+            "model": None,
+            "reasoning": None,
+        }
+        dialect, create = _dialect(raw)
+
+        response = await dialect.arun(
+            Request(
+                input=_chat(
+                    ChatMessage(
+                        "tool",
+                        (ToolResultPart("call_1", "plain result"),),
+                    )
+                )
+            )
+        )
+
+        assert response.texts == ("mapped",)
+        assert _awaited_kwargs(create)["input"] == [
+            {
+                "type": "function_call_output",
+                "call_id": "call_1",
+                "output": "plain result",
+            }
+        ]
+
+    @pytest.mark.anyio
+    async def test_url_image_and_call_only_history_preserve_their_wire_shapes(
+        self,
+    ) -> None:
+        dialect, create = _dialect()
+
+        await dialect.arun(
+            Request(
+                input=_chat(
+                    ChatMessage(
+                        "user",
+                        (
+                            ImagePart(
+                                url="https://example.test/image.png",
+                                detail="low",
+                            ),
+                        ),
+                    ),
+                    ChatMessage(
+                        "assistant",
+                        (ToolCallPart("call_1", "lookup", "{}"),),
+                    ),
+                )
+            )
+        )
+
+        assert _awaited_kwargs(create)["input"] == [
+            {
+                "type": "message",
+                "role": "user",
+                "content": [
+                    {
+                        "type": "input_image",
+                        "image_url": "https://example.test/image.png",
+                        "detail": "low",
+                    }
+                ],
+            },
+            {
+                "type": "function_call",
+                "call_id": "call_1",
+                "name": "lookup",
+                "arguments": "{}",
+            },
+        ]
+
+    @pytest.mark.anyio
+    async def test_real_sdk_transmits_current_original_image_detail(self) -> None:
+        requests: list[dict[str, Any]] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            payload = json.loads(request.content)
+            assert isinstance(payload, dict)
+            requests.append(payload)
+            return httpx.Response(200, json=_sdk_response_payload(), request=request)
+
+        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        client = AsyncOpenAI(
+            api_key="test",
+            base_url="https://example.test/v1",
+            http_client=http_client,
+        )
+        try:
+            dialect = OpenAIResponsesDialect(client, "requested/model")
+            await dialect.arun(
+                Request(
+                    input=_chat(
+                        ChatMessage(
+                            "user",
+                            (
+                                ImagePart(
+                                    url="https://example.test/image.png",
+                                    detail="original",
+                                ),
+                            ),
+                        )
+                    )
+                )
+            )
+        finally:
+            await client.close()
+
+        assert requests[0]["input"] == [
+            {
+                "type": "message",
+                "role": "user",
+                "content": [
+                    {
+                        "type": "input_image",
+                        "image_url": "https://example.test/image.png",
+                        "detail": "original",
+                    }
+                ],
+            }
+        ]
+        assert "include" not in requests[0]
+
+    @pytest.mark.anyio
+    async def test_interleaved_assistant_content_preserves_ir_order(self) -> None:
+        dialect, create = _dialect()
+
+        await dialect.arun(
+            Request(
+                input=_chat(
+                    ChatMessage(
+                        "assistant",
+                        (
+                            ToolCallPart("call_1", "first", {}),
+                            TextPart("middle"),
+                            ToolCallPart("call_2", "second", {"value": 2}),
+                            TextPart("tail"),
+                        ),
+                    )
+                )
+            )
+        )
+
+        assert _awaited_kwargs(create)["input"] == [
+            {
+                "type": "function_call",
+                "call_id": "call_1",
+                "name": "first",
+                "arguments": "{}",
+            },
+            {
+                "type": "message",
+                "role": "assistant",
+                "content": "middle",
+            },
+            {
+                "type": "function_call",
+                "call_id": "call_2",
+                "name": "second",
+                "arguments": '{"value":2}',
+            },
+            {
+                "type": "message",
+                "role": "assistant",
+                "content": "tail",
+            },
+        ]
+
+    @pytest.mark.anyio
+    async def test_complete_request_preserves_responses_wire_shape(self) -> None:
+        raw = _sdk_response_payload()
+        raw["id"] = "resp_1"
+        raw["output"] = [
+            {
+                "type": "reasoning",
+                "id": "rs_1",
+                "summary": [{"type": "summary_text", "text": "summary"}],
+                "content": None,
+                "encrypted_content": "opaque",
+                "status": "completed",
+            },
+            {
+                "type": "message",
+                "id": "msg_1",
+                "status": "completed",
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "output_text",
+                        "text": '{"answer":42}',
+                        "annotations": [
+                            {
+                                "type": "url_citation",
+                                "start_index": 0,
+                                "end_index": 13,
+                                "url": "https://example.test/source",
+                                "title": "Source",
+                            }
+                        ],
+                        "logprobs": [
+                            {
+                                "token": "A",
+                                "bytes": [65],
+                                "logprob": -0.1,
+                                "top_logprobs": [
+                                    {
+                                        "token": "B",
+                                        "bytes": [66],
+                                        "logprob": -2.0,
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            },
+            {
+                "type": "function_call",
+                "id": "fc_1",
+                "call_id": "call_out",
+                "name": "weather",
+                "arguments": '{"city":"Paris"}',
+                "status": "completed",
+            },
+            {
+                "type": "web_search_call",
+                "id": "ws_1",
+                "status": "completed",
+                "action": {
+                    "type": "search",
+                    "query": "weather Paris",
+                    "sources": [
+                        {
+                            "type": "url",
+                            "url": "https://example.test/source",
+                        }
+                    ],
+                },
+            },
+        ]
+        raw["usage"] = {
+            "input_tokens": 2,
+            "output_tokens": 3,
+            "total_tokens": 5,
+            "input_tokens_details": {
+                "cached_tokens": 1,
+                "cache_write_tokens": 17,
+            },
+            "output_tokens_details": {"reasoning_tokens": 2},
+        }
+        dialect, create = _dialect(SDKResponse.model_validate(raw))
+        function: Mapping[str, JSONValue] = {
+            "type": "function",
+            "function": {
+                "name": "weather",
+                "description": "Get weather",
+                "parameters": {"type": "object"},
+                "strict": True,
+            },
+        }
+        request = Request(
+            input=_chat(
+                ChatMessage(
+                    "user",
+                    (
+                        TextPart("question"),
+                        ImagePart(data="YWJj", media_type="image/png", detail="high"),
+                    ),
+                ),
+                ChatMessage(
+                    "assistant",
+                    (
+                        TextPart("checking"),
+                        ToolCallPart("call_1", "weather", {"city": "Paris"}),
+                    ),
+                ),
+                ChatMessage(
+                    "tool",
+                    (ToolResultPart("call_1", {"temperature": 20}),),
+                ),
+            ),
+            sampling=SamplingParams(max_tokens=64, temperature=0.2, top_p=0.9),
+            scoring=ScoringParams(sampled_logprobs=True, top_logprobs=2),
+            reasoning=ReasoningParams(effort="high", summary="detailed"),
+            tools=ToolParams(
+                functions=(function,),
+                choice={"type": "function", "function": {"name": "weather"}},
+                parallel=False,
+                hosted=(
+                    HostedToolSpec(
+                        "web_search_preview", {"search_context_size": "medium"}
+                    ),
+                ),
+            ),
+            structured_output=StructuredOutputParams(
+                format="json_schema",
+                schema={"type": "object"},
+                name="answer",
+                strict=True,
+            ),
+            session=SessionParams(previous_response_id="resp_previous"),
+            dialect_options=DialectOptions(
+                "openai_responses", {"store": True, "service_tier": "flex"}
+            ),
+        )
+
+        response = await dialect.arun(request)
+
+        create.assert_awaited_once_with(
+            model="requested/model",
+            input=[
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [
+                        {"type": "input_text", "text": "question"},
+                        {
+                            "type": "input_image",
+                            "image_url": "data:image/png;base64,YWJj",
+                            "detail": "high",
+                        },
+                    ],
+                },
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": "checking",
+                },
+                {
+                    "type": "function_call",
+                    "call_id": "call_1",
+                    "name": "weather",
+                    "arguments": '{"city":"Paris"}',
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_1",
+                    "output": '{"temperature":20}',
+                },
+            ],
+            stream=False,
+            max_output_tokens=64,
+            temperature=0.2,
+            top_p=0.9,
+            top_logprobs=2,
+            reasoning={"effort": "high", "summary": "detailed"},
+            tools=[
+                {
+                    "type": "function",
+                    "name": "weather",
+                    "description": "Get weather",
+                    "parameters": {"type": "object"},
+                    "strict": True,
+                },
+                {
+                    "type": "web_search_preview",
+                    "search_context_size": "medium",
+                },
+            ],
+            tool_choice={"type": "function", "name": "weather"},
+            parallel_tool_calls=False,
+            text={
+                "format": {
+                    "type": "json_schema",
+                    "name": "answer",
+                    "schema": {"type": "object"},
+                    "strict": True,
+                }
+            },
+            previous_response_id="resp_previous",
+            include=[
+                "message.output_text.logprobs",
+                "reasoning.encrypted_content",
+                "web_search_call.action.sources",
+            ],
+            extra_body={"store": True, "service_tier": "flex"},
+        )
+        assert response.texts == ('{"answer":42}',)
+        assert response.finish_reasons == ("completed",)
+        assert response.reasoning is not None
+        assert response.reasoning[0] is not None
+        assert response.reasoning == (
+            ReasoningOutput(
+                text="summary",
+                opaque_roundtrip=response.reasoning[0].opaque_roundtrip,
+                thinking_tokens=2,
+                effort_used="high",
+            ),
+        )
+        assert response.tool_calls == (
+            FunctionToolCall("call_out", "weather", '{"city":"Paris"}'),
+        )
+        assert response.server_tool_uses == (
+            ServerToolUse(
+                tool_type="web_search",
+                tool_use_id="ws_1",
+                input={"type": "search", "query": "weather Paris"},
+                result=[
+                    {
+                        "type": "url",
+                        "url": "https://example.test/source",
+                    }
+                ],
+            ),
+        )
+        assert response.logprobs == (TokenLogprob("A", -0.1),)
+        assert response.top_logprobs == ((TopKEntry("B", -2.0),),)
+        assert response.structured_output is not None
+        assert response.structured_output.value == {"answer": 42}
+        assert response.session_id == "resp_1"
+        assert response.usage == UsageStats(
+            input_tokens=2,
+            output_tokens=3,
+            total_tokens=5,
+            reasoning_tokens=2,
+            cached_tokens=1,
+        )
+        assert response.citations is not None
+        assert response.citations[0].url == "https://example.test/source"
+        assert response.citations[0].title == "Source"
+        assert response.request_params == {
+            key: value
+            for key, value in _awaited_kwargs(create).items()
+            if key not in {"model", "input"}
+        }
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize("stream", [False, True], ids=["non-stream", "stream"])
+    async def test_persisted_evidence_snapshots_the_final_pre_await_body(
+        self, stream: bool
+    ) -> None:
+        raw = (
+            _AsyncItems([_sdk_completed_event()])
+            if stream
+            else _response(_reasoning(), _message())
+        )
+        dialect, create = _dialect(raw)
+        original = {"mode": "sent"}
+        sent: dict[str, Any] = {}
+
+        async def mutate_after_capture(**kwargs: Any) -> object:
+            sent.update(deepcopy(kwargs))
+            original["mode"] = "changed after response"
+            kwargs["extra_body"]["vendor"]["mode"] = "changed inside SDK"
+            kwargs["input"][0]["content"] = "changed inside SDK"
+            return raw
+
+        create.side_effect = mutate_after_capture
+        response = await dialect.arun(
+            Request(
+                input=_chat(),
+                scheduling=SchedulingParams(stream=stream),
+                dialect_options=DialectOptions(
+                    "openai_responses",
+                    {"vendor": original},
+                ),
+            )
+        )
+
+        assert sent["extra_body"] == {"vendor": {"mode": "sent"}}
+        assert sent["input"] == [
+            {"type": "message", "role": "user", "content": "hello"}
+        ]
+        assert response.request_params is not None
+        assert response.request_params["extra_body"] == {"vendor": {"mode": "sent"}}
+        assert response.reasoning is not None
+        reasoning = response.reasoning[0]
+        assert reasoning is not None
+        assert reasoning.opaque_roundtrip is not None
+        envelope = json.loads(reasoning.opaque_roundtrip)
+        assert envelope["items"][0] == {
+            "type": "message",
+            "role": "user",
+            "content": "hello",
+        }
+
+    @pytest.mark.anyio
+    async def test_real_sdk_expands_extra_body_into_http_json(self) -> None:
+        requests: list[dict[str, Any]] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            payload = json.loads(request.content)
+            assert isinstance(payload, dict)
+            requests.append(payload)
+            response_payload = _sdk_response_payload()
+            response_payload["store"] = False
+            return httpx.Response(200, json=response_payload)
+
+        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        client = AsyncOpenAI(
+            api_key="test",
+            base_url="https://example.test/v1",
+            http_client=http_client,
+        )
+        try:
+            dialect = OpenAIResponsesDialect(client, "requested/model")
+            response = await dialect.arun(
+                Request(
+                    input=_chat(),
+                    dialect_options=DialectOptions(
+                        "openai_responses",
+                        {"store": False, "service_tier": "flex"},
+                    ),
+                )
+            )
+        finally:
+            await client.close()
+
+        assert response.texts == ("sdk output",)
+        assert response.session_id is None
+        assert len(requests) == 1
+        wire = requests[0]
+        assert wire["model"] == "requested/model"
+        assert wire["store"] is False
+        assert wire["service_tier"] == "flex"
+        assert "extra_body" not in wire
+        assert wire["input"] == [
+            {"type": "message", "role": "user", "content": "hello"}
+        ]
+
+    @pytest.mark.anyio
+    async def test_real_sdk_preserves_forward_web_search_status(self) -> None:
+        async def handler(request: httpx.Request) -> httpx.Response:
+            response_payload = _sdk_response_payload()
+            response_payload["output"] = [
+                {
+                    "type": "web_search_call",
+                    "id": "ws_1",
+                    "status": "incomplete",
+                    "action": {
+                        "type": "open_page",
+                        "url": "https://example.test/source",
+                    },
+                }
+            ]
+            return httpx.Response(200, json=response_payload, request=request)
+
+        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        client = AsyncOpenAI(
+            api_key="test",
+            base_url="https://example.test/v1",
+            http_client=http_client,
+        )
+        try:
+            dialect = OpenAIResponsesDialect(client, "requested/model")
+            response = await dialect.arun(
+                Request(
+                    input=_chat(),
+                    tools=ToolParams(hosted=(HostedToolSpec("web_search"),)),
+                )
+            )
+        finally:
+            await client.close()
+
+        assert response.server_tool_uses is not None
+        assert response.server_tool_uses[0].error_code == "incomplete"
+
+    @pytest.mark.anyio
+    async def test_real_sdk_replays_complete_stateless_history(self) -> None:
+        requests: list[dict[str, Any]] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            payload = json.loads(request.content)
+            assert isinstance(payload, dict)
+            requests.append(payload)
+            response_payload = _sdk_response_payload()
+            response_payload["id"] = f"resp_{len(requests)}"
+            response_payload["store"] = False
+            return httpx.Response(200, json=response_payload)
+
+        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        client = AsyncOpenAI(
+            api_key="test",
+            base_url="https://example.test/v1",
+            http_client=http_client,
+        )
+        try:
+            dialect = OpenAIResponsesDialect(client, "requested/model")
+            first = await dialect.arun(
+                Request(
+                    input=_chat(),
+                    dialect_options=DialectOptions(
+                        "openai_responses", {"store": False}
+                    ),
+                )
+            )
+            assert first.reasoning is not None
+            first_reasoning = first.reasoning[0]
+            assert first_reasoning is not None
+            assert first_reasoning.opaque_roundtrip is not None
+
+            await dialect.arun(
+                Request(
+                    input=_chat(ChatMessage("user", (TextPart("next"),))),
+                    session=SessionParams(
+                        opaque_continuation=OpaqueContinuation(
+                            "openai_responses",
+                            first_reasoning.opaque_roundtrip,
+                        )
+                    ),
+                    dialect_options=DialectOptions(
+                        "openai_responses", {"store": False}
+                    ),
+                )
+            )
+        finally:
+            await client.close()
+
+        assert len(requests) == 2
+        assert [item["type"] for item in requests[1]["input"]] == [
+            "message",
+            "reasoning",
+            "message",
+            "message",
+        ]
+        assert requests[1]["input"][0]["content"] == "hello"
+        assert requests[1]["input"][3]["content"] == "next"
+
+    @pytest.mark.anyio
+    async def test_json_object_format_and_flat_function_tool_are_lowered(self) -> None:
+        dialect, create = _dialect(_response(_message(_text("{}"))))
+
+        await dialect.arun(
+            Request(
+                input=_chat(),
+                tools=ToolParams(
+                    functions=(
+                        {
+                            "type": "function",
+                            "name": "lookup",
+                            "parameters": None,
+                        },
+                    )
+                ),
+                structured_output=StructuredOutputParams(format="json_object"),
+            )
+        )
+
+        kwargs = _awaited_kwargs(create)
+        assert kwargs["tools"] == [
+            {"type": "function", "name": "lookup", "parameters": None}
+        ]
+        assert kwargs["text"] == {"format": {"type": "json_object"}}
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize(
+        ("choice", "expected"),
+        [
+            ("auto", "auto"),
+            (
+                {"type": "function", "name": "lookup"},
+                {"type": "function", "name": "lookup"},
+            ),
+        ],
+    )
+    async def test_supported_tool_choice_shapes_are_lowered(
+        self, choice: JSONValue, expected: JSONValue
+    ) -> None:
+        dialect, create = _dialect()
+
+        await dialect.arun(
+            Request(
+                input=_chat(),
+                tools=ToolParams(
+                    functions=({"type": "function", "name": "lookup"},),
+                    choice=choice,
+                ),
+            )
+        )
+
+        assert _awaited_kwargs(create)["tool_choice"] == expected
+
+    @pytest.mark.anyio
+    async def test_sdk_web_search_open_page_action_is_lifted(self) -> None:
+        dialect, create = _dialect(_sdk_web_search_response("completed"))
+
+        response = await dialect.arun(
+            Request(
+                input=_chat(),
+                tools=ToolParams(hosted=(HostedToolSpec("web_search"),)),
+            )
+        )
+
+        assert response.server_tool_uses == (
+            ServerToolUse(
+                tool_type="web_search",
+                tool_use_id="ws_1",
+                input={
+                    "type": "open_page",
+                    "url": "https://example.test/source",
+                },
+            ),
+        )
+        assert _awaited_kwargs(create)["include"] == ["web_search_call.action.sources"]
+
+    @pytest.mark.anyio
+    async def test_sdk_nonterminal_web_search_status_is_rejected(self) -> None:
+        dialect, _ = _dialect(_sdk_web_search_response("searching"))
+
+        with pytest.raises(OutputContractError, match="searching"):
+            await dialect.arun(
+                Request(
+                    input=_chat(),
+                    tools=ToolParams(hosted=(HostedToolSpec("web_search"),)),
+                )
+            )
+
+    @pytest.mark.anyio
+    async def test_sdk_failed_web_search_status_is_preserved(self) -> None:
+        dialect, _ = _dialect(_sdk_web_search_response("failed"))
+
+        response = await dialect.arun(
+            Request(
+                input=_chat(),
+                tools=ToolParams(hosted=(HostedToolSpec("web_search"),)),
+            )
+        )
+
+        assert response.server_tool_uses == (
+            ServerToolUse(
+                tool_type="web_search",
+                tool_use_id="ws_1",
+                input={
+                    "type": "open_page",
+                    "url": "https://example.test/source",
+                },
+                error_code="failed",
+            ),
+        )
+
+    @pytest.mark.anyio
+    async def test_incomplete_web_search_status_is_preserved(self) -> None:
+        raw = _sdk_response_payload()
+        raw["output"] = [
+            {
+                "type": "web_search_call",
+                "id": "ws_1",
+                "status": "incomplete",
+                "action": {
+                    "type": "open_page",
+                    "url": "https://example.test/source",
+                },
+            }
+        ]
+        dialect, _ = _dialect(raw)
+
+        response = await dialect.arun(
+            Request(
+                input=_chat(),
+                tools=ToolParams(hosted=(HostedToolSpec("web_search"),)),
+            )
+        )
+
+        assert response.server_tool_uses == (
+            ServerToolUse(
+                tool_type="web_search",
+                tool_use_id="ws_1",
+                input={
+                    "type": "open_page",
+                    "url": "https://example.test/source",
+                },
+                error_code="incomplete",
+            ),
+        )
+
+    @pytest.mark.anyio
+    async def test_json_schema_uses_defaults_only_for_absent_optional_fields(
+        self,
+    ) -> None:
+        dialect, create = _dialect(_response(_message(_text("{}"))))
+
+        await dialect.arun(
+            Request(
+                input=_chat(),
+                structured_output=StructuredOutputParams(
+                    format="json_schema",
+                    schema={"type": "object"},
+                ),
+            )
+        )
+
+        assert _awaited_kwargs(create)["text"] == {
+            "format": {
+                "type": "json_schema",
+                "name": "response",
+                "schema": {"type": "object"},
+            }
+        }
+
+    @pytest.mark.anyio
+    async def test_reasoning_summary_none_and_empty_options_are_noops(self) -> None:
+        dialect, create = _dialect()
+
+        await dialect.arun(
+            Request(
+                input=_chat(),
+                reasoning=ReasoningParams(summary="none"),
+                dialect_options=DialectOptions("openai_responses", {}),
+            )
+        )
+
+        kwargs = _awaited_kwargs(create)
+        assert "reasoning" not in kwargs
+        assert "include" not in kwargs
+        assert "extra_body" not in kwargs
+
+    @pytest.mark.anyio
+    async def test_plain_request_does_not_request_encrypted_reasoning(self) -> None:
+        dialect, create = _dialect()
+
+        await dialect.arun(Request(input=_chat()))
+
+        assert "include" not in _awaited_kwargs(create)
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize(
+        "reasoning",
+        [
+            pytest.param(ReasoningParams(effort="high"), id="effort"),
+            pytest.param(ReasoningParams(summary="auto"), id="summary"),
+        ],
+    )
+    async def test_active_reasoning_requests_encrypted_content(
+        self, reasoning: ReasoningParams
+    ) -> None:
+        dialect, create = _dialect(_response(_reasoning(), _message()))
+
+        await dialect.arun(Request(input=_chat(), reasoning=reasoning))
+
+        assert _awaited_kwargs(create)["include"] == ["reasoning.encrypted_content"]
+
+    @pytest.mark.anyio
+    async def test_reasoning_effort_none_does_not_require_a_reasoning_item(
+        self,
+    ) -> None:
+        dialect, create = _dialect(_response(_message()))
+
+        response = await dialect.arun(
+            Request(input=_chat(), reasoning=ReasoningParams(effort="none"))
+        )
+
+        assert response.reasoning is None
+        kwargs = _awaited_kwargs(create)
+        assert kwargs["reasoning"] == {"effort": "none"}
+        assert "include" not in kwargs
+
+    @pytest.mark.anyio
+    async def test_opaque_history_is_complete_ordered_and_cumulative(self) -> None:
+        dialect, create = _dialect(_response(_reasoning(), _message()))
+        first = await dialect.arun(
+            Request(input=_chat(), reasoning=ReasoningParams(effort="high"))
+        )
+        assert first.reasoning is not None
+        opaque = first.reasoning[0]
+        assert opaque is not None and opaque.opaque_roundtrip is not None
+
+        create.reset_mock()
+        create.return_value = _response(
+            _reasoning("rs_2", encrypted="opaque-2"),
+            _message(_text("second")),
+        )
+        second = await dialect.arun(
+            Request(
+                input=_chat(ChatMessage("user", (TextPart("next"),))),
+                session=SessionParams(
+                    opaque_continuation=OpaqueContinuation(
+                        "openai_responses", opaque.opaque_roundtrip
+                    )
+                ),
+            )
+        )
+
+        kwargs = _awaited_kwargs(create)
+        assert kwargs["input"] == [
+            {"type": "message", "role": "user", "content": "hello"},
+            {
+                "encrypted_content": "opaque",
+                "id": "rs_1",
+                "status": "completed",
+                "summary": [{"text": "summary", "type": "summary_text"}],
+                "type": "reasoning",
+            },
+            {
+                "type": "message",
+                "id": "msg_1",
+                "role": "assistant",
+                "status": "completed",
+                "content": [
+                    {
+                        "type": "output_text",
+                        "text": "ok",
+                        "annotations": [],
+                        "logprobs": None,
+                    }
+                ],
+            },
+            {
+                "type": "message",
+                "role": "user",
+                "content": "next",
+            },
+        ]
+        assert kwargs["include"] == ["reasoning.encrypted_content"]
+
+        assert second.reasoning is not None
+        second_reasoning = second.reasoning[0]
+        assert second_reasoning is not None
+        assert second_reasoning.opaque_roundtrip is not None
+        create.reset_mock()
+        create.return_value = _response(
+            _reasoning("rs_3", encrypted="opaque-3"),
+            _message(_text("third")),
+        )
+        await dialect.arun(
+            Request(
+                input=_chat(ChatMessage("user", (TextPart("again"),))),
+                session=SessionParams(
+                    opaque_continuation=OpaqueContinuation(
+                        "openai_responses",
+                        second_reasoning.opaque_roundtrip,
+                    )
+                ),
+            )
+        )
+
+        third_input = _awaited_kwargs(create)["input"]
+        assert [item["type"] for item in third_input] == [
+            "message",
+            "reasoning",
+            "message",
+            "message",
+            "reasoning",
+            "message",
+            "message",
+        ]
+        assert third_input[0]["content"] == "hello"
+        assert third_input[3]["content"] == "next"
+        assert third_input[6] == {
+            "type": "message",
+            "role": "user",
+            "content": "again",
+        }
+
+    @pytest.mark.anyio
+    async def test_opaque_history_preserves_interleaved_function_calls(self) -> None:
+        function_call = SimpleNamespace(
+            type="function_call",
+            id="fc_1",
+            call_id="call_1",
+            name="lookup",
+            arguments='{"q":"x"}',
+            status="completed",
+        )
+        dialect, create = _dialect(
+            _response(
+                _reasoning("rs_1", encrypted="opaque-1"),
+                SimpleNamespace(
+                    type="web_search_call",
+                    id="ws_1",
+                    status="completed",
+                    action={"type": "search", "query": "x"},
+                ),
+                function_call,
+                _reasoning("rs_2", encrypted="opaque-2"),
+            )
+        )
+        first = await dialect.arun(Request(input=_chat()))
+        assert first.reasoning is not None
+        first_reasoning = first.reasoning[0]
+        assert first_reasoning is not None
+        assert first_reasoning.opaque_roundtrip is not None
+
+        create.reset_mock()
+        create.return_value = _response(
+            _reasoning("rs_3", encrypted="opaque-3"),
+            _message(),
+        )
+        await dialect.arun(
+            Request(
+                input=_chat(
+                    ChatMessage(
+                        "tool",
+                        (ToolResultPart("call_1", {"value": 1}),),
+                    )
+                ),
+                session=SessionParams(
+                    opaque_continuation=OpaqueContinuation(
+                        "openai_responses",
+                        first_reasoning.opaque_roundtrip,
+                    )
+                ),
+            )
+        )
+
+        wire = _awaited_kwargs(create)["input"]
+        assert [item["type"] for item in wire] == [
+            "message",
+            "reasoning",
+            "web_search_call",
+            "function_call",
+            "reasoning",
+            "function_call_output",
+        ]
+        assert wire[3]["call_id"] == "call_1"
+        assert wire[5] == {
+            "type": "function_call_output",
+            "call_id": "call_1",
+            "output": '{"value":1}',
+        }
+
+    @pytest.mark.anyio
+    async def test_continuation_survives_a_turn_without_new_reasoning(self) -> None:
+        dialect, create = _dialect(_response(_reasoning(), _message()))
+        first = await dialect.arun(Request(input=_chat()))
+        assert first.reasoning is not None
+        first_reasoning = first.reasoning[0]
+        assert first_reasoning is not None
+        assert first_reasoning.opaque_roundtrip is not None
+
+        create.reset_mock()
+        create.return_value = _response(_message(_text("no new reasoning")))
+        second = await dialect.arun(
+            Request(
+                input=_chat(ChatMessage("user", (TextPart("next"),))),
+                session=SessionParams(
+                    opaque_continuation=OpaqueContinuation(
+                        "openai_responses",
+                        first_reasoning.opaque_roundtrip,
+                    )
+                ),
+            )
+        )
+
+        assert second.reasoning is not None
+        continuation = second.reasoning[0]
+        assert continuation is not None
+        assert continuation.text is None
+        assert continuation.thinking_tokens == 0
+        assert continuation.opaque_roundtrip is not None
+        envelope = json.loads(continuation.opaque_roundtrip)
+        assert [item["type"] for item in envelope["items"]] == [
+            "message",
+            "reasoning",
+            "message",
+            "message",
+            "message",
+        ]
+
+    @pytest.mark.anyio
+    async def test_previous_response_chain_does_not_claim_standalone_history(
+        self,
+    ) -> None:
+        dialect, _ = _dialect(_response(_reasoning(), _message()))
+
+        response = await dialect.arun(
+            Request(
+                input=_chat(),
+                session=SessionParams(previous_response_id="resp_previous"),
+            )
+        )
+
+        assert response.reasoning is not None
+        assert response.reasoning[0] is not None
+        assert response.reasoning[0].opaque_roundtrip is None
+
+    @pytest.mark.anyio
+    async def test_sampled_logprobs_without_alternatives_requests_zero(self) -> None:
+        dialect, create = _dialect(_response(_message(_text(logprobs=[_logprob()]))))
+
+        response = await dialect.arun(
+            Request(
+                input=_chat(),
+                scoring=ScoringParams(sampled_logprobs=True),
+            )
+        )
+
+        kwargs = _awaited_kwargs(create)
+        assert kwargs["top_logprobs"] == 0
+        assert kwargs["include"] == ["message.output_text.logprobs"]
+        assert response.logprobs is not None
+        assert response.top_logprobs is None
+
+
+class TestWireEvidence:
+    @pytest.mark.anyio
+    async def test_input_lowering_drift_is_rejected_before_sdk_io(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        dialect, create = _dialect()
+        original = openai_responses_module._message_to_input_items
+
+        def corrupt_role(message: ChatMessage) -> list[dict[str, JSONValue]]:
+            items = original(message)
+            items[0]["role"] = "system"
+            return items
+
+        monkeypatch.setattr(
+            openai_responses_module,
+            "_message_to_input_items",
+            corrupt_role,
+        )
+
+        with pytest.raises(RequestAuditError, match="body.input"):
+            await dialect.arun(Request(input=_chat()))
+
+        create.assert_not_awaited()
+
+    def test_wire_verifiers_reject_every_semantic_mutation(self) -> None:
+        dialect, _ = _dialect()
+        request = Request(
+            input=_chat(
+                ChatMessage(
+                    "user",
+                    (
+                        TextPart("look"),
+                        ImagePart(
+                            data="YWJj",
+                            media_type="image/png",
+                            detail="high",
+                        ),
+                    ),
+                ),
+                ChatMessage(
+                    "assistant",
+                    (ToolCallPart("call_1", "lookup", {"city": "Paris"}),),
+                ),
+                ChatMessage(
+                    "tool",
+                    (ToolResultPart("call_1", {"ok": True}),),
+                ),
+            ),
+            sampling=SamplingParams(
+                max_tokens=64,
+                temperature=0.2,
+                top_p=0.9,
+            ),
+            scoring=ScoringParams(sampled_logprobs=True, top_logprobs=2),
+            reasoning=ReasoningParams(effort="high", summary="detailed"),
+            tools=ToolParams(
+                functions=(
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "lookup",
+                            "description": "Look up a city",
+                            "parameters": {"type": "object"},
+                            "strict": True,
+                        },
+                    },
+                ),
+                choice={"type": "function", "function": {"name": "lookup"}},
+                parallel=False,
+                hosted=(
+                    HostedToolSpec(
+                        "web_search",
+                        {"search_context_size": "medium"},
+                    ),
+                ),
+            ),
+            structured_output=StructuredOutputParams(
+                format="json_schema",
+                schema={"type": "object"},
+                name="answer",
+                strict=True,
+            ),
+            session=SessionParams(
+                opaque_continuation=OpaqueContinuation(
+                    "openai_responses",
+                    _opaque_reasoning_continuation(),
+                )
+            ),
+            scheduling=SchedulingParams(stream=True),
+            dialect_options=DialectOptions(
+                "openai_responses",
+                {"vendor": {"mode": "strict"}},
+            ),
+        )
+        audit, prepared = _prepare_for_audit(dialect, request)
+        audit.finish(prepared)
+
+        mutations: tuple[tuple[str, Callable[[dict[str, Any]], object]], ...] = (
+            (
+                "opaque continuation",
+                lambda body: body["input"][0].__setitem__(
+                    "encrypted_content", "changed"
+                ),
+            ),
+            (
+                "message role",
+                lambda body: body["input"][1].__setitem__("role", "system"),
+            ),
+            (
+                "message text",
+                lambda body: body["input"][1]["content"][0].__setitem__(
+                    "text", "changed"
+                ),
+            ),
+            (
+                "image URL",
+                lambda body: body["input"][1]["content"][1].__setitem__(
+                    "image_url", "data:image/png;base64,changed"
+                ),
+            ),
+            (
+                "image detail",
+                lambda body: body["input"][1]["content"][1].__setitem__(
+                    "detail", "low"
+                ),
+            ),
+            (
+                "historical tool-call arguments",
+                lambda body: body["input"][2].__setitem__(
+                    "arguments", '{"city":"London"}'
+                ),
+            ),
+            (
+                "historical tool-result output",
+                lambda body: body["input"][3].__setitem__("output", '{"ok":false}'),
+            ),
+            ("input order", lambda body: body["input"].reverse()),
+            (
+                "max output tokens",
+                lambda body: body.__setitem__("max_output_tokens", 32),
+            ),
+            ("temperature", lambda body: body.__setitem__("temperature", 0.4)),
+            ("top p", lambda body: body.__setitem__("top_p", 0.8)),
+            ("top logprobs", lambda body: body.__setitem__("top_logprobs", 1)),
+            (
+                "logprobs include",
+                lambda body: body["include"].remove("message.output_text.logprobs"),
+            ),
+            (
+                "reasoning effort",
+                lambda body: body["reasoning"].__setitem__("effort", "low"),
+            ),
+            (
+                "reasoning summary",
+                lambda body: body["reasoning"].__setitem__("summary", "concise"),
+            ),
+            (
+                "function tool",
+                lambda body: body["tools"][0].__setitem__("name", "changed"),
+            ),
+            (
+                "hosted tool",
+                lambda body: body["tools"][1].__setitem__("search_context_size", "low"),
+            ),
+            ("tool order", lambda body: body["tools"].reverse()),
+            (
+                "hosted-tool include",
+                lambda body: body["include"].remove("web_search_call.action.sources"),
+            ),
+            (
+                "tool choice",
+                lambda body: body["tool_choice"].__setitem__("name", "changed"),
+            ),
+            (
+                "parallel tools",
+                lambda body: body.__setitem__("parallel_tool_calls", True),
+            ),
+            (
+                "structured format",
+                lambda body: body["text"]["format"].__setitem__("type", "json_object"),
+            ),
+            (
+                "structured schema",
+                lambda body: body["text"]["format"]["schema"].__setitem__(
+                    "type", "array"
+                ),
+            ),
+            (
+                "structured name",
+                lambda body: body["text"]["format"].__setitem__("name", "changed"),
+            ),
+            (
+                "structured strict",
+                lambda body: body["text"]["format"].__setitem__("strict", False),
+            ),
+            ("stream", lambda body: body.__setitem__("stream", False)),
+            (
+                "dialect passthrough",
+                lambda body: body["extra_body"]["vendor"].__setitem__(
+                    "mode", "changed"
+                ),
+            ),
+        )
+
+        survived: list[str] = []
+        for label, mutate in mutations:
+            body = cast(dict[str, Any], prepared.thaw_body())
+            mutate(body)
+            try:
+                audit.finish(replace(prepared, body=body))
+            except RequestAuditError:
+                continue
+            survived.append(label)
+        assert not survived, f"wire mutations the audit accepted: {survived}"
+
+
+class TestPreflightRejections:
+    def test_capability_row_and_config_validators_are_concrete(self) -> None:
+        assert set(CAPABILITY_DECISIONS) == {
+            "input_scoring",
+            "sampled_logprobs",
+            "top_logprobs",
+            "reasoning",
+            "function_tools",
+            "hosted_tools",
+            "structured_output",
+            "stateful_session",
+            "opaque_continuation",
+            "multimodal_input",
+            "prefill",
+            "fim",
+        }
+        assert (
+            Capability.ServerTools
+            in OpenAIResponsesDialect(MagicMock(), "model").capabilities
+        )
+
+        top = CAPABILITY_DECISIONS["top_logprobs"]
+        reasoning = CAPABILITY_DECISIONS["reasoning"]
+        hosted = CAPABILITY_DECISIONS["hosted_tools"]
+        multimodal = CAPABILITY_DECISIONS["multimodal_input"]
+        assert isinstance(top, Supported)
+        assert isinstance(reasoning, Supported)
+        assert isinstance(hosted, Supported)
+        assert isinstance(multimodal, Supported)
+        assert "input.modality.image.detail" in multimodal.binding.request_leaves
+        top.binding.validate_config(TopLogprobsOptions(minimum=20))
+        with pytest.raises(ValueError, match="at most 20"):
+            top.binding.validate_config(TopLogprobsOptions(minimum=21))
+        with pytest.raises(ValueError, match="budget_tokens"):
+            reasoning.binding.validate_config(ReasoningOptions(budget_tokens=32))
+        reasoning.binding.validate_config(ReasoningOptions(effort="max"))
+        with pytest.raises(ValueError, match="effort"):
+            reasoning.binding.validate_config(ReasoningOptions(effort="ultra"))
+        hosted.binding.validate_config(HostedToolsOptions(kinds=("web_search",)))
+        with pytest.raises(ValueError, match="unsupported kinds"):
+            hosted.binding.validate_config(HostedToolsOptions(kinds=("file_search",)))
+        multimodal.binding.validate_config(
+            MultimodalInputOptions(modalities=("image",))
+        )
+        invalid_multimodal = object.__new__(MultimodalInputOptions)
+        object.__setattr__(invalid_multimodal, "modalities", ("audio",))
+        with pytest.raises(ValueError, match="does not support modalities"):
+            multimodal.binding.validate_config(invalid_multimodal)
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize(
+        ("model_request", "message"),
+        [
+            (Request(input=CompletionInput("prompt")), "requires ChatInput"),
+            (
+                Request(input=_chat(), sampling=SamplingParams(top_k=10)),
+                "no equivalent request field",
+            ),
+            (
+                Request(input=_chat(), sampling=SamplingParams(stop=("END",))),
+                "no equivalent request field",
+            ),
+            (
+                Request(input=_chat(), sampling=SamplingParams(seed=7)),
+                "no equivalent request field",
+            ),
+            (
+                Request(input=_chat(), sampling=SamplingParams(frequency_penalty=0.2)),
+                "no equivalent request field",
+            ),
+            (
+                Request(input=_chat(), sampling=SamplingParams(presence_penalty=0.2)),
+                "no equivalent request field",
+            ),
+            (
+                Request(input=_chat(), sampling=SamplingParams(n=2)),
+                "no equivalent request field",
+            ),
+            (
+                Request(input=_chat(), scoring=ScoringParams(input_scoring=True)),
+                "unavailable capability 'input_scoring'",
+            ),
+            (
+                Request(
+                    input=_chat(),
+                    scoring=ScoringParams(sampled_logprobs=True, top_logprobs=21),
+                ),
+                "at most 20",
+            ),
+            (
+                Request(input=_chat(), reasoning=ReasoningParams(budget_tokens=32)),
+                "token-budget",
+            ),
+            (
+                Request(input=_chat(), reasoning=ReasoningParams(effort="ultra")),
+                "unsupported OpenAI reasoning effort",
+            ),
+            (
+                Request(
+                    input=_chat(),
+                    tools=ToolParams(hosted=(HostedToolSpec("file_search"),)),
+                ),
+                "web-search hosted tools",
+            ),
+            (
+                Request(
+                    input=_chat(
+                        ChatMessage(
+                            "user",
+                            (
+                                ImagePart(
+                                    url="https://example.test/image.png",
+                                    media_type="image/png",
+                                ),
+                            ),
+                        )
+                    )
+                ),
+                "no media-type field",
+            ),
+            (
+                Request(input=_chat(ChatMessage("user", (ImagePart(data="YWJj"),)))),
+                "explicit image media type",
+            ),
+            (
+                Request(
+                    input=_chat(
+                        ChatMessage(
+                            "user",
+                            (ImagePart(data="YWJj", media_type="image/tiff"),),
+                        )
+                    )
+                ),
+                "unsupported Responses image media type",
+            ),
+            (
+                Request(
+                    input=_chat(
+                        ChatMessage(
+                            "user",
+                            (ImagePart(data="YWJj", media_type=""),),
+                        )
+                    )
+                ),
+                "unsupported Responses image media type",
+            ),
+            (
+                Request(
+                    input=_chat(
+                        ChatMessage(
+                            "user",
+                            (
+                                ImagePart(
+                                    data="YWJj",
+                                    media_type="image/png",
+                                    detail="",
+                                ),
+                            ),
+                        )
+                    )
+                ),
+                "unsupported Responses image detail",
+            ),
+            (
+                Request(input=_chat(ChatMessage("user", (ImagePart(url=""),)))),
+                "image URLs must not be empty",
+            ),
+            (
+                Request(
+                    input=_chat(
+                        ChatMessage(
+                            "user",
+                            (ImagePart(data="", media_type="image/png"),),
+                        )
+                    )
+                ),
+                "inline images require non-empty base64 data",
+            ),
+            (
+                Request(
+                    input=_chat(
+                        ChatMessage(
+                            "tool",
+                            (ToolResultPart("call", "failed", is_error=True),),
+                        )
+                    )
+                ),
+                "cannot transmit is_error",
+            ),
+            (
+                Request(
+                    input=_chat(ChatMessage("user", (TextPart("hello"),), name="named"))
+                ),
+                "no name field",
+            ),
+            (
+                Request(
+                    input=_chat(),
+                    structured_output=StructuredOutputParams(
+                        format="json_schema",
+                        schema={},
+                        name="",
+                    ),
+                ),
+                "schema names must not be empty",
+            ),
+            (
+                Request(
+                    input=_chat(),
+                    structured_output=StructuredOutputParams(
+                        format="json_object",
+                        schema={"type": "object"},
+                    ),
+                ),
+                "schema, name, and strict require format='json_schema'",
+            ),
+            (
+                Request(
+                    input=_chat(),
+                    session=SessionParams(
+                        previous_response_id="resp_1",
+                        opaque_continuation=OpaqueContinuation(
+                            "openai_responses", '{"version":1,"items":[]}'
+                        ),
+                    ),
+                ),
+                "mutually exclusive",
+            ),
+            (
+                Request(
+                    input=_chat(),
+                    session=SessionParams(previous_response_id="resp_1"),
+                    dialect_options=DialectOptions(
+                        "openai_responses", {"store": False}
+                    ),
+                ),
+                "store=false is stateless",
+            ),
+            (
+                Request(
+                    input=_chat(),
+                    dialect_options=DialectOptions(
+                        "openai_responses", {"conversation": "conv_123"}
+                    ),
+                ),
+                "conversation state is not yet modeled",
+            ),
+            (
+                Request(
+                    input=_chat(),
+                    dialect_options=DialectOptions(
+                        "openai_responses", {"instructions": "ignore the input"}
+                    ),
+                ),
+                "must be expressed through provider-neutral",
+            ),
+            (
+                Request(
+                    input=_chat(),
+                    dialect_options=DialectOptions(
+                        "openai_responses", {"max_output_tokens": 1}
+                    ),
+                ),
+                "canonical provider-neutral field",
+            ),
+            (
+                Request(
+                    input=_chat(),
+                    dialect_options=DialectOptions(
+                        "openai_responses", {"background": True}
+                    ),
+                ),
+                "background Responses cannot complete",
+            ),
+            (
+                Request(
+                    input=_chat(),
+                    dialect_options=DialectOptions(
+                        "openai_responses", {"store": "false"}
+                    ),
+                ),
+                "store must be a boolean",
+            ),
+        ],
+    )
+    async def test_every_request_rejection_happens_before_io(
+        self, model_request: Request, message: str
+    ) -> None:
+        dialect, create = _dialect()
+
+        with pytest.raises(
+            (DialectError, RequestAuditError, ValueError), match=message
+        ):
+            await dialect.arun(model_request)
+
+        create.assert_not_awaited()
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize("option_key", _RESPONSES_IR_OWNED_OPTIONS)
+    async def test_every_ir_owned_wire_key_rejects_alternate_authority(
+        self, option_key: str
+    ) -> None:
+        dialect, create = _dialect()
+
+        with pytest.raises(RequestAuditError, match="dialect_options"):
+            await dialect.arun(
+                Request(
+                    input=_chat(),
+                    dialect_options=DialectOptions(
+                        "openai_responses",
+                        {option_key: None},
+                    ),
+                )
+            )
+
+        create.assert_not_awaited()
+
+    def test_ir_owned_wire_key_oracle_matches_the_dialect_policy(self) -> None:
+        assert set(openai_responses_module._IR_OWNED_BODY_KEYS) == (
+            set(BINDING_RESOURCE_KEYS) | set(_RESPONSES_IR_OWNED_OPTIONS)
+        )
+
+    @pytest.mark.parametrize(
+        "available_capabilities",
+        [
+            pytest.param(frozenset(), id="stateful-session-disabled"),
+            pytest.param(
+                frozenset({"stateful_session"}),
+                id="stateful-session-available",
+            ),
+        ],
+    )
+    def test_conversation_option_cannot_bypass_stateful_session_gate(
+        self, available_capabilities: frozenset[str]
+    ) -> None:
+        dialect, create = _dialect()
+        request = Request(
+            input=_chat(),
+            dialect_options=DialectOptions(
+                "openai_responses", {"conversation": "conv_123"}
+            ),
+        )
+        plan = SimpleNamespace(
+            dialect_id="openai_responses",
+            available_capabilities=available_capabilities,
+            capability_minimums={},
+            required_output_channels=frozenset(),
+        )
+
+        validate_runtime_binding_plan(plan, request)
+        audit = RequestAudit(active_request_leaves(request))
+        dialect.validate_request(request, audit, plan)
+
+        with pytest.raises(
+            RequestAuditError,
+            match=r"dialect_options\.conversation.*not yet modeled",
+        ):
+            audit.raise_rejections()
+        create.assert_not_awaited()
+
+    def test_empty_requested_model_id_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="requested_model_id must not be empty"):
+            OpenAIResponsesDialect(MagicMock(), "")
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize(
+        ("model_request", "message"),
+        [
+            (
+                Request(
+                    input=_chat(),
+                    tools=ToolParams(functions=({"type": "custom", "name": "x"},)),
+                ),
+                "require type='function'",
+            ),
+            (
+                Request(
+                    input=_chat(),
+                    tools=ToolParams(
+                        functions=({"type": "function", "name": "x", "unknown": True},)
+                    ),
+                ),
+                "unsupported function tool field",
+            ),
+            (
+                Request(
+                    input=_chat(),
+                    tools=ToolParams(functions=({"type": "function"},)),
+                ),
+                "function tool name must be a non-empty string",
+            ),
+            (
+                Request(
+                    input=_chat(),
+                    tools=ToolParams(
+                        functions=(
+                            {"type": "function", "function": {"name": "x"}, "x": 1},
+                        )
+                    ),
+                ),
+                "invalid Chat-shaped",
+            ),
+            (
+                Request(input=_chat(), tools=ToolParams(choice="sometimes")),
+                "unsupported Responses tool choice",
+            ),
+            (
+                Request(input=_chat(), tools=ToolParams(choice=1)),
+                "tool choice must be a string or mapping",
+            ),
+            (
+                Request(
+                    input=_chat(),
+                    tools=ToolParams(choice={"type": "web_search"}),
+                ),
+                "only function-specific",
+            ),
+            (
+                Request(
+                    input=_chat(),
+                    tools=ToolParams(
+                        choice={
+                            "type": "function",
+                            "function": {"name": "x"},
+                            "unknown": True,
+                        }
+                    ),
+                ),
+                "invalid Chat-shaped function tool choice",
+            ),
+            (
+                Request(
+                    input=_chat(),
+                    tools=ToolParams(
+                        choice={"type": "function", "name": "x", "unknown": True}
+                    ),
+                ),
+                "invalid Responses function tool choice",
+            ),
+            (
+                Request(
+                    input=_chat(),
+                    tools=ToolParams(choice={"type": "function", "name": ""}),
+                ),
+                "function tool choice requires a non-empty name",
+            ),
+            (
+                Request(
+                    input=_chat(),
+                    tools=ToolParams(
+                        hosted=(HostedToolSpec("web_search", {"type": "other"}),)
+                    ),
+                ),
+                "cannot override",
+            ),
+            (
+                Request(
+                    input=_chat(
+                        ChatMessage("user", (ToolCallPart("call", "tool", {}),))
+                    )
+                ),
+                "assistant message",
+            ),
+            (
+                Request(input=_chat(ChatMessage("tool", (TextPart("x"),)))),
+                "requires one result",
+            ),
+            (
+                Request(
+                    input=_chat(
+                        ChatMessage(
+                            "tool",
+                            (
+                                ToolResultPart("call", "result"),
+                                TextPart("extra"),
+                            ),
+                        )
+                    )
+                ),
+                "must contain exactly one result",
+            ),
+        ],
+    )
+    async def test_structural_lowering_errors_happen_before_io(
+        self, model_request: Request, message: str
+    ) -> None:
+        dialect, create = _dialect()
+
+        with pytest.raises(DialectError, match=message):
+            await dialect.arun(model_request)
+
+        create.assert_not_awaited()
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize(
+        "opaque",
+        [
+            "not-json",
+            "[]",
+            '{"version":2,"items":[]}',
+            (
+                '{"version":true,"items":[{"type":"reasoning","id":"rs_1",'
+                '"summary":[],"encrypted_content":"opaque"}]}'
+            ),
+            '{"version":1,"items":[]}',
+            '{"version":2,"items":[{"type":"unknown"}]}',
+            (
+                '{"version":2,"items":[{"type":"message","role":"user",'
+                '"content":"hello"}]}'
+            ),
+            '{"version":2,"items":[{"type":"reasoning"}]}',
+            ('{"version":2,"items":[{"type":"reasoning","id":"rs_1","summary":[]}]}'),
+            (
+                '{"version":2,"items":[{"type":"reasoning","id":"rs_1",'
+                '"summary":[],"encrypted_content":"opaque"}],"extra":true}'
+            ),
+            (
+                '{"version":2,"version":2,"items":[{"type":"reasoning",'
+                '"id":"rs_1","summary":[],"encrypted_content":"opaque"}]}'
+            ),
+            (
+                '{"version":2,"items":[{"type":"reasoning","id":"rs_1",'
+                '"id":"rs_2","summary":[],"encrypted_content":"opaque"}]}'
+            ),
+            pytest.param(
+                _opaque_reasoning_continuation(unknown=None),
+                id="reasoning-item-unknown-null-field",
+            ),
+            pytest.param(
+                _opaque_reasoning_continuation(summary="bad"),
+                id="reasoning-summary-not-list",
+            ),
+            pytest.param(
+                _opaque_reasoning_continuation(
+                    summary=[{"type": "reasoning_text", "text": "bad"}]
+                ),
+                id="reasoning-summary-wrong-type",
+            ),
+            pytest.param(
+                _opaque_reasoning_continuation(
+                    summary=[{"type": "summary_text", "text": "ok", "extra": None}]
+                ),
+                id="reasoning-summary-extra-field",
+            ),
+            pytest.param(
+                _opaque_reasoning_continuation(
+                    summary=[{"type": "summary_text", "text": 1}]
+                ),
+                id="reasoning-summary-text-not-string",
+            ),
+            pytest.param(
+                _opaque_reasoning_continuation(content="bad"),
+                id="reasoning-content-not-list",
+            ),
+            pytest.param(
+                _opaque_reasoning_continuation(
+                    content=[{"type": "summary_text", "text": "bad"}]
+                ),
+                id="reasoning-content-wrong-type",
+            ),
+            pytest.param(
+                _opaque_reasoning_continuation(
+                    content=[{"type": "reasoning_text", "text": "ok", "extra": None}]
+                ),
+                id="reasoning-content-extra-field",
+            ),
+            pytest.param(
+                _opaque_reasoning_continuation(status=1),
+                id="reasoning-status-not-string",
+            ),
+            pytest.param(
+                _opaque_reasoning_continuation(status="queued"),
+                id="reasoning-status-not-terminal-or-in-progress",
+            ),
+            pytest.param(
+                _opaque_reasoning_continuation(encrypted_content=1),
+                id="reasoning-encrypted-content-not-string",
+            ),
+            pytest.param(
+                _opaque_reasoning_continuation(encrypted_content=""),
+                id="reasoning-encrypted-content-empty",
+            ),
+        ],
+    )
+    async def test_invalid_opaque_continuation_fails_before_io(
+        self, opaque: str
+    ) -> None:
+        dialect, create = _dialect()
+
+        with pytest.raises(DialectError, match="opaque continuation"):
+            await dialect.arun(
+                Request(
+                    input=_chat(),
+                    session=SessionParams(
+                        opaque_continuation=OpaqueContinuation(
+                            "openai_responses", opaque
+                        )
+                    ),
+                )
+            )
+
+        create.assert_not_awaited()
+
+    def test_prepare_rejects_mismatched_audit(self) -> None:
+        dialect, _ = _dialect()
+        req = Request(input=_chat())
+        wrong = RequestAudit(active_request_leaves(Request(CompletionInput("x"))))
+
+        with pytest.raises(DialectError, match="audit does not match"):
+            dialect.prepare(req, wrong)
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize(
+        "prepared",
+        [
+            PreparedRequest("other", {}),
+            PreparedRequest("responses.create", {}),
+        ],
+    )
+    async def test_execute_rejects_invalid_prepared_requests(
+        self, prepared: PreparedRequest
+    ) -> None:
+        dialect, create = _dialect()
+
+        with pytest.raises(DialectError, match="operation|context"):
+            await dialect.execute(prepared)
+
+        create.assert_not_awaited()
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize(
+        ("mutate", "message"),
+        [
+            (lambda body: body.pop("model"), "invalid model"),
+            (lambda body: body.pop("stream"), "invalid stream flag"),
+            (lambda body: body.__setitem__("stream", "false"), "stream flag"),
+            (lambda body: body.__setitem__("input", "hello"), "input body"),
+            (lambda body: body.__setitem__("input", [1]), "input item"),
+            (lambda body: body.__setitem__("extra_body", []), "extra_body"),
+            (
+                lambda body: body["extra_body"].__setitem__("store", "false"),
+                "store must be a boolean",
+            ),
+        ],
+    )
+    async def test_execute_validates_prepared_body_before_sdk_io(
+        self,
+        mutate: Callable[[dict[str, Any]], object],
+        message: str,
+    ) -> None:
+        dialect, create = _dialect()
+        _, prepared = _prepare_for_audit(
+            dialect,
+            Request(
+                input=_chat(),
+                dialect_options=DialectOptions(
+                    "openai_responses",
+                    {"store": False},
+                ),
+            ),
+        )
+        body = cast(dict[str, Any], prepared.thaw_body())
+        mutate(body)
+
+        with pytest.raises(DialectError, match=message):
+            await dialect.execute(replace(prepared, body=body))
+
+        create.assert_not_awaited()
+
+
+class TestResponseLifting:
+    @pytest.mark.parametrize(
+        "channel",
+        ["server_tool_uses", "citations"],
+    )
+    def test_custom_tuple_output_validators_reject_wrong_item_types(
+        self, channel: str
+    ) -> None:
+        with pytest.raises(OutputContractError, match=rf"{channel} channel"):
+            OUTPUT_CONTRACT.rules[channel].validator((object(),))
+
+    @pytest.mark.anyio
+    async def test_locked_openai_sdk_response_shape_is_lifted_directly(self) -> None:
+        raw = _sdk_response_payload()
+        sdk_response = SDKResponse.model_validate(raw)
+        dialect, _ = _dialect(sdk_response)
+
+        response = await dialect.arun(Request(input=_chat()))
+
+        assert response.texts == ("sdk output",)
+        assert response.session_id == "resp_sdk"
+        assert response.reasoning is not None
+        assert response.reasoning[0] is not None
+        assert response.reasoning[0].text == "why"
+
+    @pytest.mark.anyio
+    async def test_reported_store_false_suppresses_session_id(self) -> None:
+        raw = _response(response_id="resp_zdr")
+        raw.store = False
+        dialect, _ = _dialect(raw)
+
+        response = await dialect.arun(Request(input=_chat()))
+
+        assert response.session_id is None
+
+    @pytest.mark.anyio
+    async def test_reported_store_must_be_boolean(self) -> None:
+        raw = _response()
+        raw.store = "false"
+        dialect, _ = _dialect(raw)
+
+        with pytest.raises(
+            OutputContractError, match="response.store must be a boolean"
+        ):
+            await dialect.arun(Request(input=_chat()))
+
+    @pytest.mark.anyio
+    async def test_store_false_falls_back_to_request_when_response_omits_it(
+        self,
+    ) -> None:
+        dialect, _ = _dialect(_response(response_id="resp_stateless"))
+
+        response = await dialect.arun(
+            Request(
+                input=_chat(),
+                dialect_options=DialectOptions("openai_responses", {"store": False}),
+            )
+        )
+
+        assert response.session_id is None
+
+    @pytest.mark.anyio
+    async def test_store_false_returns_replayable_history_not_a_session_id(
+        self,
+    ) -> None:
+        dialect, _ = _dialect(_response(_reasoning(), _message()))
+
+        response = await dialect.arun(
+            Request(
+                input=_chat(),
+                dialect_options=DialectOptions("openai_responses", {"store": False}),
+            )
+        )
+
+        assert response.session_id is None
+        assert response.reasoning is not None
+        reasoning = response.reasoning[0]
+        assert reasoning is not None
+        assert reasoning.opaque_roundtrip is not None
+        envelope = json.loads(reasoning.opaque_roundtrip)
+        assert envelope["version"] == 2
+        assert [item["type"] for item in envelope["items"]] == [
+            "message",
+            "reasoning",
+            "message",
+        ]
+
+    @pytest.mark.anyio
+    async def test_reported_store_must_match_explicit_request(self) -> None:
+        raw = _response()
+        raw.store = True
+        dialect, _ = _dialect(raw)
+
+        with pytest.raises(OutputContractError, match="store contradicts"):
+            await dialect.arun(
+                Request(
+                    input=_chat(),
+                    dialect_options=DialectOptions(
+                        "openai_responses", {"store": False}
+                    ),
+                )
+            )
+
+    @pytest.mark.anyio
+    async def test_incomplete_reason_is_preserved_verbatim(self) -> None:
+        dialect, _ = _dialect(
+            _response(status="incomplete", incomplete_reason="max_output_tokens")
+        )
+
+        response = await dialect.arun(Request(input=_chat()))
+
+        assert response.finish_reasons == ("max_output_tokens",)
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize(
+        "item",
+        [
+            pytest.param(
+                SimpleNamespace(
+                    type="message",
+                    id="msg_1",
+                    role="assistant",
+                    status="in_progress",
+                    content=[_text()],
+                ),
+                id="message",
+            ),
+            pytest.param(
+                SimpleNamespace(
+                    type="reasoning",
+                    id="rs_1",
+                    summary=[],
+                    content=None,
+                    encrypted_content="opaque",
+                    status="in_progress",
+                ),
+                id="reasoning",
+            ),
+            pytest.param(
+                SimpleNamespace(
+                    type="function_call",
+                    id="fc_1",
+                    call_id="call_1",
+                    name="lookup",
+                    arguments="{}",
+                    status="in_progress",
+                ),
+                id="function-call",
+            ),
+            pytest.param(
+                SimpleNamespace(
+                    type="web_search_call",
+                    id="ws_1",
+                    status="in_progress",
+                    action={"type": "search", "query": "test"},
+                ),
+                id="web-search",
+            ),
+        ],
+    )
+    async def test_terminal_response_rejects_in_progress_output_items(
+        self, item: object
+    ) -> None:
+        dialect, _ = _dialect(_response(item))
+
+        with pytest.raises(OutputContractError, match="remains in_progress"):
+            await dialect.arun(Request(input=_chat()))
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize(
+        "item",
+        [
+            pytest.param(_message(status=1), id="message-non-string"),
+            pytest.param(_message(status="queued"), id="message-unknown"),
+            pytest.param(
+                SimpleNamespace(
+                    type="function_call",
+                    id="fc_1",
+                    call_id="call_1",
+                    name="lookup",
+                    arguments="{}",
+                    status=1,
+                ),
+                id="function-call-non-string",
+            ),
+            pytest.param(
+                SimpleNamespace(
+                    type="function_call",
+                    id="fc_1",
+                    call_id="call_1",
+                    name="lookup",
+                    arguments="{}",
+                    status="queued",
+                ),
+                id="function-call-unknown",
+            ),
+            pytest.param(_reasoning(status=1), id="reasoning-non-string"),
+            pytest.param(_reasoning(status="queued"), id="reasoning-unknown"),
+        ],
+    )
+    async def test_terminal_response_rejects_invalid_output_item_status(
+        self, item: object
+    ) -> None:
+        dialect, _ = _dialect(_response(item))
+
+        with pytest.raises(OutputContractError, match="status .* is not terminal"):
+            await dialect.arun(Request(input=_chat()))
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize(
+        "item",
+        [
+            pytest.param(_message(status="incomplete"), id="message"),
+            pytest.param(_reasoning(status="incomplete"), id="reasoning"),
+            pytest.param(
+                SimpleNamespace(
+                    type="function_call",
+                    id="fc_1",
+                    call_id="call_1",
+                    name="lookup",
+                    arguments="{}",
+                    status="incomplete",
+                ),
+                id="function-call",
+            ),
+        ],
+    )
+    async def test_incomplete_response_accepts_incomplete_output_item_status(
+        self, item: object
+    ) -> None:
+        dialect, _ = _dialect(
+            _response(
+                item,
+                status="incomplete",
+                incomplete_reason="max_output_tokens",
+            )
+        )
+
+        response = await dialect.arun(Request(input=_chat()))
+
+        assert response.finish_reasons == ("max_output_tokens",)
+
+    @pytest.mark.anyio
+    async def test_incomplete_reasoning_status_is_preserved_for_replay(self) -> None:
+        dialect, _ = _dialect(
+            _response(
+                _reasoning(status="incomplete"),
+                status="incomplete",
+                incomplete_reason="max_output_tokens",
+            )
+        )
+
+        response = await dialect.arun(Request(input=_chat()))
+
+        assert response.reasoning is not None
+        reasoning = response.reasoning[0]
+        assert reasoning is not None
+        assert reasoning.opaque_roundtrip is not None
+        envelope = json.loads(reasoning.opaque_roundtrip)
+        assert envelope["items"][-1]["status"] == "incomplete"
+
+    @pytest.mark.anyio
+    async def test_requested_logprobs_cover_every_nonempty_text_part(self) -> None:
+        dialect, _ = _dialect(
+            _response(
+                _message(
+                    _text("A", logprobs=None),
+                    _text("B", logprobs=[_logprob()]),
+                )
+            )
+        )
+
+        with pytest.raises(OutputContractError, match="logprobs is absent"):
+            await dialect.arun(
+                Request(
+                    input=_chat(),
+                    scoring=ScoringParams(sampled_logprobs=True),
+                )
+            )
+
+    @pytest.mark.anyio
+    async def test_tool_only_reply_has_empty_requested_logprob_channels(self) -> None:
+        dialect, _ = _dialect(
+            _response(
+                SimpleNamespace(
+                    type="function_call",
+                    call_id="call_1",
+                    name="lookup",
+                    arguments="{}",
+                )
+            )
+        )
+
+        response = await dialect.arun(
+            Request(
+                input=_chat(),
+                scoring=ScoringParams(sampled_logprobs=True, top_logprobs=2),
+            )
+        )
+
+        assert response.logprobs == ()
+        assert response.top_logprobs == ()
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize(
+        "reasoning_items",
+        [
+            (_reasoning(summary=None, content="raw reasoning"),),
+            (_reasoning(summary=""),),
+            (
+                _reasoning("rs_raw", summary=None, content="raw reasoning"),
+                _reasoning("rs_summary", summary="visible summary"),
+            ),
+        ],
+    )
+    async def test_requested_reasoning_summary_must_exist_on_every_item(
+        self, reasoning_items: tuple[object, ...]
+    ) -> None:
+        dialect, _ = _dialect(_response(*reasoning_items, _message()))
+
+        with pytest.raises(OutputContractError, match="requested visible reasoning"):
+            await dialect.arun(
+                Request(
+                    input=_chat(),
+                    reasoning=ReasoningParams(summary="detailed"),
+                )
+            )
+
+    @pytest.mark.anyio
+    async def test_missing_encrypted_reasoning_is_not_advertised_as_opaque(
+        self,
+    ) -> None:
+        dialect, _ = _dialect(_response(_reasoning(encrypted=None), _message()))
+
+        response = await dialect.arun(Request(input=_chat()))
+
+        assert response.reasoning is not None
+        assert response.reasoning[0] is not None
+        assert response.reasoning[0].opaque_roundtrip is None
+
+    @pytest.mark.anyio
+    async def test_reported_usage_total_is_preserved_only_when_it_differs(self) -> None:
+        dialect, _ = _dialect(_response(usage=_usage(total_tokens=9)))
+
+        response = await dialect.arun(Request(input=_chat()))
+
+        assert response.usage is not None
+        assert response.usage.total_tokens == 5
+        assert response.usage.reported_total_tokens == 9
+
+    @pytest.mark.anyio
+    async def test_invalid_optional_usage_details_are_ignored(self) -> None:
+        dialect, _ = _dialect(
+            _response(usage=_usage(cached_tokens=True, reasoning_tokens=-1))
+        )
+
+        response = await dialect.arun(Request(input=_chat()))
+
+        assert response.usage is not None
+        assert response.usage.cached_tokens is None
+        assert response.usage.reasoning_tokens is None
+
+    @pytest.mark.anyio
+    async def test_reasoning_without_visible_text_remains_opaque_only(self) -> None:
+        dialect, _ = _dialect(
+            _response(_reasoning(summary=None, content=None), _message())
+        )
+
+        response = await dialect.arun(Request(input=_chat()))
+
+        assert response.reasoning is not None
+        assert response.reasoning[0] is not None
+        assert response.reasoning[0].text is None
+        assert response.reasoning[0].opaque_roundtrip is not None
+
+    @pytest.mark.anyio
+    async def test_empty_requested_logprobs_fail_for_nonempty_text(self) -> None:
+        dialect, _ = _dialect(_response(_message(_text("A", logprobs=[]))))
+
+        with pytest.raises(OutputContractError, match="logprobs is empty"):
+            await dialect.arun(
+                Request(
+                    input=_chat(),
+                    scoring=ScoringParams(sampled_logprobs=True),
+                )
+            )
+
+    @pytest.mark.anyio
+    async def test_structured_output_rejects_non_json_text(self) -> None:
+        dialect, _ = _dialect(_response(_message(_text("not-json"))))
+
+        with pytest.raises(
+            OutputContractError, match="structured output is not valid JSON"
+        ):
+            await dialect.arun(
+                Request(
+                    input=_chat(),
+                    structured_output=StructuredOutputParams(format="json_object"),
+                )
+            )
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize(
+        "text",
+        [
+            '{"value":NaN}',
+            '{"value":Infinity}',
+            '{"value":-Infinity}',
+            '{"value":1,"value":2}',
+        ],
+    )
+    async def test_structured_output_rejects_nonstandard_json(self, text: str) -> None:
+        dialect, _ = _dialect(_response(_message(_text(text))))
+
+        with pytest.raises(
+            OutputContractError, match="structured output is not valid JSON"
+        ):
+            await dialect.arun(
+                Request(
+                    input=_chat(),
+                    structured_output=StructuredOutputParams(format="json_object"),
+                )
+            )
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize(
+        ("raw", "message"),
+        [
+            (
+                _response(
+                    status="failed",
+                    error=SimpleNamespace(code="server_error", message="boom"),
+                ),
+                "server_error.*boom",
+            ),
+            (_response(status="cancelled"), "non-terminal status"),
+            (
+                _response(status="completed", error=SimpleNamespace(code="x")),
+                "completed.*error",
+            ),
+            (
+                _response(status="completed", incomplete_reason="max_output_tokens"),
+                "completed.*incomplete_details",
+            ),
+            (
+                _response(
+                    status="incomplete",
+                    incomplete_reason="max_output_tokens",
+                    error=SimpleNamespace(code="x"),
+                ),
+                "incomplete.*error",
+            ),
+            (
+                _response(status="incomplete", incomplete_reason=None),
+                "incomplete_details.reason",
+            ),
+            (
+                _response(status="failed", error=None),
+                "failed.*omitted.*error",
+            ),
+            (
+                _response(
+                    status="failed",
+                    incomplete_reason="max_output_tokens",
+                    error=SimpleNamespace(code="x", message="boom"),
+                ),
+                "failed.*incomplete_details",
+            ),
+            (_response(response_id=None), "response.id"),
+            (
+                SimpleNamespace(
+                    id="resp",
+                    status="completed",
+                    output="bad",
+                    error=None,
+                    usage=None,
+                    model=None,
+                    reasoning=None,
+                ),
+                "response.output must be a sequence",
+            ),
+            (
+                _response(_message(SimpleNamespace(type="refusal", refusal="no"))),
+                "refusal has no faithful",
+            ),
+            (
+                _response(
+                    _message(
+                        SimpleNamespace(
+                            type="output_text",
+                            text=1,
+                            annotations=[],
+                            logprobs=None,
+                        )
+                    )
+                ),
+                "text must be a string",
+            ),
+            (_response(model=1), "response.model must be a string or None"),
+            (
+                _response(
+                    _message(
+                        _text(
+                            logprobs=[
+                                SimpleNamespace(
+                                    token="A", logprob=True, top_logprobs=[]
+                                )
+                            ]
+                        )
+                    )
+                ),
+                "logprob must be numeric",
+            ),
+            (
+                _response(SimpleNamespace(type="image_generation_call")),
+                "has no IR mapping",
+            ),
+            (
+                _response(
+                    _message(SimpleNamespace(type="output_audio", audio="ignored"))
+                ),
+                "unsupported type 'output_audio'",
+            ),
+            (
+                _response(
+                    SimpleNamespace(
+                        type="function_call",
+                        call_id="call_1",
+                        name="lookup",
+                        arguments={},
+                    )
+                ),
+                "arguments must be a string",
+            ),
+            (
+                _response(
+                    SimpleNamespace(
+                        type="web_search_call",
+                        id="ws_1",
+                        status="completed",
+                        action="search",
+                    )
+                ),
+                "action must be an object",
+            ),
+            (
+                _response(
+                    SimpleNamespace(
+                        type="web_search_call",
+                        id="ws_1",
+                        status="completed",
+                        action={"confidence": float("nan")},
+                    )
+                ),
+                "contains a non-finite float",
+            ),
+            (
+                _response(
+                    SimpleNamespace(
+                        type="web_search_call",
+                        id="ws_1",
+                        status="completed",
+                        action={1: "bad"},
+                    )
+                ),
+                "contains a non-string key",
+            ),
+            (
+                _response(
+                    SimpleNamespace(
+                        type="web_search_call",
+                        id="ws_1",
+                        status="completed",
+                        action=object(),
+                    )
+                ),
+                "contains unsupported value object",
+            ),
+            (
+                _response(
+                    SimpleNamespace(
+                        type="reasoning",
+                        id="rs_1",
+                        summary="bad",
+                        content=None,
+                        encrypted_content="opaque",
+                    )
+                ),
+                "summary must be a list",
+            ),
+            (
+                _response(
+                    SimpleNamespace(
+                        type="reasoning",
+                        id="rs_1",
+                        summary=[SimpleNamespace(type="other", text="bad")],
+                        content=None,
+                        encrypted_content="opaque",
+                    )
+                ),
+                r"summary\[0\]\.type must be 'summary_text'",
+            ),
+            (
+                _response(
+                    SimpleNamespace(
+                        type="reasoning",
+                        id="rs_1",
+                        summary=[],
+                        content=[SimpleNamespace(type="other", text="bad")],
+                        encrypted_content="opaque",
+                    )
+                ),
+                r"content\[0\]\.type must be 'reasoning_text'",
+            ),
+            (
+                _response(
+                    _message(
+                        _text(
+                            annotations=[
+                                SimpleNamespace(type="file_citation", file_id="file")
+                            ]
+                        )
+                    )
+                ),
+                "no lossless IR mapping",
+            ),
+            (
+                _response(
+                    _message(
+                        _text(
+                            logprobs=[
+                                SimpleNamespace(
+                                    token="A", logprob=float("nan"), top_logprobs=[]
+                                )
+                            ]
+                        )
+                    )
+                ),
+                "must be finite",
+            ),
+            (
+                _response(usage=_usage(input_tokens=True)),
+                "usage.input_tokens",
+            ),
+        ],
+    )
+    async def test_malformed_or_unrepresentable_replies_fail_loudly(
+        self, raw: object, message: str
+    ) -> None:
+        dialect, _ = _dialect(raw)
+
+        with pytest.raises(OutputContractError, match=message):
+            await dialect.arun(Request(input=_chat()))
+
+    @pytest.mark.anyio
+    async def test_reasoning_content_falls_back_when_summary_is_absent(self) -> None:
+        dialect, _ = _dialect(
+            _response(_reasoning(summary=None, content="visible"), _message())
+        )
+
+        response = await dialect.arun(
+            Request(input=_chat(), reasoning=ReasoningParams(effort="low"))
+        )
+
+        assert response.reasoning is not None
+        assert response.reasoning[0] is not None
+        assert response.reasoning[0].text == "visible"
+
+    @pytest.mark.anyio
+    async def test_missing_requested_channel_fails_output_contract(self) -> None:
+        dialect, _ = _dialect(_response())
+
+        with pytest.raises(OutputContractError, match="required.*reasoning"):
+            await dialect.arun(
+                Request(
+                    input=_chat(),
+                    reasoning=ReasoningParams(summary="detailed"),
+                )
+            )
+
+
+class TestStreaming:
+    @pytest.mark.anyio
+    async def test_stream_and_nonstream_build_identical_opaque_history(self) -> None:
+        raw = _sdk_response_payload()
+        nonstream_dialect, _ = _dialect(SDKResponse.model_validate(raw))
+        streamed_dialect, _ = _dialect(
+            _AsyncItems([_sdk_completed_event(response=raw)])
+        )
+
+        nonstream = await nonstream_dialect.arun(Request(input=_chat()))
+        streamed = await streamed_dialect.arun(
+            Request(input=_chat(), scheduling=SchedulingParams(stream=True))
+        )
+
+        assert nonstream.reasoning is not None
+        assert streamed.reasoning is not None
+        assert nonstream.reasoning[0] is not None
+        assert streamed.reasoning[0] is not None
+        assert (
+            nonstream.reasoning[0].opaque_roundtrip
+            == streamed.reasoning[0].opaque_roundtrip
+        )
+
+    @pytest.mark.anyio
+    async def test_real_sdk_sse_stream_is_lifted(self) -> None:
+        delta = ResponseTextDeltaEvent.model_validate(
+            {
+                "type": "response.output_text.delta",
+                "item_id": "msg_sdk",
+                "output_index": 1,
+                "content_index": 0,
+                "delta": "ignored",
+                "logprobs": [],
+                "sequence_number": 1,
+            }
+        )
+        terminal = _sdk_completed_event(sequence_number=2)
+        body = (
+            f"event: {delta.type}\ndata: {delta.model_dump_json()}\n\n"
+            f"event: {terminal.type}\ndata: {terminal.model_dump_json()}\n\n"
+        )
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            payload = json.loads(request.content)
+            assert payload["stream"] is True
+            return httpx.Response(
+                200,
+                headers={"content-type": "text/event-stream"},
+                content=body,
+            )
+
+        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        client = AsyncOpenAI(
+            api_key="test",
+            base_url="https://example.test/v1",
+            http_client=http_client,
+        )
+        try:
+            dialect = OpenAIResponsesDialect(client, "requested/model")
+            response = await dialect.arun(
+                Request(input=_chat(), scheduling=SchedulingParams(stream=True))
+            )
+        finally:
+            await client.close()
+
+        assert response.texts == ("sdk output",)
+        assert response.finish_reasons == ("completed",)
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize(
+        ("event", "error_match", "finish_reasons"),
+        [
+            (
+                ResponseIncompleteEvent.model_validate(
+                    {
+                        "type": "response.incomplete",
+                        "sequence_number": 1,
+                        "response": _sdk_incomplete_response_payload(
+                            "max_output_tokens"
+                        ),
+                    }
+                ),
+                None,
+                ("max_output_tokens",),
+            ),
+            (_sdk_failed_event(), "server_error.*boom", None),
+            (_sdk_error_event(), "bad stream", None),
+        ],
+    )
+    async def test_real_sdk_terminal_sse_variants_are_lifted(
+        self,
+        event: ResponseIncompleteEvent | ResponseFailedEvent | ResponseErrorEvent,
+        error_match: str | None,
+        finish_reasons: tuple[str, ...] | None,
+    ) -> None:
+        body = f"event: {event.type}\ndata: {event.model_dump_json()}\n\n"
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            assert json.loads(request.content)["stream"] is True
+            return httpx.Response(
+                200,
+                headers={"content-type": "text/event-stream"},
+                content=body,
+            )
+
+        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        client = AsyncOpenAI(
+            api_key="test",
+            base_url="https://example.test/v1",
+            http_client=http_client,
+        )
+        try:
+            dialect = OpenAIResponsesDialect(client, "requested/model")
+            request = Request(input=_chat(), scheduling=SchedulingParams(stream=True))
+            if error_match is not None:
+                with pytest.raises(OutputContractError, match=error_match):
+                    await dialect.arun(request)
+            else:
+                response = await dialect.arun(request)
+                assert response.finish_reasons == finish_reasons
+        finally:
+            await client.close()
+
+    @pytest.mark.anyio
+    async def test_sdk_incomplete_terminal_uses_terminal_response(self) -> None:
+        terminal = ResponseIncompleteEvent.model_validate(
+            {
+                "type": "response.incomplete",
+                "sequence_number": 1,
+                "response": _sdk_incomplete_response_payload("content_filter"),
+            }
+        )
+        dialect, create = _dialect(_AsyncItems([terminal]))
+
+        response = await dialect.arun(
+            Request(input=_chat(), scheduling=SchedulingParams(stream=True))
+        )
+
+        assert response.finish_reasons == ("content_filter",)
+        assert _awaited_kwargs(create)["stream"] is True
+
+    @pytest.mark.anyio
+    async def test_sdk_failed_terminal_reports_response_error(self) -> None:
+        dialect, _ = _dialect(_AsyncItems([_sdk_failed_event()]))
+
+        with pytest.raises(OutputContractError, match="server_error.*boom"):
+            await dialect.arun(
+                Request(input=_chat(), scheduling=SchedulingParams(stream=True))
+            )
+
+    @pytest.mark.anyio
+    async def test_sdk_error_event_reports_stream_error(self) -> None:
+        dialect, _ = _dialect(_AsyncItems([_sdk_error_event()]))
+
+        with pytest.raises(OutputContractError, match="bad stream"):
+            await dialect.arun(
+                Request(input=_chat(), scheduling=SchedulingParams(stream=True))
+            )
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize(
+        ("events", "message"),
+        [
+            (None, "not asynchronously iterable"),
+            ([], "omitted its terminal"),
+            (
+                [
+                    _sdk_completed_event(sequence_number=1),
+                    _sdk_completed_event(sequence_number=2),
+                ],
+                "two terminal events",
+            ),
+            (
+                [
+                    _sdk_completed_event(
+                        response=_sdk_incomplete_response_payload("max_output_tokens")
+                    )
+                ],
+                "carried status",
+            ),
+            (
+                [
+                    SimpleNamespace(type="response.completed", response=None),
+                    _sdk_completed_event(sequence_number=2),
+                ],
+                "omitted its response",
+            ),
+        ],
+    )
+    async def test_invalid_streams_fail_loudly(
+        self, events: list[object] | None, message: str
+    ) -> None:
+        stream: object = object() if events is None else _AsyncItems(events)
+        dialect, _ = _dialect(stream)
+
+        with pytest.raises(OutputContractError, match=message):
+            await dialect.arun(
+                Request(input=_chat(), scheduling=SchedulingParams(stream=True))
+            )

--- a/tests/unit/core/models/test_dialect_registry.py
+++ b/tests/unit/core/models/test_dialect_registry.py
@@ -47,6 +47,7 @@ from sieval.core.models.dialect_registry import (
 )
 from sieval.core.models.dialects.openai_chat import OpenAIChatDialect
 from sieval.core.models.dialects.openai_completions import OpenAICompletionsDialect
+from sieval.core.models.dialects.openai_responses import OpenAIResponsesDialect
 
 EXPECTED_DIALECTS = (
     "openai_chat",
@@ -64,7 +65,9 @@ class _Connection:
         pass
 
 
-def _runtime_binding() -> tuple[Deployment, ConnectionPool[Any], SimpleNamespace]:
+def _runtime_binding(
+    dialect_id: str = "openai_chat",
+) -> tuple[Deployment, ConnectionPool[Any], SimpleNamespace]:
     deployment = Deployment(
         deployment_id="deployment",
         plan=DeploymentPlanProjection("sha256:plan", "vllm"),
@@ -76,7 +79,7 @@ def _runtime_binding() -> tuple[Deployment, ConnectionPool[Any], SimpleNamespace
         metrics_url=None,
         facts=ServingFacts(),
     )
-    route = resolve_route(deployment, "openai_chat", "openai_sdk")
+    route = resolve_route(deployment, dialect_id, "openai_sdk")
     identity = ConnectionIdentity(
         endpoint=route.endpoint,
         connection_family=route.connection_family,
@@ -85,7 +88,7 @@ def _runtime_binding() -> tuple[Deployment, ConnectionPool[Any], SimpleNamespace
         quota_scope="deployment",
     )
     plan = SimpleNamespace(
-        dialect_id="openai_chat",
+        dialect_id=dialect_id,
         requested_model_id="requested-model",
         deployment_fingerprint=deployment.fingerprint,
         resolved_route=route,
@@ -121,20 +124,24 @@ class TestDialectDescriptors:
         } == {
             "openai_chat": RequestSeedSupport.SUPPORTED,
             "openai_completions": RequestSeedSupport.SUPPORTED,
-            "openai_responses": RequestSeedSupport.RESERVED,
+            "openai_responses": RequestSeedSupport.UNSUPPORTED,
             "anthropic_messages": RequestSeedSupport.RESERVED,
             "google_genai": RequestSeedSupport.RESERVED,
             "sglang_native": RequestSeedSupport.RESERVED,
             "vllm_native": RequestSeedSupport.RESERVED,
         }
 
-    def test_only_pr1_dialects_are_active_and_bindable(self) -> None:
+    def test_implemented_dialects_are_active_and_bindable(self) -> None:
         active = {
             dialect_id
             for dialect_id, spec in DIALECT_SPECS.items()
             if spec.implementation_status is DialectImplementationStatus.ACTIVE
         }
-        assert active == {"openai_chat", "openai_completions"}
+        assert active == {
+            "openai_chat",
+            "openai_completions",
+            "openai_responses",
+        }
         assert set(DIALECT_BINDERS) == active
         assert all(inspect.isfunction(binder) for binder in DIALECT_BINDERS.values())
 
@@ -245,6 +252,7 @@ class TestDialectDescriptors:
 
     def test_capability_decisions_are_available_only_for_active_dialects(self) -> None:
         assert set(capability_decisions_for("openai_chat")) == set(CAPABILITY_KEYS)
+        assert set(capability_decisions_for("openai_responses")) == set(CAPABILITY_KEYS)
         with pytest.raises(DialectNotImplemented, match="later #25 adapter"):
             capability_decisions_for("anthropic_messages")
 
@@ -255,7 +263,6 @@ class TestDialectBinders:
         [
             ("vllm_native", "explicitly deferred"),
             ("sglang_native", "legacy bypass"),
-            ("openai_responses", "later #25 adapter PR"),
         ],
     )
     def test_reserved_dialects_fail_with_named_error(
@@ -275,9 +282,10 @@ class TestDialectBinders:
         [
             ("openai_chat", OpenAIChatDialect),
             ("openai_completions", OpenAICompletionsDialect),
+            ("openai_responses", OpenAIResponsesDialect),
         ],
     )
-    def test_two_binders_construct_expected_dialect(
+    def test_active_binders_construct_expected_dialect(
         self, dialect_id: str, expected_type: type
     ) -> None:
         binder = DIALECT_BINDERS[dialect_id]
@@ -287,14 +295,24 @@ class TestDialectBinders:
         assert dialect.dialect_id == dialect_id
         assert dialect.connection_family == "openai_sdk"
 
-    def test_validated_runtime_plan_binds_active_dialect(self) -> None:
-        deployment, pool, plan = _runtime_binding()
+    @pytest.mark.parametrize(
+        ("dialect_id", "expected_type"),
+        [
+            ("openai_chat", OpenAIChatDialect),
+            ("openai_completions", OpenAICompletionsDialect),
+            ("openai_responses", OpenAIResponsesDialect),
+        ],
+    )
+    def test_validated_runtime_plan_binds_active_dialect(
+        self, dialect_id: str, expected_type: type
+    ) -> None:
+        deployment, pool, plan = _runtime_binding(dialect_id)
 
         dialect = bind_dialect(
-            "openai_chat", "requested-model", deployment, pool, cast(Any, plan)
+            dialect_id, "requested-model", deployment, pool, cast(Any, plan)
         )
 
-        assert isinstance(dialect, OpenAIChatDialect)
+        assert isinstance(dialect, expected_type)
 
     @pytest.mark.parametrize(
         ("requested_model_id", "changes", "message"),

--- a/tests/unit/core/models/test_reconcile.py
+++ b/tests/unit/core/models/test_reconcile.py
@@ -37,6 +37,7 @@ from sieval.core.models.deployment import (
 from sieval.core.models.dialect_registry import DialectRegistryError, bind_dialect
 from sieval.core.models.dialects.openai_chat import OpenAIChatDialect
 from sieval.core.models.dialects.openai_completions import OpenAICompletionsDialect
+from sieval.core.models.dialects.openai_responses import OpenAIResponsesDialect
 from sieval.core.models.reconcile import (
     BindingCapabilityPlan,
     BindingReconcileInput,
@@ -1564,6 +1565,7 @@ class TestRuntimePlanAndBinding:
         [
             ("openai_chat", OpenAIChatDialect),
             ("openai_completions", OpenAICompletionsDialect),
+            ("openai_responses", OpenAIResponsesDialect),
         ],
     )
     def test_runtime_plan_binds_only_to_exact_pool_identity(

--- a/tests/unit/core/tasks/test_anomaly.py
+++ b/tests/unit/core/tasks/test_anomaly.py
@@ -186,6 +186,7 @@ class TestDetectTruncatedOutput:
         """Single-sample (n=1) finish reason variants."""
         cases = [
             (["length"], {0}, "length"),
+            (["max_output_tokens"], {0}, "max_output_tokens"),
             (["max_tokens"], {0}, "max_tokens"),
             (["content_filter"], {0}, "content_filter"),
             (["stop"], set(), "stop"),

--- a/tests/unit/core/utils/test_meta.py
+++ b/tests/unit/core/utils/test_meta.py
@@ -305,10 +305,16 @@ class TestCountTruncatedRollouts:
         assert count_truncated_rollouts([one, four]) == 5
 
     def test_every_provider_spelling_counts(self):
-        # The IR keeps finish_reasons provider-verbatim: an OpenAI-compatible
-        # server says `length`, Anthropic says `max_tokens`. A set holding only
-        # one spelling would read zero on the other provider.
-        for reason in ("length", "max_tokens", "content_filter"):
+        # The IR keeps finish_reasons provider-verbatim: OpenAI-compatible
+        # Chat/Completions and SGLang native say `length`, Responses says
+        # `max_output_tokens`, and Anthropic says `max_tokens`. A set holding only
+        # one spelling would silently read zero on another provider.
+        for reason in (
+            "length",
+            "max_output_tokens",
+            "max_tokens",
+            "content_filter",
+        ):
             assert (
                 count_truncated_rollouts([_inferred({"finish_reasons": [reason]})]) == 1
             )


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Type

- feature — new benchmark, task, or capability

## Summary

- Add an active [OpenAI Responses API](https://developers.openai.com/api/reference/resources/responses/methods/create) dialect with audited request lowering, strict response lifting, and a shared parser for streaming and non-streaming responses.
- Keep plain requests minimal: request encrypted reasoning only for active or replayed reasoning, output logprobs only when requested, and web-search sources only for hosted web search. This avoids unnecessary request failures on non-reasoning models and partially compatible endpoints.
- Implement dialect mechanics for text, reasoning, function and web-search tools, structured output, image input, logprobs, stored sessions, and opaque continuations. Capabilities lacking admission fail before I/O, while missing required response channels fail during lifting rather than being silently ignored.
- Capability-gated features on canonical configuration paths remain unavailable until the model/serving profile reports support; vendor capability profiles and broader vendor live probes remain follow-up work.
- Declare per-request seeds unsupported: deterministic mode does not inject a seed, and an explicit seed is rejected before I/O.
- Persist request evidence from the final `PreparedRequest` sent to the SDK and recognize the provider-verbatim `max_output_tokens` truncation reason.

## Related Issues

Refs #25  
Refs #113

## Test Plan

### Automated

- [x] Lint/format clean (`ruff check && ruff format --check`)
- [x] Type check clean (`ty check` or `mypy --strict`)
- [x] Unit tests pass (`pdm run pytest`)

### Manual

- [x] Live-probed a third-party Responses-compatible MaaS endpoint with the reasoning-capable `gpt-5.6-sol` model: verified non-streaming and streaming completion, `max_output_tokens` truncation, and usage parsing. The probe did not request or assert reasoning output items.

Coverage note: reasoning-item lifting and encrypted continuation, function and web-search tools, image input, `store` / `previous_response_id`, and non-reasoning third-party models were not live-probed. They are covered by unit-level contract and wire tests, including real SDK calls over mocked HTTP for the SDK integration paths, and remain follow-up live-probe coverage.

## Checklist

### Required (all PRs)

- [x] PR title follows conventional format (`type(scope): description`)
- [x] No internal paths, credentials, or personal info in committed files
- [x] AI-generated code has `AI-Generated Code - <model> (<provider>)` in module docstring
- [x] No new upper-layer dependencies added to `core/`
- [x] Deleted code verified — no remaining call sites depend on it